### PR TITLE
Reconcile with upstream containerization and restore the build

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -29,6 +29,33 @@
       }
     },
     {
+      "identity" : "grpc-swift-2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-swift-2.git",
+      "state" : {
+        "revision" : "28cdd63ef88583ddc67d7bb179eab46fab465ce9",
+        "version" : "2.4.2"
+      }
+    },
+    {
+      "identity" : "grpc-swift-nio-transport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-swift-nio-transport.git",
+      "state" : {
+        "revision" : "c46f77c07c3ae4fce4734e7af03fcb35ab544428",
+        "version" : "2.9.1"
+      }
+    },
+    {
+      "identity" : "grpc-swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-swift-protobuf.git",
+      "state" : {
+        "revision" : "8723cf856dc23d9c2fad4d874e7b9ed3254acf03",
+        "version" : "2.3.0"
+      }
+    },
+    {
       "identity" : "sqlite.swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephencelis/SQLite.swift.git",
@@ -60,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "cdd0ef3755280949551dc26dee5de9ddeda89f54",
-        "version" : "1.6.2"
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
       }
     },
     {
@@ -195,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
-        "version" : "1.6.4"
+        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
+        "version" : "1.14.0"
       }
     },
     {
@@ -204,8 +231,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "4e8f4b1c9adaa59315c523540c1ff2b38adc20a9",
-        "version" : "2.87.0"
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
       }
     },
     {
@@ -222,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "5e9e99ec96c53bc2c18ddd10c1e25a3cd97c55e5",
-        "version" : "1.38.0"
+        "revision" : "45bdf670248be5f16ec0340e125dca285536f0fb",
+        "version" : "1.45.0"
       }
     },
     {
@@ -231,8 +258,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "d3bad3847c53015fe8ec1e6c3ab54e53a5b6f15f",
-        "version" : "2.35.0"
+        "revision" : "d930168b86f46ca51a4bc09c5ca45c1833db8067",
+        "version" : "2.37.2"
       }
     },
     {
@@ -285,8 +312,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "395a77f0aa927f0ff73941d7ac35f2b46d47c9db",
-        "version" : "1.6.3"
+        "revision" : "704705c5c51156ede21172a38654d522ce487074",
+        "version" : "1.8.0"
       }
     },
     {
@@ -305,6 +332,15 @@
       "state" : {
         "revision" : "0a939dd2b955bf5a0aa5ea2073ee21200e1575a3",
         "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "zstd",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/facebook/zstd.git",
+      "state" : {
+        "revision" : "f8745da6ff1ad1e7bab384bd1f9d742439278e99",
+        "version" : "1.5.7"
       }
     }
   ],

--- a/Sources/ContainerBridge/ContainerManager.swift
+++ b/Sources/ContainerBridge/ContainerManager.swift
@@ -3628,6 +3628,14 @@ public actor ContainerManager {
 
     // MARK: - Volume/Mount Helpers
 
+    /// Where Containerization mounts virtiofs shares inside the VM, one subdirectory per tag.
+    ///
+    /// `LinuxContainer.create()` mounts this before any container mount is applied, and its own
+    /// virtiofs-to-bind transform in `start()` sources from the same path. Bind mounts that read
+    /// from a share must source from here rather than from the share's in-container destination,
+    /// which is only available after that share's own mount has been applied.
+    private static let guestVirtiofsRoot = "/run/virtiofs"
+
     /// The guest-side virtiofs tag Containerization will assign to a share of `source`.
     ///
     /// Arca derives guest paths (/mnt/arca-volumes/<tag>, /mnt/arca-file-mounts/<tag>) from
@@ -3790,12 +3798,15 @@ public actor ContainerManager {
                         ])
                     }
 
-                    // 2. Create bind mount from VirtioFS data/ subdirectory to container path
-                    // vmexec prefixes mount DESTINATIONS with rootfs path, but NOT sources
-                    // So VirtioFS gets mounted at: /run/container/{id}/rootfs/mnt/arca-volumes/{hash}/
-                    // We need the bind mount source to point there (with rootfs prefix)
-                    let containerRootfs = "/run/container/\(dockerID)/rootfs"
-                    let bindSource = "\(containerRootfs)\(guestVolumeMount)/data"
+                    // 2. Create bind mount from the VirtioFS data/ subdirectory to the container path.
+                    // Source from /run/virtiofs/{tag}, which LinuxContainer.create() mounts in the VM
+                    // before any container mount is applied, rather than from the share's own
+                    // in-container destination. Upstream sorts spec.mounts by destination depth
+                    // (sortMountsByDestinationDepth), so a container path shallower than
+                    // /mnt/arca-volumes/{hash} would otherwise be mounted before the share it reads
+                    // from and fail with ENOENT. Sourcing from /run/virtiofs removes the ordering
+                    // dependency instead of trying to satisfy it.
+                    let bindSource = "\(Self.guestVirtiofsRoot)/\(volumeRootHash)/data"
 
                     var bindOptions = ["bind"]
                     if isReadOnly {
@@ -3896,12 +3907,9 @@ public actor ContainerManager {
                         ])
                     }
 
-                    // 2. Create bind mount from VirtioFS location to container path
-                    // vmexec prefixes mount DESTINATIONS with rootfs path, but NOT sources
-                    // So VirtioFS gets mounted at: /run/container/{id}/rootfs/mnt/arca-file-mounts/{hash}/
-                    // We need the bind mount source to point there (with rootfs prefix)
-                    let containerRootfs = "/run/container/\(dockerID)/rootfs"
-                    let bindSource = "\(containerRootfs)\(guestParentMount)/\(filename)"
+                    // 2. Create bind mount from the VirtioFS location to the container path.
+                    // Sourced from /run/virtiofs/{tag} for the same reason as the volume case above.
+                    let bindSource = "\(Self.guestVirtiofsRoot)/\(parentDirHash)/\(filename)"
 
                     // For file bind mounts, we need to signal to vminitd that the target
                     // should be created as an empty file, not a directory

--- a/Sources/ContainerBridge/ContainerManager.swift
+++ b/Sources/ContainerBridge/ContainerManager.swift
@@ -2,6 +2,7 @@ import Foundation
 import Logging
 import Containerization
 import ContainerizationOCI
+import ContainerizationOS
 import ContainerizationEXT4
 import SystemPackage
 import Virtualization
@@ -239,7 +240,7 @@ public actor ContainerManager {
         nativeManager = try await Containerization.ContainerManager(
             kernel: kernel,
             initfsReference: "arca-vminit:latest",  // Custom vminit loaded and tagged by ArcaDaemon
-            network: try Containerization.ContainerManager.VmnetNetwork()
+            network: try Containerization.VmnetNetwork()
         )
 
         // Initialize OverlayFS unpacker for parallel layer caching
@@ -791,16 +792,16 @@ public actor ContainerManager {
         // host network containers use Apple's vmnet framework and don't have networkAttachments
         if info.hostConfig.networkMode == "host", let nativeContainer = nativeContainers[dockerID] {
             // Get all vmnet interfaces from native container
-            // Try to cast each interface to ContainerManager.VmnetNetwork.Interface
+            // Try to cast each interface to VmnetNetwork.Interface
             var vmnetIndex = 0
             for iface in nativeContainer.interfaces {
-                if let vmnetInterface = iface as? Containerization.ContainerManager.VmnetNetwork.Interface {
-                    // Parse address string "192.168.81.2/24" into IP and prefix
-                    let addressComponents = vmnetInterface.address.split(separator: "/")
-                    let ipString = String(addressComponents[0])  // "192.168.81.2"
-                    let prefixLen = addressComponents.count > 1 ? Int(addressComponents[1]) ?? 24 : 24
+                if let vmnetInterface = iface as? Containerization.VmnetNetwork.Interface {
+                    // Interface.ipv4Address is a CIDRv4 ("192.168.81.2/24"); take its
+                    // components directly rather than re-parsing a formatted string.
+                    let ipString = vmnetInterface.ipv4Address.address.description  // "192.168.81.2"
+                    let prefixLen = Int(vmnetInterface.ipv4Address.prefix.length)
 
-                    let gatewayString = vmnetInterface.gateway
+                    let gatewayString = vmnetInterface.ipv4Gateway?.description
 
                     // Use "host" for the first interface, "host1", "host2" for additional ones
                     let networkName = vmnetIndex == 0 ? "host" : "host\(vmnetIndex)"
@@ -909,42 +910,30 @@ public actor ContainerManager {
     /// Docker semantics:
     /// - privileged=true: Grant ALL capabilities (CAP_CHOWN, CAP_NET_ADMIN, etc.)
     /// - Otherwise: Start with Docker's default caps, then apply cap-add/cap-drop
+    /// - Note: `CapabilityName(rawValue:)` rejects names Linux does not define, so an
+    ///   unrecognised `--cap-add`/`--cap-drop` value now fails container creation instead
+    ///   of being passed through to the OCI spec verbatim.
     private func buildLinuxCapabilities(
         privileged: Bool,
         capAdd: [String]?,
         capDrop: [String]?
-    ) -> ContainerizationOCI.LinuxCapabilities {
-        // Full list of all Linux capabilities (as of Linux 5.x)
-        let allCapabilities = [
-            "CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_DAC_READ_SEARCH", "CAP_FOWNER",
-            "CAP_FSETID", "CAP_KILL", "CAP_SETGID", "CAP_SETUID", "CAP_SETPCAP",
-            "CAP_LINUX_IMMUTABLE", "CAP_NET_BIND_SERVICE", "CAP_NET_BROADCAST",
-            "CAP_NET_ADMIN", "CAP_NET_RAW", "CAP_IPC_LOCK", "CAP_IPC_OWNER",
-            "CAP_SYS_MODULE", "CAP_SYS_RAWIO", "CAP_SYS_CHROOT", "CAP_SYS_PTRACE",
-            "CAP_SYS_PACCT", "CAP_SYS_ADMIN", "CAP_SYS_BOOT", "CAP_SYS_NICE",
-            "CAP_SYS_RESOURCE", "CAP_SYS_TIME", "CAP_SYS_TTY_CONFIG", "CAP_MKNOD",
-            "CAP_LEASE", "CAP_AUDIT_WRITE", "CAP_AUDIT_CONTROL", "CAP_SETFCAP",
-            "CAP_MAC_OVERRIDE", "CAP_MAC_ADMIN", "CAP_SYSLOG", "CAP_WAKE_ALARM",
-            "CAP_BLOCK_SUSPEND", "CAP_AUDIT_READ", "CAP_PERFMON", "CAP_BPF",
-            "CAP_CHECKPOINT_RESTORE"
-        ]
-
+    ) throws -> Containerization.LinuxCapabilities {
         // Docker's default capabilities (matches Docker 20.10+)
         // These are the capabilities granted to non-privileged containers
-        let dockerDefaultCapabilities = [
-            "CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FSETID", "CAP_FOWNER",
-            "CAP_MKNOD", "CAP_NET_RAW", "CAP_SETGID", "CAP_SETUID",
-            "CAP_SETFCAP", "CAP_SETPCAP", "CAP_NET_BIND_SERVICE",
-            "CAP_SYS_CHROOT", "CAP_KILL", "CAP_AUDIT_WRITE"
+        let dockerDefaultCapabilities: [CapabilityName] = [
+            .chown, .dacOverride, .fsetid, .fowner,
+            .mknod, .netRaw, .setgid, .setuid,
+            .setfcap, .setpcap, .netBindService,
+            .sysChroot, .kill, .auditWrite
         ]
 
-        var caps: [String]
+        var caps: [CapabilityName]
 
         if privileged {
             // Privileged mode: Grant ALL capabilities
-            caps = allCapabilities
+            caps = CapabilityName.allCases
             logger.debug("Privileged mode enabled - granting all capabilities", metadata: [
-                "capability_count": "\(allCapabilities.count)"
+                "capability_count": "\(caps.count)"
             ])
         } else {
             // Normal mode: Start with Docker default capabilities
@@ -954,9 +943,10 @@ public actor ContainerManager {
         // Apply cap-add (add capabilities)
         if let add = capAdd, !add.isEmpty {
             for cap in add {
-                let normalizedCap = cap.hasPrefix("CAP_") ? cap : "CAP_\(cap.uppercased())"
-                if !caps.contains(normalizedCap) {
-                    caps.append(normalizedCap)
+                // CapabilityName normalizes case and the "CAP_" prefix itself.
+                let parsed = try CapabilityName(rawValue: cap)
+                if !caps.contains(parsed) {
+                    caps.append(parsed)
                 }
             }
             logger.debug("Added capabilities", metadata: [
@@ -967,8 +957,8 @@ public actor ContainerManager {
         // Apply cap-drop (remove capabilities)
         if let drop = capDrop, !drop.isEmpty {
             for cap in drop {
-                let normalizedCap = cap.hasPrefix("CAP_") ? cap : "CAP_\(cap.uppercased())"
-                caps.removeAll { $0 == normalizedCap }
+                let parsed = try CapabilityName(rawValue: cap)
+                caps.removeAll { $0 == parsed }
             }
             logger.debug("Dropped capabilities", metadata: [
                 "dropped": "\(drop.joined(separator: ", "))"
@@ -977,7 +967,7 @@ public actor ContainerManager {
 
         // LinuxCapabilities has 5 sets: bounding, effective, inheritable, permitted, ambient
         // Docker's behavior: Set the same capabilities in all sets for simplicity
-        return ContainerizationOCI.LinuxCapabilities(
+        return Containerization.LinuxCapabilities(
             bounding: caps,
             effective: caps,
             inheritable: caps,
@@ -1068,7 +1058,7 @@ public actor ContainerManager {
         let imageWorkingDir = imageConfig.config?.workingDir ?? "/"
 
         // Build capabilities before closure for @Sendable capture
-        let capabilities = buildLinuxCapabilities(
+        let capabilities = try buildLinuxCapabilities(
             privileged: config.privileged,
             capAdd: config.capAdd,
             capDrop: config.capDrop
@@ -2771,7 +2761,8 @@ public actor ContainerManager {
         ])
 
         // Send signal to container using Containerization API
-        try await nativeContainer.kill(signalNumber)
+        // `kill` takes a `Signal` rather than a bare Int32 as of upstream 0.40.
+        try await nativeContainer.kill(Containerization.Signal(rawValue: signalNumber))
 
         logger.info("Signal sent to container successfully", metadata: [
             "id": "\(dockerID)",
@@ -2879,8 +2870,8 @@ public actor ContainerManager {
 
         logger.debug("Container statistics retrieved", metadata: [
             "id": "\(dockerID)",
-            "memory_usage": "\(stats.memory.usageBytes)",
-            "cpu_usage": "\(stats.cpu.usageUsec)"
+            "memory_usage": "\(stats.memory?.usageBytes.description ?? "unavailable")",
+            "cpu_usage": "\(stats.cpu?.usageUsec.description ?? "unavailable")"
         ])
 
         return stats
@@ -3637,6 +3628,17 @@ public actor ContainerManager {
 
     // MARK: - Volume/Mount Helpers
 
+    /// The guest-side virtiofs tag Containerization will assign to a share of `source`.
+    ///
+    /// Arca derives guest paths (/mnt/arca-volumes/<tag>, /mnt/arca-file-mounts/<tag>) from
+    /// this value, so it must match the tag `AttachedFilesystem` computes for the same share.
+    /// Upstream replaced the free function `hashMountSource(source:)` with `Mount.tagHash` and
+    /// made it resolve symlinks before hashing; delegating keeps the two in step rather than
+    /// re-deriving the hash here.
+    private static func virtiofsTag(forSource source: String) throws -> String {
+        try Containerization.Mount.share(source: source, destination: "/").tagHash
+    }
+
     /// Parse Docker volume mount strings into Containerization.Mount objects
     /// Supports both bind mounts and named volumes:
     /// - Bind mounts: "/host/path:/container/path[:ro]" or "relative/path:/container/path[:ro]"
@@ -3770,7 +3772,7 @@ public actor ContainerManager {
                     let volumeRoot = (volumeMetadata.mountpoint as NSString).deletingLastPathComponent
 
                     // Create unique mount point for volume root using deterministic hash
-                    let volumeRootHash = try hashMountSource(source: volumeRoot)
+                    let volumeRootHash = try Self.virtiofsTag(forSource: volumeRoot)
                     let guestVolumeMount = "/mnt/arca-volumes/\(volumeRootHash)"
 
                     // 1. Track VirtioFS mount for volume root (deduplicated)
@@ -3873,9 +3875,9 @@ public actor ContainerManager {
                     let filename = (expandedHostPath as NSString).lastPathComponent
 
                     // Create unique mount point for parent directory using deterministic hash
-                    // Must use hashMountSource() which is the same hash used for VirtioFS tags
+                    // Must use the same hash used for VirtioFS tags
                     // This ensures consistency between the VirtioFS mount and bind mount paths
-                    let parentDirHash = try hashMountSource(source: parentDir)
+                    let parentDirHash = try Self.virtiofsTag(forSource: parentDir)
                     let guestParentMount = "/mnt/arca-file-mounts/\(parentDirHash)"
 
                     // 1. Track VirtioFS mount for parent directory (deduplicated)

--- a/Sources/ContainerBridge/SharedVmnetNetwork.swift
+++ b/Sources/ContainerBridge/SharedVmnetNetwork.swift
@@ -10,14 +10,14 @@ import Containerization
 /// This class wrapper ensures all code (helper VM, all containers) shares the
 /// same VmnetNetwork instance with synchronized access to the allocator.
 public final class SharedVmnetNetwork: @unchecked Sendable {
-    private var network: Containerization.ContainerManager.VmnetNetwork
+    private var network: Containerization.VmnetNetwork
     private let lock = NSLock()
 
     /// Initialize with auto-allocated subnet from Apple's vmnet framework
     /// Apple's vmnet framework auto-allocates subnets and ignores custom subnet requests.
     /// The actual subnet can be queried via the `subnet` property after initialization.
     public init() throws {
-        self.network = try Containerization.ContainerManager.VmnetNetwork()
+        self.network = try Containerization.VmnetNetwork()
     }
 
     /// Create a new network interface for the given container ID
@@ -25,7 +25,7 @@ public final class SharedVmnetNetwork: @unchecked Sendable {
     public func createInterface(_ id: String) throws -> (any Containerization.Interface)? {
         lock.lock()
         defer { lock.unlock() }
-        return try network.create(id)
+        return try network.createInterface(id)
     }
 
     /// Release a network interface for the given container ID
@@ -33,7 +33,7 @@ public final class SharedVmnetNetwork: @unchecked Sendable {
     public func releaseInterface(_ id: String) throws {
         lock.lock()
         defer { lock.unlock() }
-        try network.release(id)
+        try network.releaseInterface(id)
     }
 
     /// The IPv4 subnet of this network
@@ -43,6 +43,6 @@ public final class SharedVmnetNetwork: @unchecked Sendable {
 
     /// The gateway address of this network
     public var gateway: String {
-        network.gateway.description
+        network.ipv4Gateway.description
     }
 }

--- a/Sources/ContainerBridge/TCPProxy.swift
+++ b/Sources/ContainerBridge/TCPProxy.swift
@@ -185,18 +185,25 @@ private final class TCPProxyHandler: ChannelInboundHandler {
             case .failure(let error):
                 // Dump nftables state on connection failure (for debugging)
                 if let dumpFn = self.onConnectionFailed {
+                    // Bind the Sendable values the Task needs. The handler itself is a
+                    // ChannelInboundHandler bound to this event loop and is not Sendable,
+                    // so capturing self here would let it escape into the concurrent context.
+                    let logger = self.logger
+                    let targetAddress = self.targetAddress
+                    let targetPort = self.targetPort
+                    let errorDescription = "\(error)"
                     Task {
                         if let ruleset = await dumpFn() {
-                            self.logger.error("TCP proxy: Failed to connect to target",
-                                            metadata: ["error": "\(error)",
-                                                      "targetAddress": "\(self.targetAddress)",
-                                                      "targetPort": "\(self.targetPort)",
+                            logger.error("TCP proxy: Failed to connect to target",
+                                            metadata: ["error": "\(errorDescription)",
+                                                      "targetAddress": "\(targetAddress)",
+                                                      "targetPort": "\(targetPort)",
                                                       "nftables": "\n\(ruleset)"])
                         } else {
-                            self.logger.warning("TCP proxy: Failed to connect to target",
-                                              metadata: ["error": "\(error)",
-                                                        "targetAddress": "\(self.targetAddress)",
-                                                        "targetPort": "\(self.targetPort)"])
+                            logger.warning("TCP proxy: Failed to connect to target",
+                                              metadata: ["error": "\(errorDescription)",
+                                                        "targetAddress": "\(targetAddress)",
+                                                        "targetPort": "\(targetPort)"])
                         }
                     }
                 } else {

--- a/Sources/ContainerBridge/UDPProxy.swift
+++ b/Sources/ContainerBridge/UDPProxy.swift
@@ -123,6 +123,52 @@ actor UDPProxy {
         return clientMappings[clientAddress]?.outboundChannel
     }
 
+    /// Returns the outbound channel for a client, creating and tracking one if absent.
+    ///
+    /// Channel creation lives on the actor rather than in the calling handler's `Task`
+    /// deliberately. Building the `DatagramBootstrap` involves an escaping
+    /// `channelInitializer` that constructs a non-Sendable `UDPProxyBackendHandler`, and
+    /// awaiting `bind()` on that bootstrap from inside a freshly-created task region makes
+    /// Swift 6.3 fail with "pattern that the region-based isolation checker does not
+    /// understand how to check. Please file a bug". Performing it under actor isolation
+    /// keeps it out of the caller's task region. Awaiting an actor method that returns a
+    /// `Channel` is checkable; doing the bind in the task region is not.
+    ///
+    /// Making this atomic on the actor also closes a check-then-act window in the previous
+    /// arrangement, where two datagrams from the same client could each create a channel
+    /// and the second would overwrite the first's mapping, orphaning it.
+    func outboundChannel(
+        for clientAddress: SocketAddress,
+        eventLoop: EventLoop,
+        inboundChannel: Channel
+    ) async throws -> Channel {
+        if let existing = getOutboundChannel(for: clientAddress) {
+            return existing
+        }
+
+        // Bind the logger so the escaping initializer does not capture the actor.
+        let logger = self.logger
+        let bootstrap = DatagramBootstrap(group: eventLoop)
+            .channelInitializer { channel in
+                channel.pipeline.addHandler(
+                    UDPProxyBackendHandler(
+                        inboundChannel: inboundChannel,
+                        clientAddress: clientAddress,
+                        logger: logger
+                    )
+                )
+            }
+
+        let channel = try await bootstrap.bind(host: "0.0.0.0", port: 0).get()
+        trackClient(clientAddress, outboundChannel: channel)
+
+        logger.debug("UDP proxy: Created outbound channel",
+                    metadata: ["clientAddress": "\(clientAddress.description)",
+                              "localPort": "\(channel.localAddress?.port ?? 0)"])
+
+        return channel
+    }
+
     /// Start periodic cleanup task for idle mappings
     private func startCleanupTask() {
         cleanupTask = Task {
@@ -203,37 +249,36 @@ private final class UDPProxyHandler: ChannelInboundHandler {
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let envelope = self.unwrapInboundIn(data)
         let clientAddress = envelope.remoteAddress
-        var buffer = envelope.data
+        let buffer = envelope.data
 
         guard let targetAddr = targetSocketAddress else {
             logger.warning("UDP proxy: Target address not resolved, dropping datagram")
             return
         }
 
-        // Use NIO's event loop instead of Task for better concurrency handling
-        context.eventLoop.execute {
-            Task { [weak self, clientAddress, targetAddr, buffer] in
-                // Track client for reply routing
-                guard let self = self, let proxy = self.proxy else { return }
+        guard let proxy = self.proxy else { return }
 
-                // Check if we already have an outbound channel for this client
-                let outboundChannel: Channel
-                if let existing = await proxy.getOutboundChannel(for: clientAddress) {
-                    outboundChannel = existing
-                } else {
-                    // Create new outbound channel for this client
-                    do {
-                        outboundChannel = try await self.createOutboundChannel(context: context, clientAddress: clientAddress)
-                        await proxy.trackClient(clientAddress, outboundChannel: outboundChannel)
-                    } catch {
-                        self.logger.error("Failed to create outbound channel", metadata: ["error": "\(error)"])
-                        return
-                    }
-                }
+        // channelRead already runs on the channel's event loop, so reading the handler's
+        // state here is safe. Bind the Sendable values the Task needs: neither the handler
+        // nor the ChannelHandlerContext is Sendable, and the context in particular is only
+        // valid on this event loop, so neither may be captured by the Task.
+        let eventLoop = context.eventLoop
+        let inboundChannel = context.channel
+        let logger = self.logger
+
+        Task {
+            do {
+                let outbound = try await proxy.outboundChannel(
+                    for: clientAddress,
+                    eventLoop: eventLoop,
+                    inboundChannel: inboundChannel
+                )
 
                 // Forward datagram to target
                 let outboundEnvelope = AddressedEnvelope(remoteAddress: targetAddr, data: buffer)
-                outboundChannel.writeAndFlush(self.wrapOutboundOut(outboundEnvelope), promise: nil)
+                outbound.writeAndFlush(NIOAny(outboundEnvelope), promise: nil)
+            } catch {
+                logger.error("Failed to create outbound channel", metadata: ["error": "\(error)"])
             }
         }
     }
@@ -243,26 +288,6 @@ private final class UDPProxyHandler: ChannelInboundHandler {
                     metadata: ["error": "\(error)"])
     }
 
-    private func createOutboundChannel(context: ChannelHandlerContext, clientAddress: SocketAddress) async throws -> Channel {
-        let bootstrap = DatagramBootstrap(group: context.eventLoop)
-            .channelInitializer { channel in
-                channel.pipeline.addHandler(
-                    UDPProxyBackendHandler(
-                        inboundChannel: context.channel,
-                        clientAddress: clientAddress,
-                        logger: self.logger
-                    )
-                )
-            }
-
-        let channel = try await bootstrap.bind(host: "0.0.0.0", port: 0).get()
-
-        logger.debug("UDP proxy: Created outbound channel",
-                    metadata: ["clientAddress": "\(clientAddress.description)",
-                              "localPort": "\(channel.localAddress?.port ?? 0)"])
-
-        return channel
-    }
 }
 
 // MARK: - UDP Proxy Backend Handler

--- a/Sources/ContainerBridge/VmnetNetworkBackend.swift
+++ b/Sources/ContainerBridge/VmnetNetworkBackend.swift
@@ -146,7 +146,7 @@ public actor VmnetNetworkBackend {
         logger.info("Allocated vmnet interface for container", metadata: [
             "container_id": "\(containerID)",
             "network_id": "\(networkID)",
-            "ip": "\(interface.address)"
+            "ip": "\(interface.ipv4Address)"
         ])
 
         // Update metadata

--- a/Sources/DockerAPI/Handlers/ContainerHandlers.swift
+++ b/Sources/DockerAPI/Handlers/ContainerHandlers.swift
@@ -570,7 +570,7 @@ public struct ContainerHandlers: Sendable {
 
             // Transform to Docker format
             let now = ISO8601DateFormatter().string(from: Date())
-            let dockerStats = transformToDockerStats(
+            let dockerStats = try transformToDockerStats(
                 stats: stats,
                 containerID: containerInfo.id,
                 containerName: containerInfo.name,
@@ -605,60 +605,49 @@ public struct ContainerHandlers: Sendable {
     }
 
     /// Transform Apple ContainerStatistics to Docker stats format
+    ///
+    /// Every `ContainerStatistics` category became optional upstream: a category is nil
+    /// when the guest did not report it. Docker's `/stats` payload has no representation
+    /// for "unknown" in the cpu/memory/pids objects, so a missing one is surfaced as an
+    /// error rather than reported as zero. The blkio and network collections already model
+    /// absence (they are omitted when empty), so nil there is just the empty case.
     private func transformToDockerStats(
         stats: Containerization.ContainerStatistics,
         containerID: String,
         containerName: String,
         timestamp: String
-    ) -> ContainerStatsResponse {
-        // Convert microseconds to nanoseconds for Docker compatibility
-        let cpuUsageNano = stats.cpu.usageUsec * 1000
-        let userUsageNano = stats.cpu.userUsec * 1000
-        let systemUsageNano = stats.cpu.systemUsec * 1000
-        let throttledTimeNano = stats.cpu.throttledTimeUsec * 1000
+    ) throws -> ContainerStatsResponse {
+        let cpuStats = try buildCPUStats(from: stats)
 
-        // Build CPU stats
-        let cpuUsage = CPUUsage(
-            totalUsage: cpuUsageNano,
-            usageInKernelmode: systemUsageNano,
-            usageInUsermode: userUsageNano
-        )
-
-        let throttlingData = ThrottlingData(
-            periods: stats.cpu.throttlingPeriods,
-            throttledPeriods: stats.cpu.throttledPeriods,
-            throttledTime: throttledTimeNano
-        )
-
-        let cpuStats = CPUStats(
-            cpuUsage: cpuUsage,
-            systemCpuUsage: cpuUsageNano,  // Approximate
-            onlineCpus: ProcessInfo.processInfo.processorCount,
-            throttlingData: throttlingData
-        )
+        guard let memory = stats.memory else {
+            throw ContainerError.statsFailed("container \(containerID) reported no memory statistics")
+        }
+        guard let process = stats.process else {
+            throw ContainerError.statsFailed("container \(containerID) reported no process statistics")
+        }
 
         // Build memory stats
         let memoryStatsDetails = MemoryStatsDetails(
-            cache: stats.memory.cacheBytes,
-            pgfault: stats.memory.pageFaults,
-            pgmajfault: stats.memory.majorPageFaults
+            cache: memory.cacheBytes,
+            pgfault: memory.pageFaults,
+            pgmajfault: memory.majorPageFaults
         )
 
         let memoryStats = MemoryStats(
-            usage: stats.memory.usageBytes,
-            limit: stats.memory.limitBytes,
+            usage: memory.usageBytes,
+            limit: memory.limitBytes,
             stats: memoryStatsDetails
         )
 
         // Build PID stats
         let pidsStats = PidsStats(
-            current: stats.process.current,
-            limit: stats.process.limit
+            current: process.current,
+            limit: process.limit
         )
 
         // Build block I/O stats
         var blkioEntries: [BlkioStatEntry] = []
-        for device in stats.blockIO.devices {
+        for device in stats.blockIO?.devices ?? [] {
             blkioEntries.append(BlkioStatEntry(
                 major: device.major,
                 minor: device.minor,
@@ -679,7 +668,7 @@ public struct ContainerHandlers: Sendable {
 
         // Build network stats
         var networks: [String: NetworkStats] = [:]
-        for netStat in stats.networks {
+        for netStat in stats.networks ?? [] {
             networks[netStat.interface] = NetworkStats(
                 rxBytes: netStat.receivedBytes,
                 rxPackets: netStat.receivedPackets,
@@ -766,7 +755,7 @@ public struct ContainerHandlers: Sendable {
                         let currentTimestamp = ISO8601DateFormatter().string(from: Date())
 
                         // Build stats response with previous values for deltas
-                        var statsResponse = self.transformToDockerStats(
+                        var statsResponse = try self.transformToDockerStats(
                             stats: currentStats,
                             containerID: containerInfo.id,
                             containerName: containerInfo.name,
@@ -775,6 +764,9 @@ public struct ContainerHandlers: Sendable {
 
                         // Update preread and precpu stats if we have previous values
                         if let prevTimestamp = previousTimestamp {
+                            let precpuStats = try previousStats.map { prevStats in
+                                try self.buildCPUStats(from: prevStats)
+                            }
                             statsResponse = ContainerStatsResponse(
                                 id: statsResponse.id,
                                 name: statsResponse.name,
@@ -782,9 +774,7 @@ public struct ContainerHandlers: Sendable {
                                 preread: prevTimestamp,
                                 pidsStats: statsResponse.pidsStats,
                                 cpuStats: statsResponse.cpuStats,
-                                precpuStats: previousStats.map { prevStats in
-                                    self.buildCPUStats(from: prevStats)
-                                } ?? statsResponse.cpuStats,
+                                precpuStats: precpuStats ?? statsResponse.cpuStats,
                                 memoryStats: statsResponse.memoryStats,
                                 blkioStats: statsResponse.blkioStats,
                                 networks: statsResponse.networks
@@ -835,12 +825,17 @@ public struct ContainerHandlers: Sendable {
         }
     }
 
-    /// Helper to build CPUStats from ContainerStatistics (for precpu stats)
-    private func buildCPUStats(from stats: Containerization.ContainerStatistics) -> CPUStats {
-        let cpuUsageNano = stats.cpu.usageUsec * 1000
-        let userUsageNano = stats.cpu.userUsec * 1000
-        let systemUsageNano = stats.cpu.systemUsec * 1000
-        let throttledTimeNano = stats.cpu.throttledTimeUsec * 1000
+    /// Helper to build CPUStats from ContainerStatistics (used for both cpu and precpu stats)
+    private func buildCPUStats(from stats: Containerization.ContainerStatistics) throws -> CPUStats {
+        guard let cpu = stats.cpu else {
+            throw ContainerError.statsFailed("container \(stats.id) reported no CPU statistics")
+        }
+
+        // Convert microseconds to nanoseconds for Docker compatibility
+        let cpuUsageNano = cpu.usageUsec * 1000
+        let userUsageNano = cpu.userUsec * 1000
+        let systemUsageNano = cpu.systemUsec * 1000
+        let throttledTimeNano = cpu.throttledTimeUsec * 1000
 
         let cpuUsage = CPUUsage(
             totalUsage: cpuUsageNano,
@@ -849,14 +844,14 @@ public struct ContainerHandlers: Sendable {
         )
 
         let throttlingData = ThrottlingData(
-            periods: stats.cpu.throttlingPeriods,
-            throttledPeriods: stats.cpu.throttledPeriods,
+            periods: cpu.throttlingPeriods,
+            throttledPeriods: cpu.throttledPeriods,
             throttledTime: throttledTimeNano
         )
 
         return CPUStats(
             cpuUsage: cpuUsage,
-            systemCpuUsage: cpuUsageNano,
+            systemCpuUsage: cpuUsageNano,  // Approximate
             onlineCpus: ProcessInfo.processInfo.processorCount,
             throttlingData: throttlingData
         )

--- a/scripts/build-vminit.sh
+++ b/scripts/build-vminit.sh
@@ -123,23 +123,35 @@ VMINIT_DIR="$HOME/.arca/vminit"
 rm -rf "$VMINIT_DIR"
 mkdir -p "$VMINIT_DIR"
 
-# Create rootfs tarball with cctl, adding our custom binaries
-ROOTFS_TAR="$VMINIT_DIR/vminit-rootfs.tar"
+# Create the OCI image from the rootfs tar produced by `make init`.
+#
+# The 2026-08 upstream merge changed this flow. `cctl rootfs create` no longer assembles a
+# rootfs from --vminitd/--vmexec/--add-file; it now consumes a prebuilt gzip tar, which
+# containerization/scripts/build-initfs.sh writes to bin/init.rootfs.tar.gz along with the
+# ext4 initfs. arca-services is staged into both by the --add-file flag that the fork adds
+# to that script, wired in via the Makefile's INITFS_BUILD_CMD.
 OCI_DIR="$VMINIT_DIR/oci"
+ROOTFS_TAR="$VMINITD_DIR/bin/init.rootfs.tar.gz"
 
-echo "  Using cctl to create rootfs with Swift runtime..."
+if [ ! -f "$ROOTFS_TAR" ]; then
+    echo "ERROR: rootfs tar not found at $ROOTFS_TAR"
+    echo "Expected 'make init' to have produced it."
+    exit 1
+fi
+
+# Confirm arca-services actually made it into the rootfs, rather than trusting the flag.
+if ! tar -tzf "$ROOTFS_TAR" | grep -q '^\./sbin/arca-services$'; then
+    echo "ERROR: arca-services missing from $ROOTFS_TAR"
+    echo "Check the --add-file wiring in containerization/Makefile (INITFS_BUILD_CMD)."
+    exit 1
+fi
+echo "  ✓ arca-services present in rootfs tar"
+
+echo "  Creating arca-vminit:latest image from rootfs tar..."
 "$CCTL_BINARY" rootfs create \
-    --vminitd "$VMINITD_BINARY" \
-    --vmexec "$VMEXEC_BINARY" \
-    --add-file "$VMINITD_DIR/vminitd/extensions/arca-services/arca-services:/sbin/arca-services" \
     --image arca-vminit:latest \
     --label org.opencontainers.image.source=https://github.com/Vas-Solutus/arca \
     "$ROOTFS_TAR"
-
-if [ ! -f "$ROOTFS_TAR" ]; then
-    echo "ERROR: cctl failed to create rootfs tarball"
-    exit 1
-fi
 
 echo "  ✓ Rootfs tarball created: $(du -h "$ROOTFS_TAR" | awk '{print $1}')"
 


### PR DESCRIPTION
Brings Arca onto the reconciled containerization fork and makes it build and run
again. Fast-forwards `main` from `98c86a0`.

Depends on Vas-Solutus/arca-containerization#1 — this PR pins `f02cdf9`, which
that PR puts on the fork's `main`. The gitlink is by SHA, so the pin stays valid
either way, but landing the fork first keeps the pin reachable from a branch.

### Commits

| | |
|---|---|
| `0910463` | Build under Swift 6.3 strict concurrency |
| `4e27394` | Point at the merged fork; adapt vminit packaging |
| `4591a21` | Update `Package.resolved` |
| `b8903f7` | Adapt to upstream API drift (0.35.0 → 0.40.2) |
| `9c2db5a` | Source volume and file-bind mounts from `/run/virtiofs` |

### Why the build was broken before this

`swift build` failed under Swift 6.3.3 on two strict-concurrency errors in
`ContainerBridge/{TCPProxy,UDPProxy}.swift`. Verified pre-existing: it reproduced
identically at both the old pin `f48a6c7` and `5754902`, and neither file imports
anything from the submodule. This broke the **release** path, not just
development — `publish` → `notarize` → `dist-dmg` → `release` → `all` →
`codesign` → `swift build`. The last release (v0.2.4-alpha, 2025-12-02) predates
the old pin, consistent with the build having broken at a later toolchain upgrade.

Fixed in `0910463` with no `@unchecked Sendable`, `nonisolated(unsafe)`,
`@preconcurrency`, or `Package.swift` concurrency change.

### Upstream API drift (`b8903f7`)

After `swift package clean`, 107 error lines across 11 unique sites:

- `VmnetNetwork` un-nested from `ContainerManager`; `create`/`release` →
  `createInterface`/`releaseInterface`; `.gateway` → `.ipv4Gateway`.
- `Interface.address: String` → `ipv4Address: CIDRv4`, `gateway: String?` →
  `ipv4Gateway: IPv4Address?`. String-splitting with a `?? 24` fallback replaced
  by the typed components; the fallback was unreachable.
- `process.capabilities` non-optional `Containerization.LinuxCapabilities` over
  `[CapabilityName]`. The deleted hardcoded 41-name list and
  `CapabilityName.allCases` were compared as sorted sets: identical. Upstream's
  new `defaultOCICapabilities` is exactly the 14 Docker defaults this code already
  used, so nothing was weakened. `buildLinuxCapabilities` is now throwing —
  an unrecognised `--cap-add` fails container creation rather than reaching the
  OCI spec verbatim.
- `kill` takes `Signal`, not `Int32`.
- `hashMountSource` replaced by upstream's `Mount.tagHash`, delegated to rather
  than reimplemented — the tag is load-bearing, since guest paths derive from it.
- `ContainerStatistics` categories became optional, which surfaced 21 further
  errors in `DockerAPI` once `ContainerBridge` compiled. A nil cpu/memory/pids
  category now errors rather than reporting a fabricated zero.

### Mount-ordering regression (`9c2db5a`)

`docker run -v <volume>:/data` failed with `errno 2`. Upstream's
`LinuxContainer.start()` now ends with `cleanAndSortMounts`, sorting by
destination path depth; at the merge base the same line preserved caller order
verbatim. Arca's bind read from the share's own in-container destination, so a
container path shallower than the share sorted ahead of it. Measured against one
volume: `/data` (depth 1) and `/opt/data` (depth 2) failed, `/a/b/c/d` (depth 4)
succeeded, with the share at depth 3.

Fixed by sourcing binds from `/run/virtiofs/<tag>`, which
`LinuxContainer.create()` mounts before any container mount is applied and which
upstream's own virtiofs-to-bind transform already uses.

### Verification

`swift build` exit 0 at `-c debug` (from `swift package clean`), `--build-tests`,
and `-c release`; 0 errors each. The 21 remaining warnings are all in files these
commits do not touch.

Functionally, against a daemon built from this branch:

- A container boots. `waitForServicesReady` gates start on vsock 51819, which
  opens only after the wireguard, filesystem and process services initialise.
- Networking: address, default route, DNS, and outbound HTTP all work.
- PTY allocation (`/dev/pts/0`), `docker exec`, `docker logs`.
- Volumes at depths 1, 2 and 4; content written in a container appears at
  `~/.arca/volumes/<name>/data/` on the host and is readable by a later container
  mounting the same volume at a different path.
- File binds 5/5 at `/f.conf` and at `/etc/app.conf`; `:ro` refuses the write and
  leaves the host file unchanged.
- Capabilities: default `CapEff` `00000000a80425fb` (Docker's canonical default),
  `--privileged` `000001ffffffffff` (all 41), `--cap-add SYS_ADMIN` flips exactly
  bit 21, `--cap-drop CHOWN` enforced, `--cap-add BOGUSCAP` fails with
  `invalid CapabilityName 'CAP_BOGUSCAP'`.
- `docker stats` populates every category, and streaming emitted 23 updates with
  no errors.

### Known defects, not addressed here

Both are Arca-internal Docker semantics untouched by the merge:

- `generateContainerName()` draws from 6 adjectives × 6 nouns with no uniqueness
  check and no retry, and nothing acts on `HostConfig.autoRemove`, so
  `docker run --rm` leaves the container behind. Names accumulate against a
  36-name pool until `docker run` fails with `Conflict. The container name '<x>'
  is already in use` — 2 of 6 identical runs failed with 17 distinct names present.
- `docker start` on a stopped container on a bridge network fails with
  `already connected to network bridge`, then upstream's `invalidState` on retry.
  `WireGuardNetworkBackend.cleanupStoppedContainer` is a deliberate no-op, so the
  attachment is meant to survive a stop and the start path's re-attach validation
  rejects it. The same sequence succeeds on `--network host`.

No CI exists in this repository, so this PR is a review gate only.
