### PR TITLE
fix: Allow block volume reuse after container stops

### DIFF
--- a/Sources/ContainerBridge/VolumeManager.swift
+++ b/Sources/ContainerBridge/VolumeManager.swift
@@ -419,8 +419,9 @@ public actor VolumeManager {
             return
         }
 
-        // Check if volume is already in use by a different container
-        let users = try await stateStore.getVolumeUsers(volumeName: volumeName)
+        // Check if volume is already in use by a different RUNNING container
+        // Stopped containers don't actually hold the block device, so they shouldn't block reuse
+        let users = try await stateStore.getVolumeUsers(volumeName: volumeName, runningOnly: true)
         if !users.isEmpty && !users.contains(containerID) {
             let ownerContainer = users[0]
             logger.error("Block volume exclusive access violation", metadata: [

--- a/Sources/DockerAPI/Handlers/SystemHandlers.swift
+++ b/Sources/DockerAPI/Handlers/SystemHandlers.swift
@@ -23,7 +23,7 @@ public struct SystemHandlers: Sendable {
     /// Returns: Version information about the Docker Engine API
     public static func handleVersion() -> VersionResponse {
         return VersionResponse(
-            version: "0.1.10-alpha",
+            version: "0.1.11-alpha",
             apiVersion: "1.51",
             minAPIVersion: "1.24",
             gitCommit: "unknown",
@@ -80,14 +80,14 @@ public struct SystemHandlers: Sendable {
             cgroupVersion: "2",
             kernelVersion: processInfo.kernelVersion,
             operatingSystem: "Arca Container Runtime",
-            osVersion: "0.1.10-alpha",
+            osVersion: "0.1.11-alpha",
             osType: "linux",
             architecture: processInfo.machineArchitecture,
             ncpu: processInfo.activeProcessorCount,
             memTotal: Int64(processInfo.physicalMemory),
             name: processInfo.hostName,
             experimentalBuild: false,
-            serverVersion: "0.1.10-alpha"
+            serverVersion: "0.1.11-alpha"
         )
     }
 


### PR DESCRIPTION
## Summary

- Fixed block volume exclusive access validation to only consider **running** containers
- Stopped containers no longer block new containers from attaching the same block volume
- Bumped version to 0.1.11-alpha

Fixes #28

## Problem

When using `docker compose up -d` to recreate containers with block volumes, the recreation would fail with:
```
Volume 'myvolume' uses driver 'block' (exclusive access). Currently in use by container: <old-container-id>
```

This happened because `validateVolumeAccess()` was checking if ANY container had the volume mounted, regardless of whether that container was running or stopped.

## Solution

- Added `runningOnly: Bool` parameter to `StateStore.getVolumeUsers()`
- When `true`, JOINs with containers table and filters by `running == true`
- Updated `VolumeManager.validateVolumeAccess()` to pass `runningOnly: true`

This ensures only running containers block volume reuse. Stopped containers don't actually hold the block device, so they shouldn't prevent attachment.

## Test plan

- [x] Verified new container can attach block volume after previous container stops
- [x] Verified running container still blocks other containers from attaching same block volume