### PR TITLE
fix: Handle empty driver string in network creation for Docker Compose

### DIFF
--- a/Sources/ContainerBridge/NetworkManager.swift
+++ b/Sources/ContainerBridge/NetworkManager.swift
@@ -169,7 +169,9 @@ public actor NetworkManager {
         isDefault: Bool = false
     ) async throws -> String {
         // Determine effective driver (explicit driver or "bridge" as default)
-        let effectiveDriver = driver ?? "bridge"
+        // Normalize empty string to nil (Docker Compose and other clients may send "")
+        let normalizedDriver = driver?.isEmpty == false ? driver : nil
+        let effectiveDriver = normalizedDriver ?? "bridge"
 
         // Generate network ID
         let networkID = generateNetworkID()

--- a/Sources/DockerAPI/Handlers/NetworkHandlers.swift
+++ b/Sources/DockerAPI/Handlers/NetworkHandlers.swift
@@ -149,9 +149,12 @@ public struct NetworkHandlers: Sendable {
         let ipRange = request.ipam?.config?.first?.ipRange
 
         do {
+            // Normalize empty driver string to nil (Docker Compose sends "" instead of nil)
+            let normalizedDriver = request.driver?.isEmpty == false ? request.driver : nil
+
             let networkID = try await networkManager.createNetwork(
                 name: request.name,
-                driver: request.driver ?? "bridge",
+                driver: normalizedDriver ?? "bridge",
                 subnet: subnet,
                 gateway: gateway,
                 ipRange: ipRange,


### PR DESCRIPTION
Fixes #5

## Problem

Docker Compose was failing with error:
```
failed to create network tmp_default: Error response from daemon: network driver  not supported
```

## Root Cause

Docker Compose sends `driver: ""` (empty string) instead of `driver: nil` when no driver is specified in compose files. Our network creation code only handled `nil`, causing empty strings to bypass the default and hit the "unsupported driver" path.

## Solution

Added normalization in two locations:
- `NetworkHandlers.swift` - Normalize empty driver at API handler level
- `NetworkManager.swift` - Normalize empty driver at manager level

Empty driver strings now properly default to `"bridge"` (which maps to wireguard backend).

## Testing

Verified with Docker Compose:
```bash
# compose.yml with no driver specified
services:
  test:
    image: alpine
    command: sleep 300

# Results
✅ Network tmp_default created successfully (wireguard driver)
✅ Container started and attached to network
✅ Container assigned IP 172.19.0.2
✅ docker compose down cleaned up successfully
```

## Impact

- Enables Docker Compose compatibility
- Fixes network creation for any tool sending empty driver strings
- Critical for compose file support