### PR TITLE
fix: Increase default container disk size from 10GB to 64GB (#25)

### DIFF
--- a/Sources/ContainerBridge/ContainerManager.swift
+++ b/Sources/ContainerBridge/ContainerManager.swift
@@ -1121,7 +1121,9 @@ public actor ContainerManager {
         let mounter = OverlayFSMounter(logger: logger)
 
         if !FileManager.default.fileExists(atPath: writablePath.path) {
-            try mounter.createWritableFilesystem(at: writablePath.path, sizeMB: 10240)
+            // 64 GB provides sufficient space for build caches and large workloads
+            // Thin-provisioned (sparse file) so only actual data consumes disk space
+            try mounter.createWritableFilesystem(at: writablePath.path, sizeMB: 65536)
             logger.info("Created writable filesystem", metadata: [
                 "docker_id": "\(dockerID)",
                 "path": "\(writablePath.path)"

--- a/Sources/ContainerBridge/OverlayFS/OverlayFSMounter.swift
+++ b/Sources/ContainerBridge/OverlayFS/OverlayFSMounter.swift
@@ -159,9 +159,9 @@ public struct OverlayFSMounter: Sendable {
     ///
     /// - Parameters:
     ///   - path: Path where to create writable.ext4
-    ///   - sizeMB: Size in megabytes (default: 10240 MB = 10 GB)
+    ///   - sizeMB: Size in megabytes (default: 65536 MB = 64 GB, thin-provisioned)
     /// - Throws: If filesystem creation fails
-    public func createWritableFilesystem(at path: String, sizeMB: Int = 10240) throws {
+    public func createWritableFilesystem(at path: String, sizeMB: Int = 65536) throws {
         logger?.info("Creating writable filesystem", metadata: [
             "path": "\(path)",
             "size_mb": "\(sizeMB)"

--- a/Sources/DockerAPI/Handlers/SystemHandlers.swift
+++ b/Sources/DockerAPI/Handlers/SystemHandlers.swift
@@ -87,7 +87,7 @@ public struct SystemHandlers: Sendable {
             memTotal: Int64(processInfo.physicalMemory),
             name: processInfo.hostName,
             experimentalBuild: false,
-            serverVersion: "0.1.8-alpha"
+            serverVersion: "0.1.9-alpha"
         )
     }
 


### PR DESCRIPTION
## Summary

- Increases default writable filesystem from 10 GB to 64 GB
- Thin-provisioned (sparse EXT4) so only actual data uses disk space
- Bumps version to v0.1.9-alpha

Fixes #25

## Test plan

- [ ] Rebuild Arca and restart daemon
- [ ] Run a multi-image Docker Compose build that previously failed
- [ ] Verify builds complete without "no space left on device" errors