### PR TITLE
chore: Bump version to v0.1.7-alpha

### DIFF
--- a/Sources/Arca/main.swift
+++ b/Sources/Arca/main.swift
@@ -16,7 +16,7 @@ struct Arca: AsyncParsableCommand {
 
             Part of the Vas Solutus project - freeing containers on macOS.
             """,
-        version: "0.1.6-alpha (API v1.51)",
+        version: "0.1.7-alpha (API v1.51)",
         subcommands: [Daemon.self],
         defaultSubcommand: Daemon.self
     )

--- a/Sources/ArcaDaemon/HTTPHandler.swift
+++ b/Sources/ArcaDaemon/HTTPHandler.swift
@@ -185,7 +185,7 @@ final class HTTPHandler: ChannelInboundHandler, RemovableChannelHandler, @unchec
 
         case .streaming(let status, var headers, let callback):
             // Send response head with chunked transfer encoding
-            headers.add(name: "Server", value: "Arca/0.1.6-alpha")
+            headers.add(name: "Server", value: "Arca/0.1.7-alpha")
             headers.add(name: "Transfer-Encoding", value: "chunked")
 
             let responseHead = HTTPResponseHead(
@@ -219,7 +219,7 @@ final class HTTPHandler: ChannelInboundHandler, RemovableChannelHandler, @unchec
     private func sendResponse(context: ChannelHandlerContext, response: HTTPResponse) {
         // Send response head
         var headers = response.headers
-        headers.add(name: "Server", value: "Arca/0.1.6-alpha")
+        headers.add(name: "Server", value: "Arca/0.1.7-alpha")
 
         let responseHead = HTTPResponseHead(
             version: .http1_1,

--- a/Sources/DockerAPI/Handlers/SystemHandlers.swift
+++ b/Sources/DockerAPI/Handlers/SystemHandlers.swift
@@ -23,7 +23,7 @@ public struct SystemHandlers: Sendable {
     /// Returns: Version information about the Docker Engine API
     public static func handleVersion() -> VersionResponse {
         return VersionResponse(
-            version: "0.1.6-alpha",
+            version: "0.1.7-alpha",
             apiVersion: "1.51",
             minAPIVersion: "1.24",
             gitCommit: "unknown",
@@ -80,14 +80,14 @@ public struct SystemHandlers: Sendable {
             cgroupVersion: "2",
             kernelVersion: processInfo.kernelVersion,
             operatingSystem: "Arca Container Runtime",
-            osVersion: "0.1.6-alpha",
+            osVersion: "0.1.7-alpha",
             osType: "linux",
             architecture: processInfo.machineArchitecture,
             ncpu: processInfo.activeProcessorCount,
             memTotal: Int64(processInfo.physicalMemory),
             name: processInfo.hostName,
             experimentalBuild: false,
-            serverVersion: "0.1.6-alpha"
+            serverVersion: "0.1.7-alpha"
         )
     }
 


### PR DESCRIPTION
Bump version to v0.1.7-alpha to include the vminit auto-update fix (#17).

This version will automatically update vminit when users upgrade from v0.1.6-alpha.