### PR TITLE
fix: Auto-update vminit when upgrading Arca versions

### DIFF
--- a/ArcaApp/ArcaApp/ContentView.swift
+++ b/ArcaApp/ArcaApp/ContentView.swift
@@ -131,13 +131,13 @@ struct ContentView: View {
                 .padding(.bottom, 20)
 
             } else if setupManager.isRunningSetup {
-                // Setup in progress
+                // Setup or update in progress
                 VStack(spacing: 12) {
                     ProgressView()
                         .scaleEffect(1.5)
                         .padding()
 
-                    Text("Running first-time setup...")
+                    Text(setupManager.needsVminitUpdate ? "Updating Arca..." : "Running first-time setup...")
                         .font(.headline)
 
                     Text(setupManager.setupStatus)


### PR DESCRIPTION
## Summary
- Adds version tracking to vminit extraction in SetupManager
- Automatically updates vminit when app version changes (instead of skipping extraction)
- Updates UI to show "Updating Arca..." during auto-updates

## Problem
When upgrading Arca to a new version, the vminit OCI image in `~/.arca/vminit/` was not being updated because `SetupManager` only checked if the directory exists, not whether it matches the current app version.

This caused fixes in vminit (like the file bind mount fix in v0.1.6-alpha) to not be applied on machines that already had an older vminit installed.

## Solution
1. **Version file**: After extracting vminit, writes the app version to `~/.arca/vminit/.version`
2. **Version check**: On startup, compares installed vminit version against app version
3. **Auto-update**: If versions don't match, automatically updates vminit:
   - Stops daemon
   - Extracts new vminit
   - Restarts daemon
4. **UI feedback**: Shows "Updating Arca..." instead of "Running first-time setup..." during updates

## Test plan
- [ ] Fresh install: Verify first-time setup works and `.version` file is created
- [ ] Upgrade: Verify vminit is re-extracted when app version changes
- [ ] UI: Verify "Updating Arca..." is shown during auto-update

Fixes #17