### PR TITLE
fix: Resolve VirtioFS mount point chmod/chown permission issues

### DIFF
--- a/Sources/Arca/main.swift
+++ b/Sources/Arca/main.swift
@@ -16,7 +16,7 @@ struct Arca: AsyncParsableCommand {
 
             Part of the Vas Solutus project - freeing containers on macOS.
             """,
-        version: "0.1.10-alpha (API v1.51)",
+        version: "0.2.0-alpha (API v1.51)",
         subcommands: [Daemon.self],
         defaultSubcommand: Daemon.self
     )

--- a/Sources/ArcaDaemon/HTTPHandler.swift
+++ b/Sources/ArcaDaemon/HTTPHandler.swift
@@ -185,7 +185,7 @@ final class HTTPHandler: ChannelInboundHandler, RemovableChannelHandler, @unchec
 
         case .streaming(let status, var headers, let callback):
             // Send response head with chunked transfer encoding
-            headers.add(name: "Server", value: "Arca/0.1.10-alpha")
+            headers.add(name: "Server", value: "Arca/0.2.0-alpha")
             headers.add(name: "Transfer-Encoding", value: "chunked")
 
             let responseHead = HTTPResponseHead(
@@ -219,7 +219,7 @@ final class HTTPHandler: ChannelInboundHandler, RemovableChannelHandler, @unchec
     private func sendResponse(context: ChannelHandlerContext, response: HTTPResponse) {
         // Send response head
         var headers = response.headers
-        headers.add(name: "Server", value: "Arca/0.1.10-alpha")
+        headers.add(name: "Server", value: "Arca/0.2.0-alpha")
 
         let responseHead = HTTPResponseHead(
             version: .http1_1,

--- a/Sources/DockerAPI/Handlers/SystemHandlers.swift
+++ b/Sources/DockerAPI/Handlers/SystemHandlers.swift
@@ -23,7 +23,7 @@ public struct SystemHandlers: Sendable {
     /// Returns: Version information about the Docker Engine API
     public static func handleVersion() -> VersionResponse {
         return VersionResponse(
-            version: "0.1.11-alpha",
+            version: "0.2.0-alpha",
             apiVersion: "1.51",
             minAPIVersion: "1.24",
             gitCommit: "unknown",
@@ -80,14 +80,14 @@ public struct SystemHandlers: Sendable {
             cgroupVersion: "2",
             kernelVersion: processInfo.kernelVersion,
             operatingSystem: "Arca Container Runtime",
-            osVersion: "0.1.11-alpha",
+            osVersion: "0.2.0-alpha",
             osType: "linux",
             architecture: processInfo.machineArchitecture,
             ncpu: processInfo.activeProcessorCount,
             memTotal: Int64(processInfo.physicalMemory),
             name: processInfo.hostName,
             experimentalBuild: false,
-            serverVersion: "0.1.11-alpha"
+            serverVersion: "0.2.0-alpha"
         )
     }
 


### PR DESCRIPTION
## Summary

- VirtioFS mount point root directories cannot be chmod/chown'd, causing containers like TimescaleDB to fail
- Implements subdirectory mounting: mount volume root to hidden location, bind mount data/ subdirectory to container path
- Bumps version to v0.2.0-alpha

## Test plan

- [x] TimescaleDB with local volume initializes successfully
- [x] `fixing permissions on existing directory /var/lib/postgresql/data ... ok`
- [x] PostgreSQL responds to queries

Closes #12