### PR TITLE
fix: Add startup readiness gate for network setup

### DIFF
--- a/Sources/ContainerBridge/BuildInfo.generated.swift
+++ b/Sources/ContainerBridge/BuildInfo.generated.swift
@@ -7,8 +7,8 @@ import Foundation
 /// Build-time information injected by Makefile
 public struct ArcaBuildInfo {
     /// Git commit hash at build time
-    public static let gitCommit = "3f4dfd5"
+    public static let gitCommit = "d572c7a"
 
     /// ISO8601 timestamp of build
-    public static let buildTime = "2025-12-01T19:45:32Z"
+    public static let buildTime = "2025-12-03T19:38:25Z"
 }

--- a/Sources/ContainerBridge/Generated/filesystem.grpc.swift
+++ b/Sources/ContainerBridge/Generated/filesystem.grpc.swift
@@ -19,6 +19,11 @@ public protocol Arca_Filesystem_V1_FilesystemServiceClientProtocol: GRPCClient {
   var serviceName: String { get }
   var interceptors: Arca_Filesystem_V1_FilesystemServiceClientInterceptorFactoryProtocol? { get }
 
+  func ready(
+    _ request: Arca_Filesystem_V1_ReadyRequest,
+    callOptions: CallOptions?
+  ) -> UnaryCall<Arca_Filesystem_V1_ReadyRequest, Arca_Filesystem_V1_ReadyResponse>
+
   func syncFilesystem(
     _ request: Arca_Filesystem_V1_SyncFilesystemRequest,
     callOptions: CallOptions?
@@ -48,6 +53,25 @@ public protocol Arca_Filesystem_V1_FilesystemServiceClientProtocol: GRPCClient {
 extension Arca_Filesystem_V1_FilesystemServiceClientProtocol {
   public var serviceName: String {
     return "arca.filesystem.v1.FilesystemService"
+  }
+
+  /// Check if service is fully initialized and ready to handle requests
+  /// Used by vminitd to verify service startup before allowing container creation
+  ///
+  /// - Parameters:
+  ///   - request: Request to send to Ready.
+  ///   - callOptions: Call options.
+  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
+  public func ready(
+    _ request: Arca_Filesystem_V1_ReadyRequest,
+    callOptions: CallOptions? = nil
+  ) -> UnaryCall<Arca_Filesystem_V1_ReadyRequest, Arca_Filesystem_V1_ReadyResponse> {
+    return self.makeUnaryCall(
+      path: Arca_Filesystem_V1_FilesystemServiceClientMetadata.Methods.ready.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeReadyInterceptors() ?? []
+    )
   }
 
   /// Sync filesystem (flush all cached writes to disk)
@@ -215,6 +239,11 @@ public protocol Arca_Filesystem_V1_FilesystemServiceAsyncClientProtocol: GRPCCli
   static var serviceDescriptor: GRPCServiceDescriptor { get }
   var interceptors: Arca_Filesystem_V1_FilesystemServiceClientInterceptorFactoryProtocol? { get }
 
+  func makeReadyCall(
+    _ request: Arca_Filesystem_V1_ReadyRequest,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncUnaryCall<Arca_Filesystem_V1_ReadyRequest, Arca_Filesystem_V1_ReadyResponse>
+
   func makeSyncFilesystemCall(
     _ request: Arca_Filesystem_V1_SyncFilesystemRequest,
     callOptions: CallOptions?
@@ -249,6 +278,18 @@ extension Arca_Filesystem_V1_FilesystemServiceAsyncClientProtocol {
 
   public var interceptors: Arca_Filesystem_V1_FilesystemServiceClientInterceptorFactoryProtocol? {
     return nil
+  }
+
+  public func makeReadyCall(
+    _ request: Arca_Filesystem_V1_ReadyRequest,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncUnaryCall<Arca_Filesystem_V1_ReadyRequest, Arca_Filesystem_V1_ReadyResponse> {
+    return self.makeAsyncUnaryCall(
+      path: Arca_Filesystem_V1_FilesystemServiceClientMetadata.Methods.ready.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeReadyInterceptors() ?? []
+    )
   }
 
   public func makeSyncFilesystemCall(
@@ -314,6 +355,18 @@ extension Arca_Filesystem_V1_FilesystemServiceAsyncClientProtocol {
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Arca_Filesystem_V1_FilesystemServiceAsyncClientProtocol {
+  public func ready(
+    _ request: Arca_Filesystem_V1_ReadyRequest,
+    callOptions: CallOptions? = nil
+  ) async throws -> Arca_Filesystem_V1_ReadyResponse {
+    return try await self.performAsyncUnaryCall(
+      path: Arca_Filesystem_V1_FilesystemServiceClientMetadata.Methods.ready.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeReadyInterceptors() ?? []
+    )
+  }
+
   public func syncFilesystem(
     _ request: Arca_Filesystem_V1_SyncFilesystemRequest,
     callOptions: CallOptions? = nil
@@ -394,6 +447,9 @@ public struct Arca_Filesystem_V1_FilesystemServiceAsyncClient: Arca_Filesystem_V
 
 public protocol Arca_Filesystem_V1_FilesystemServiceClientInterceptorFactoryProtocol: Sendable {
 
+  /// - Returns: Interceptors to use when invoking 'ready'.
+  func makeReadyInterceptors() -> [ClientInterceptor<Arca_Filesystem_V1_ReadyRequest, Arca_Filesystem_V1_ReadyResponse>]
+
   /// - Returns: Interceptors to use when invoking 'syncFilesystem'.
   func makeSyncFilesystemInterceptors() -> [ClientInterceptor<Arca_Filesystem_V1_SyncFilesystemRequest, Arca_Filesystem_V1_SyncFilesystemResponse>]
 
@@ -415,6 +471,7 @@ public enum Arca_Filesystem_V1_FilesystemServiceClientMetadata {
     name: "FilesystemService",
     fullName: "arca.filesystem.v1.FilesystemService",
     methods: [
+      Arca_Filesystem_V1_FilesystemServiceClientMetadata.Methods.ready,
       Arca_Filesystem_V1_FilesystemServiceClientMetadata.Methods.syncFilesystem,
       Arca_Filesystem_V1_FilesystemServiceClientMetadata.Methods.enumerateUpperdir,
       Arca_Filesystem_V1_FilesystemServiceClientMetadata.Methods.readArchive,
@@ -424,6 +481,12 @@ public enum Arca_Filesystem_V1_FilesystemServiceClientMetadata {
   )
 
   public enum Methods {
+    public static let ready = GRPCMethodDescriptor(
+      name: "Ready",
+      path: "/arca.filesystem.v1.FilesystemService/Ready",
+      type: GRPCCallType.unary
+    )
+
     public static let syncFilesystem = GRPCMethodDescriptor(
       name: "SyncFilesystem",
       path: "/arca.filesystem.v1.FilesystemService/SyncFilesystem",

--- a/Sources/ContainerBridge/Generated/filesystem.pb.swift
+++ b/Sources/ContainerBridge/Generated/filesystem.pb.swift
@@ -30,6 +30,37 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
+/// Request to check service readiness
+public struct Arca_Filesystem_V1_ReadyRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+/// Response indicating service readiness
+public struct Arca_Filesystem_V1_ReadyResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// True if service is fully initialized and ready
+  public var ready: Bool = false
+
+  /// Service version
+  public var version: String = String()
+
+  /// Milliseconds since service started
+  public var uptimeMs: Int64 = 0
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 /// Request to sync filesystem (flush all cached writes)
 public struct Arca_Filesystem_V1_SyncFilesystemRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
@@ -268,6 +299,65 @@ public struct Arca_Filesystem_V1_CreateBindMountResponse: Sendable {
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "arca.filesystem.v1"
+
+extension Arca_Filesystem_V1_ReadyRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".ReadyRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    // Load everything into unknown fields
+    while try decoder.nextFieldNumber() != nil {}
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Arca_Filesystem_V1_ReadyRequest, rhs: Arca_Filesystem_V1_ReadyRequest) -> Bool {
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Arca_Filesystem_V1_ReadyResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".ReadyResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}ready\0\u{1}version\0\u{3}uptime_ms\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularBoolField(value: &self.ready) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.version) }()
+      case 3: try { try decoder.decodeSingularInt64Field(value: &self.uptimeMs) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.ready != false {
+      try visitor.visitSingularBoolField(value: self.ready, fieldNumber: 1)
+    }
+    if !self.version.isEmpty {
+      try visitor.visitSingularStringField(value: self.version, fieldNumber: 2)
+    }
+    if self.uptimeMs != 0 {
+      try visitor.visitSingularInt64Field(value: self.uptimeMs, fieldNumber: 3)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Arca_Filesystem_V1_ReadyResponse, rhs: Arca_Filesystem_V1_ReadyResponse) -> Bool {
+    if lhs.ready != rhs.ready {return false}
+    if lhs.version != rhs.version {return false}
+    if lhs.uptimeMs != rhs.uptimeMs {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
 
 extension Arca_Filesystem_V1_SyncFilesystemRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".SyncFilesystemRequest"

--- a/Sources/ContainerBridge/Generated/wireguard.grpc.swift
+++ b/Sources/ContainerBridge/Generated/wireguard.grpc.swift
@@ -19,6 +19,11 @@ public protocol Arca_Wireguard_V1_WireGuardServiceClientProtocol: GRPCClient {
   var serviceName: String { get }
   var interceptors: Arca_Wireguard_V1_WireGuardServiceClientInterceptorFactoryProtocol? { get }
 
+  func ready(
+    _ request: Arca_Wireguard_V1_ReadyRequest,
+    callOptions: CallOptions?
+  ) -> UnaryCall<Arca_Wireguard_V1_ReadyRequest, Arca_Wireguard_V1_ReadyResponse>
+
   func addNetwork(
     _ request: Arca_Wireguard_V1_AddNetworkRequest,
     callOptions: CallOptions?
@@ -68,6 +73,25 @@ public protocol Arca_Wireguard_V1_WireGuardServiceClientProtocol: GRPCClient {
 extension Arca_Wireguard_V1_WireGuardServiceClientProtocol {
   public var serviceName: String {
     return "arca.wireguard.v1.WireGuardService"
+  }
+
+  /// Check if service is fully initialized and ready to handle requests
+  /// Used by vminitd to verify service startup before allowing container creation
+  ///
+  /// - Parameters:
+  ///   - request: Request to send to Ready.
+  ///   - callOptions: Call options.
+  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
+  public func ready(
+    _ request: Arca_Wireguard_V1_ReadyRequest,
+    callOptions: CallOptions? = nil
+  ) -> UnaryCall<Arca_Wireguard_V1_ReadyRequest, Arca_Wireguard_V1_ReadyResponse> {
+    return self.makeUnaryCall(
+      path: Arca_Wireguard_V1_WireGuardServiceClientMetadata.Methods.ready.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeReadyInterceptors() ?? []
+    )
   }
 
   /// Add a network to this container (creates wgN interface + veth pair, renames to ethN)
@@ -298,6 +322,11 @@ public protocol Arca_Wireguard_V1_WireGuardServiceAsyncClientProtocol: GRPCClien
   static var serviceDescriptor: GRPCServiceDescriptor { get }
   var interceptors: Arca_Wireguard_V1_WireGuardServiceClientInterceptorFactoryProtocol? { get }
 
+  func makeReadyCall(
+    _ request: Arca_Wireguard_V1_ReadyRequest,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncUnaryCall<Arca_Wireguard_V1_ReadyRequest, Arca_Wireguard_V1_ReadyResponse>
+
   func makeAddNetworkCall(
     _ request: Arca_Wireguard_V1_AddNetworkRequest,
     callOptions: CallOptions?
@@ -352,6 +381,18 @@ extension Arca_Wireguard_V1_WireGuardServiceAsyncClientProtocol {
 
   public var interceptors: Arca_Wireguard_V1_WireGuardServiceClientInterceptorFactoryProtocol? {
     return nil
+  }
+
+  public func makeReadyCall(
+    _ request: Arca_Wireguard_V1_ReadyRequest,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncUnaryCall<Arca_Wireguard_V1_ReadyRequest, Arca_Wireguard_V1_ReadyResponse> {
+    return self.makeAsyncUnaryCall(
+      path: Arca_Wireguard_V1_WireGuardServiceClientMetadata.Methods.ready.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeReadyInterceptors() ?? []
+    )
   }
 
   public func makeAddNetworkCall(
@@ -465,6 +506,18 @@ extension Arca_Wireguard_V1_WireGuardServiceAsyncClientProtocol {
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Arca_Wireguard_V1_WireGuardServiceAsyncClientProtocol {
+  public func ready(
+    _ request: Arca_Wireguard_V1_ReadyRequest,
+    callOptions: CallOptions? = nil
+  ) async throws -> Arca_Wireguard_V1_ReadyResponse {
+    return try await self.performAsyncUnaryCall(
+      path: Arca_Wireguard_V1_WireGuardServiceClientMetadata.Methods.ready.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeReadyInterceptors() ?? []
+    )
+  }
+
   public func addNetwork(
     _ request: Arca_Wireguard_V1_AddNetworkRequest,
     callOptions: CallOptions? = nil
@@ -593,6 +646,9 @@ public struct Arca_Wireguard_V1_WireGuardServiceAsyncClient: Arca_Wireguard_V1_W
 
 public protocol Arca_Wireguard_V1_WireGuardServiceClientInterceptorFactoryProtocol: Sendable {
 
+  /// - Returns: Interceptors to use when invoking 'ready'.
+  func makeReadyInterceptors() -> [ClientInterceptor<Arca_Wireguard_V1_ReadyRequest, Arca_Wireguard_V1_ReadyResponse>]
+
   /// - Returns: Interceptors to use when invoking 'addNetwork'.
   func makeAddNetworkInterceptors() -> [ClientInterceptor<Arca_Wireguard_V1_AddNetworkRequest, Arca_Wireguard_V1_AddNetworkResponse>]
 
@@ -626,6 +682,7 @@ public enum Arca_Wireguard_V1_WireGuardServiceClientMetadata {
     name: "WireGuardService",
     fullName: "arca.wireguard.v1.WireGuardService",
     methods: [
+      Arca_Wireguard_V1_WireGuardServiceClientMetadata.Methods.ready,
       Arca_Wireguard_V1_WireGuardServiceClientMetadata.Methods.addNetwork,
       Arca_Wireguard_V1_WireGuardServiceClientMetadata.Methods.removeNetwork,
       Arca_Wireguard_V1_WireGuardServiceClientMetadata.Methods.addPeer,
@@ -639,6 +696,12 @@ public enum Arca_Wireguard_V1_WireGuardServiceClientMetadata {
   )
 
   public enum Methods {
+    public static let ready = GRPCMethodDescriptor(
+      name: "Ready",
+      path: "/arca.wireguard.v1.WireGuardService/Ready",
+      type: GRPCCallType.unary
+    )
+
     public static let addNetwork = GRPCMethodDescriptor(
       name: "AddNetwork",
       path: "/arca.wireguard.v1.WireGuardService/AddNetwork",

--- a/Sources/ContainerBridge/Generated/wireguard.pb.swift
+++ b/Sources/ContainerBridge/Generated/wireguard.pb.swift
@@ -23,6 +23,37 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
+/// Request to check service readiness
+public struct Arca_Wireguard_V1_ReadyRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+/// Response indicating service readiness
+public struct Arca_Wireguard_V1_ReadyResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// True if service is fully initialized and ready
+  public var ready: Bool = false
+
+  /// Service version
+  public var version: String = String()
+
+  /// Milliseconds since service started
+  public var uptimeMs: Int64 = 0
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 /// Request to add a network to the container
 public struct Arca_Wireguard_V1_AddNetworkRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
@@ -34,6 +65,9 @@ public struct Arca_Wireguard_V1_AddNetworkRequest: Sendable {
 
   /// Network index (0 for first network → wg0/eth0, 1 for second → wg1/eth1, etc.)
   public var networkIndex: UInt32 = 0
+
+  /// Container ID - used to create the network namespace on first AddNetwork call
+  public var containerID: String = String()
 
   /// Private key for this container's WireGuard interface (Base64-encoded Curve25519 key)
   /// Each wgN interface gets its own private key
@@ -61,9 +95,8 @@ public struct Arca_Wireguard_V1_AddNetworkRequest: Sendable {
   /// This is the macOS host's LAN IP, allowing containers to reach host services
   public var hostIp: String = String()
 
-  /// Extra host entries for DNS resolution (format: "hostname:ip")
-  /// These are added to the container's DNS resolver for custom name resolution
-  /// Special value "host-gateway" is resolved to host_ip before being passed here
+  /// Extra hosts for DNS resolution (from --add-host flag)
+  /// Format: "hostname:ip" (e.g., "myhost:192.168.1.100")
   public var extraHosts: [String] = []
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -93,6 +126,10 @@ public struct Arca_Wireguard_V1_AddNetworkResponse: Sendable {
 
   /// Public key for this interface (for peer configuration)
   public var publicKey: String = String()
+
+  /// Path to the network namespace (e.g., "/var/run/netns/container-xyz")
+  /// The container should join this namespace instead of creating a new one
+  public var namespacePath: String = String()
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -485,9 +522,68 @@ public struct Arca_Wireguard_V1_DumpNftablesResponse: Sendable {
 
 fileprivate let _protobuf_package = "arca.wireguard.v1"
 
+extension Arca_Wireguard_V1_ReadyRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".ReadyRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    // Load everything into unknown fields
+    while try decoder.nextFieldNumber() != nil {}
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Arca_Wireguard_V1_ReadyRequest, rhs: Arca_Wireguard_V1_ReadyRequest) -> Bool {
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Arca_Wireguard_V1_ReadyResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".ReadyResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}ready\0\u{1}version\0\u{3}uptime_ms\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularBoolField(value: &self.ready) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.version) }()
+      case 3: try { try decoder.decodeSingularInt64Field(value: &self.uptimeMs) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.ready != false {
+      try visitor.visitSingularBoolField(value: self.ready, fieldNumber: 1)
+    }
+    if !self.version.isEmpty {
+      try visitor.visitSingularStringField(value: self.version, fieldNumber: 2)
+    }
+    if self.uptimeMs != 0 {
+      try visitor.visitSingularInt64Field(value: self.uptimeMs, fieldNumber: 3)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Arca_Wireguard_V1_ReadyResponse, rhs: Arca_Wireguard_V1_ReadyResponse) -> Bool {
+    if lhs.ready != rhs.ready {return false}
+    if lhs.version != rhs.version {return false}
+    if lhs.uptimeMs != rhs.uptimeMs {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
 extension Arca_Wireguard_V1_AddNetworkRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AddNetworkRequest"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}network_id\0\u{3}network_index\0\u{3}private_key\0\u{3}listen_port\0\u{3}peer_endpoint\0\u{3}peer_public_key\0\u{3}ip_address\0\u{3}network_cidr\0\u{1}gateway\0\u{3}host_ip\0\u{3}extra_hosts\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}network_id\0\u{3}network_index\0\u{3}private_key\0\u{3}listen_port\0\u{3}peer_endpoint\0\u{3}peer_public_key\0\u{3}ip_address\0\u{3}network_cidr\0\u{1}gateway\0\u{3}host_ip\0\u{3}extra_hosts\0\u{3}container_id\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -506,6 +602,7 @@ extension Arca_Wireguard_V1_AddNetworkRequest: SwiftProtobuf.Message, SwiftProto
       case 9: try { try decoder.decodeSingularStringField(value: &self.gateway) }()
       case 10: try { try decoder.decodeSingularStringField(value: &self.hostIp) }()
       case 11: try { try decoder.decodeRepeatedStringField(value: &self.extraHosts) }()
+      case 12: try { try decoder.decodeSingularStringField(value: &self.containerID) }()
       default: break
       }
     }
@@ -545,12 +642,16 @@ extension Arca_Wireguard_V1_AddNetworkRequest: SwiftProtobuf.Message, SwiftProto
     if !self.extraHosts.isEmpty {
       try visitor.visitRepeatedStringField(value: self.extraHosts, fieldNumber: 11)
     }
+    if !self.containerID.isEmpty {
+      try visitor.visitSingularStringField(value: self.containerID, fieldNumber: 12)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Arca_Wireguard_V1_AddNetworkRequest, rhs: Arca_Wireguard_V1_AddNetworkRequest) -> Bool {
     if lhs.networkID != rhs.networkID {return false}
     if lhs.networkIndex != rhs.networkIndex {return false}
+    if lhs.containerID != rhs.containerID {return false}
     if lhs.privateKey != rhs.privateKey {return false}
     if lhs.listenPort != rhs.listenPort {return false}
     if lhs.peerEndpoint != rhs.peerEndpoint {return false}
@@ -567,7 +668,7 @@ extension Arca_Wireguard_V1_AddNetworkRequest: SwiftProtobuf.Message, SwiftProto
 
 extension Arca_Wireguard_V1_AddNetworkResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AddNetworkResponse"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{1}error\0\u{3}total_networks\0\u{3}wg_interface\0\u{3}eth_interface\0\u{3}public_key\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{1}error\0\u{3}total_networks\0\u{3}wg_interface\0\u{3}eth_interface\0\u{3}public_key\0\u{3}namespace_path\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -581,6 +682,7 @@ extension Arca_Wireguard_V1_AddNetworkResponse: SwiftProtobuf.Message, SwiftProt
       case 4: try { try decoder.decodeSingularStringField(value: &self.wgInterface) }()
       case 5: try { try decoder.decodeSingularStringField(value: &self.ethInterface) }()
       case 6: try { try decoder.decodeSingularStringField(value: &self.publicKey) }()
+      case 7: try { try decoder.decodeSingularStringField(value: &self.namespacePath) }()
       default: break
       }
     }
@@ -605,6 +707,9 @@ extension Arca_Wireguard_V1_AddNetworkResponse: SwiftProtobuf.Message, SwiftProt
     if !self.publicKey.isEmpty {
       try visitor.visitSingularStringField(value: self.publicKey, fieldNumber: 6)
     }
+    if !self.namespacePath.isEmpty {
+      try visitor.visitSingularStringField(value: self.namespacePath, fieldNumber: 7)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -615,6 +720,7 @@ extension Arca_Wireguard_V1_AddNetworkResponse: SwiftProtobuf.Message, SwiftProt
     if lhs.wgInterface != rhs.wgInterface {return false}
     if lhs.ethInterface != rhs.ethInterface {return false}
     if lhs.publicKey != rhs.publicKey {return false}
+    if lhs.namespacePath != rhs.namespacePath {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/ContainerBridge/Process/Generated/process.grpc.swift
+++ b/Sources/ContainerBridge/Process/Generated/process.grpc.swift
@@ -29,6 +29,11 @@ public protocol Arca_Process_V1_ProcessServiceClientProtocol: GRPCClient {
   var serviceName: String { get }
   var interceptors: Arca_Process_V1_ProcessServiceClientInterceptorFactoryProtocol? { get }
 
+  func ready(
+    _ request: Arca_Process_V1_ReadyRequest,
+    callOptions: CallOptions?
+  ) -> UnaryCall<Arca_Process_V1_ReadyRequest, Arca_Process_V1_ReadyResponse>
+
   func startProcess(
     _ request: Arca_Process_V1_StartProcessRequest,
     callOptions: CallOptions?
@@ -48,6 +53,25 @@ public protocol Arca_Process_V1_ProcessServiceClientProtocol: GRPCClient {
 extension Arca_Process_V1_ProcessServiceClientProtocol {
   public var serviceName: String {
     return "arca.process.v1.ProcessService"
+  }
+
+  /// Check if service is fully initialized and ready to handle requests
+  /// Used by vminitd to verify service startup before allowing container creation
+  ///
+  /// - Parameters:
+  ///   - request: Request to send to Ready.
+  ///   - callOptions: Call options.
+  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
+  public func ready(
+    _ request: Arca_Process_V1_ReadyRequest,
+    callOptions: CallOptions? = nil
+  ) -> UnaryCall<Arca_Process_V1_ReadyRequest, Arca_Process_V1_ReadyResponse> {
+    return self.makeUnaryCall(
+      path: Arca_Process_V1_ProcessServiceClientMetadata.Methods.ready.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeReadyInterceptors() ?? []
+    )
   }
 
   /// Start the container's init process
@@ -188,6 +212,11 @@ public protocol Arca_Process_V1_ProcessServiceAsyncClientProtocol: GRPCClient {
   static var serviceDescriptor: GRPCServiceDescriptor { get }
   var interceptors: Arca_Process_V1_ProcessServiceClientInterceptorFactoryProtocol? { get }
 
+  func makeReadyCall(
+    _ request: Arca_Process_V1_ReadyRequest,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncUnaryCall<Arca_Process_V1_ReadyRequest, Arca_Process_V1_ReadyResponse>
+
   func makeStartProcessCall(
     _ request: Arca_Process_V1_StartProcessRequest,
     callOptions: CallOptions?
@@ -212,6 +241,18 @@ extension Arca_Process_V1_ProcessServiceAsyncClientProtocol {
 
   public var interceptors: Arca_Process_V1_ProcessServiceClientInterceptorFactoryProtocol? {
     return nil
+  }
+
+  public func makeReadyCall(
+    _ request: Arca_Process_V1_ReadyRequest,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncUnaryCall<Arca_Process_V1_ReadyRequest, Arca_Process_V1_ReadyResponse> {
+    return self.makeAsyncUnaryCall(
+      path: Arca_Process_V1_ProcessServiceClientMetadata.Methods.ready.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeReadyInterceptors() ?? []
+    )
   }
 
   public func makeStartProcessCall(
@@ -253,6 +294,18 @@ extension Arca_Process_V1_ProcessServiceAsyncClientProtocol {
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Arca_Process_V1_ProcessServiceAsyncClientProtocol {
+  public func ready(
+    _ request: Arca_Process_V1_ReadyRequest,
+    callOptions: CallOptions? = nil
+  ) async throws -> Arca_Process_V1_ReadyResponse {
+    return try await self.performAsyncUnaryCall(
+      path: Arca_Process_V1_ProcessServiceClientMetadata.Methods.ready.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeReadyInterceptors() ?? []
+    )
+  }
+
   public func startProcess(
     _ request: Arca_Process_V1_StartProcessRequest,
     callOptions: CallOptions? = nil
@@ -309,6 +362,9 @@ public struct Arca_Process_V1_ProcessServiceAsyncClient: Arca_Process_V1_Process
 
 public protocol Arca_Process_V1_ProcessServiceClientInterceptorFactoryProtocol: Sendable {
 
+  /// - Returns: Interceptors to use when invoking 'ready'.
+  func makeReadyInterceptors() -> [ClientInterceptor<Arca_Process_V1_ReadyRequest, Arca_Process_V1_ReadyResponse>]
+
   /// - Returns: Interceptors to use when invoking 'startProcess'.
   func makeStartProcessInterceptors() -> [ClientInterceptor<Arca_Process_V1_StartProcessRequest, Arca_Process_V1_StartProcessResponse>]
 
@@ -324,6 +380,7 @@ public enum Arca_Process_V1_ProcessServiceClientMetadata {
     name: "ProcessService",
     fullName: "arca.process.v1.ProcessService",
     methods: [
+      Arca_Process_V1_ProcessServiceClientMetadata.Methods.ready,
       Arca_Process_V1_ProcessServiceClientMetadata.Methods.startProcess,
       Arca_Process_V1_ProcessServiceClientMetadata.Methods.getProcessStatus,
       Arca_Process_V1_ProcessServiceClientMetadata.Methods.listProcesses,
@@ -331,6 +388,12 @@ public enum Arca_Process_V1_ProcessServiceClientMetadata {
   )
 
   public enum Methods {
+    public static let ready = GRPCMethodDescriptor(
+      name: "Ready",
+      path: "/arca.process.v1.ProcessService/Ready",
+      type: GRPCCallType.unary
+    )
+
     public static let startProcess = GRPCMethodDescriptor(
       name: "StartProcess",
       path: "/arca.process.v1.ProcessService/StartProcess",

--- a/Sources/ContainerBridge/Process/Generated/process.pb.swift
+++ b/Sources/ContainerBridge/Process/Generated/process.pb.swift
@@ -20,6 +20,37 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
+/// Request to check service readiness
+public struct Arca_Process_V1_ReadyRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+/// Response indicating service readiness
+public struct Arca_Process_V1_ReadyResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// True if service is fully initialized and ready
+  public var ready: Bool = false
+
+  /// Service version
+  public var version: String = String()
+
+  /// Milliseconds since service started
+  public var uptimeMs: Int64 = 0
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 public struct Arca_Process_V1_StartProcessRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -125,6 +156,65 @@ public struct Arca_Process_V1_ProcessInfo: Sendable {
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "arca.process.v1"
+
+extension Arca_Process_V1_ReadyRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".ReadyRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    // Load everything into unknown fields
+    while try decoder.nextFieldNumber() != nil {}
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Arca_Process_V1_ReadyRequest, rhs: Arca_Process_V1_ReadyRequest) -> Bool {
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Arca_Process_V1_ReadyResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".ReadyResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}ready\0\u{1}version\0\u{3}uptime_ms\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularBoolField(value: &self.ready) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.version) }()
+      case 3: try { try decoder.decodeSingularInt64Field(value: &self.uptimeMs) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.ready != false {
+      try visitor.visitSingularBoolField(value: self.ready, fieldNumber: 1)
+    }
+    if !self.version.isEmpty {
+      try visitor.visitSingularStringField(value: self.version, fieldNumber: 2)
+    }
+    if self.uptimeMs != 0 {
+      try visitor.visitSingularInt64Field(value: self.uptimeMs, fieldNumber: 3)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Arca_Process_V1_ReadyResponse, rhs: Arca_Process_V1_ReadyResponse) -> Bool {
+    if lhs.ready != rhs.ready {return false}
+    if lhs.version != rhs.version {return false}
+    if lhs.uptimeMs != rhs.uptimeMs {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
 
 extension Arca_Process_V1_StartProcessRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".StartProcessRequest"

--- a/Sources/ContainerBridge/WireGuardNetworkBackend.swift
+++ b/Sources/ContainerBridge/WireGuardNetworkBackend.swift
@@ -472,6 +472,7 @@ public actor WireGuardNetworkBackend {
         let result = try await wgClient.addNetwork(
             networkID: networkID,
             networkIndex: networkIndex,
+            containerID: containerID,
             privateKey: privateKey,
             listenPort: listenPort,
             peerEndpoint: "",  // Empty - no initial peer needed

--- a/scripts/build-vminit.sh
+++ b/scripts/build-vminit.sh
@@ -51,82 +51,33 @@ if ! swift sdk list 2>/dev/null | grep -q "static-linux"; then
 fi
 echo "  ✓ Swift Static Linux SDK found"
 
-# Build WireGuard service (Go binary cross-compiled to Linux with integrated DNS)
+# Build unified arca-services (Go binary cross-compiled to Linux)
+# This single binary contains all container extension services:
+# - WireGuard network service (vsock:51820) with integrated DNS
+# - Filesystem operations service (vsock:51821)
+# - Process control service (vsock:51822)
+# - Ready signal coordination (vsock:51819)
 echo ""
-echo "→ Building WireGuard service (Go → Linux ARM64)..."
-cd "$VMINITD_DIR/vminitd/extensions/wireguard-service"
+echo "→ Building unified arca-services (Go → Linux ARM64)..."
+cd "$VMINITD_DIR/vminitd/extensions/arca-services"
 
 if [ ! -f build.sh ]; then
-    echo "ERROR: wireguard-service/build.sh not found"
+    echo "ERROR: arca-services/build.sh not found"
     exit 1
 fi
 
-# Generate protobuf code first
-if [ ! -f proto/wireguard.pb.go ]; then
-    echo "  Generating protobuf code..."
-    ./generate-proto.sh
-fi
+# Run go mod tidy to ensure dependencies are resolved
+echo "  Resolving Go dependencies..."
+go mod tidy
 
 ./build.sh
 
-if [ ! -f arca-wireguard-service ]; then
-    echo "ERROR: arca-wireguard-service binary not built"
+if [ ! -f arca-services ]; then
+    echo "ERROR: arca-services binary not built"
     exit 1
 fi
 
-echo "  ✓ WireGuard service built: arca-wireguard-service"
-
-# Build Filesystem service (Go binary cross-compiled to Linux)
-echo ""
-echo "→ Building Filesystem service (Go → Linux ARM64)..."
-cd "$VMINITD_DIR/vminitd/extensions/filesystem-service"
-
-if [ ! -f build.sh ]; then
-    echo "ERROR: filesystem-service/build.sh not found"
-    exit 1
-fi
-
-# Generate protobuf code first if needed
-if [ ! -f proto/filesystem.pb.go ]; then
-    echo "  Generating protobuf code..."
-    make gen-grpc  # Assuming we'll add this target or it exists
-fi
-
-./build.sh
-
-if [ ! -f arca-filesystem-service ]; then
-    echo "ERROR: arca-filesystem-service binary not built"
-    exit 1
-fi
-
-echo "  ✓ Filesystem service built: arca-filesystem-service"
-
-# Build Process Control service (Go binary cross-compiled to Linux)
-echo ""
-echo "→ Building Process Control service (Go → Linux ARM64)..."
-cd "$VMINITD_DIR/vminitd/extensions/process-control"
-
-if [ ! -f build.sh ]; then
-    echo "ERROR: process-control/build.sh not found"
-    exit 1
-fi
-
-# Generate protobuf code first if needed
-if [ ! -f proto/process.pb.go ]; then
-    echo "  Generating protobuf code..."
-    protoc --go_out=. --go_opt=paths=source_relative \
-           --go-grpc_out=. --go-grpc_opt=paths=source_relative \
-           proto/process.proto
-fi
-
-./build.sh
-
-if [ ! -f arca-process-service ]; then
-    echo "ERROR: arca-process-service binary not built"
-    exit 1
-fi
-
-echo "  ✓ Process Control service built: arca-process-service"
+echo "  ✓ Unified services built: arca-services"
 
 # WireGuard tools (wg command) no longer needed - using netlink API
 # Build vminitd (Swift cross-compiled to Linux)
@@ -180,9 +131,7 @@ echo "  Using cctl to create rootfs with Swift runtime..."
 "$CCTL_BINARY" rootfs create \
     --vminitd "$VMINITD_BINARY" \
     --vmexec "$VMEXEC_BINARY" \
-    --add-file "$VMINITD_DIR/vminitd/extensions/wireguard-service/arca-wireguard-service:/sbin/arca-wireguard-service" \
-    --add-file "$VMINITD_DIR/vminitd/extensions/filesystem-service/arca-filesystem-service:/sbin/arca-filesystem-service" \
-    --add-file "$VMINITD_DIR/vminitd/extensions/process-control/arca-process-service:/sbin/arca-process-service" \
+    --add-file "$VMINITD_DIR/vminitd/extensions/arca-services/arca-services:/sbin/arca-services" \
     --image arca-vminit:latest \
     --label org.opencontainers.image.source=https://github.com/Vas-Solutus/arca \
     "$ROOTFS_TAR"
@@ -303,11 +252,13 @@ echo ""
 echo "OCI image location: $VMINIT_DIR"
 echo ""
 echo "Contents:"
-echo "  /sbin/vminitd                  - Init system (PID 1)"
-echo "  /sbin/vmexec                   - Exec helper"
-echo "  /sbin/arca-wireguard-service   - WireGuard network service (vsock:51820) with integrated DNS (127.0.0.11:53)"
-echo "  /sbin/arca-filesystem-service  - Filesystem operations service (vsock:51821)"
-echo "  /sbin/arca-process-service     - Process control service (vsock:51822)"
+echo "  /sbin/vminitd      - Init system (PID 1)"
+echo "  /sbin/vmexec       - Exec helper"
+echo "  /sbin/arca-services - Unified container services (single binary):"
+echo "                        - vsock:51819 - Ready signal (opens when all services ready)"
+echo "                        - vsock:51820 - WireGuard network API with integrated DNS"
+echo "                        - vsock:51821 - Filesystem operations API"
+echo "                        - vsock:51822 - Process control API"
 echo "  + Swift runtime and system libraries (via cctl)"
 echo ""
 echo "This image will be loaded as 'arca-vminit:latest' and used by all containers."


### PR DESCRIPTION
## Summary

Fixes #43

The container startup had a race condition where the container process could start before the network namespace was created. This was caused by `LinuxContainer.start()` holding a lock that blocked `dialVsock()`, preventing `waitForServicesReady()` and `AddNetwork` from running until `start()` completed (5 second timeout).

## Solution

Reorder startup to call AddNetwork **BEFORE** `container.start()`:

```
BEFORE (broken):
  start() [holds lock] → blocks dialVsock → can't call AddNetwork → 5s timeout → fail

AFTER (fixed):
  waitForServicesReady() → AddNetwork (creates namespace) → start() (joins existing namespace)
```

## Changes

- **ContainerManager.swift**: Move network setup before `start()` call
- **WireGuardClient.swift**: Add `containerID` parameter to `addNetwork`
- **WireGuardNetworkBackend.swift**: Pass `containerID` to `addNetwork`
- **ManagedProcess.swift**: Remove namespace wait (no longer needed)
- **RuncProcess.swift**: Remove namespace wait (no longer needed)
- **RunCommand.swift**: Move namespace joining to after ack, add console logging
- **vmexec.swift**: Add `logToConsole()` for VM bootlog output
- **LinuxContainer.swift**: Add `networkNamespacePath` property
- **netns.go**: Use `/run/netns` instead of `/var/run/netns`
- Regenerate gRPC code for consolidated arca-services

## Test plan

- [x] Basic network connectivity (ping 8.8.8.8)
- [x] host.docker.internal resolution
- [x] extra_hosts support (--add-host)
- [x] Container-to-container DNS resolution
- [x] Container-to-container ping (by IP and name)
- [x] External wget (httpbin.org)
- [x] Multi-network support (docker network connect)