### PR TITLE
fix: Prevent daemon crash when stopping containers with port mappings

### DIFF
--- a/Sources/ContainerBridge/Version.swift
+++ b/Sources/ContainerBridge/Version.swift
@@ -3,8 +3,8 @@ import Foundation
 /// Centralized version configuration for Arca
 /// Update version here for releases - all version strings are derived from this
 public struct ArcaVersion {
-    /// Arca version number (e.g., "0.2.3-alpha")
-    public static let version = "0.2.3-alpha"
+    /// Arca version number (e.g., "0.2.4-alpha")
+    public static let version = "0.2.4-alpha"
 
     /// Docker Engine API version we implement
     public static let apiVersion = "1.51"


### PR DESCRIPTION
## Summary

- Fixes daemon crash (EXC_BREAKPOINT) when stopping/removing containers with port mappings
- Bumps version to v0.2.4-alpha

## Root Cause

The daemon was attempting to use a WireGuard client (via vsock) to clean up nftables rules **after** the container's VM had been stopped. Since `stop()` kills the VM, the vsock fd becomes invalid, causing NIO to crash.

## Solution

Don't pass the WireGuard client to `unpublishPorts()` when stopping/removing containers. The nftables rules inside the VM disappear with the VM anyway. Host-side proxies are still stopped correctly.

Fixes #40

## Test Plan

- [x] `docker run -d -p 9999:80 nginx:alpine` works
- [x] `docker stop <container>` works without crash
- [x] `docker rm <container>` works without crash
- [x] `docker rm -f <running-container>` works without crash