### PR TITLE
fix: replace swift-ip with the internal ArcaIP type

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a1cde01c766eaf01b4e27537a079fc75a85d2a2121903530fa599ce75f65b0f4",
+  "originHash" : "4fecaade70bdb045659873fae138e820064d1349413fa6031d6c5aaa9884f022",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -119,15 +119,6 @@
       }
     },
     {
-      "identity" : "swift-bson",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tayloraswift/swift-bson",
-      "state" : {
-        "revision" : "0d7c9735b726f931a67da00b836e8fd383f43cb3",
-        "version" : "1.0.0"
-      }
-    },
-    {
       "identity" : "swift-certificates",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
@@ -164,24 +155,6 @@
       }
     },
     {
-      "identity" : "swift-grammar",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tayloraswift/swift-grammar",
-      "state" : {
-        "revision" : "0dac977b50bf677b2c3adabd7d5586a7b6e09b17",
-        "version" : "0.5.0"
-      }
-    },
-    {
-      "identity" : "swift-hash",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tayloraswift/swift-hash",
-      "state" : {
-        "revision" : "ea0b9fc3152ed5941dd82e4a01e65f99fe1a75d2",
-        "version" : "0.7.1"
-      }
-    },
-    {
       "identity" : "swift-http-structured-headers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-structured-headers.git",
@@ -197,24 +170,6 @@
       "state" : {
         "revision" : "a0a57e949a8903563aba4615869310c0ebf14c03",
         "version" : "1.4.0"
-      }
-    },
-    {
-      "identity" : "swift-ip",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tayloraswift/swift-ip.git",
-      "state" : {
-        "revision" : "ba4efb6457f69f5f483094aa1230e8e76cc4999c",
-        "version" : "0.3.3"
-      }
-    },
-    {
-      "identity" : "swift-json",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tayloraswift/swift-json",
-      "state" : {
-        "revision" : "a349369773603889a915c645cb7b0cf8de255181",
-        "version" : "1.2.0"
       }
     },
     {
@@ -323,15 +278,6 @@
       "state" : {
         "revision" : "b626d3002773b1a1304166643e7f118f724b2132",
         "version" : "1.0.4"
-      }
-    },
-    {
-      "identity" : "swift-unixtime",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tayloraswift/swift-unixtime",
-      "state" : {
-        "revision" : "0a939dd2b955bf5a0aa5ea2073ee21200e1575a3",
-        "version" : "0.2.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,6 @@ let package = Package(
         .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.23.0"),
         .package(url: "https://github.com/stephencelis/SQLite.swift.git", from: "0.15.4"),
         .package(url: "https://github.com/tsolomko/SWCompression.git", from: "4.8.0"),
-        .package(url: "https://github.com/tayloraswift/swift-ip.git", exact: "0.3.3"),
     ],
     targets: [
         // Main executable target
@@ -71,7 +70,7 @@ let package = Package(
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "GRPC", package: "grpc-swift"),
                 .product(name: "SQLite", package: "SQLite.swift"),
-                .product(name: "IP", package: "swift-ip"),
+                "ArcaIP",
             ]
         ),
 

--- a/Package.swift
+++ b/Package.swift
@@ -75,6 +75,17 @@ let package = Package(
             ]
         ),
 
+        // Internal IPv4/CIDR types. Zero dependencies by design: this target
+        // replaced swift-ip, whose transitive graph pinned commits that no
+        // longer exist upstream and made the tree impossible to build cold.
+        // Adding a dependency here would forfeit that property.
+        .target(name: "ArcaIP"),
+
+        .testTarget(
+            name: "ArcaIPTests",
+            dependencies: ["ArcaIP"]
+        ),
+
         // Tests
         .testTarget(
             name: "ArcaTests",

--- a/Sources/ArcaIP/IP.Block.swift
+++ b/Sources/ArcaIP/IP.Block.swift
@@ -1,0 +1,67 @@
+extension IP {
+    /// A CIDR block of IPv4 addresses.
+    ///
+    /// `swift-ip` made this generic over an `Address` protocol. Arca only ever
+    /// instantiated it at `IP.V4`, so the generic parameter is dropped here; a
+    /// protocol with a single conformer buys nothing. The `IP` namespace is the
+    /// extension point if IPv6 is ever needed.
+    public struct Block: Hashable, Sendable {
+        /// The network address, already masked to `bits`.
+        public let base: V4
+
+        /// The prefix length, in the range `0...32`.
+        public let bits: UInt8
+
+        /// Creates a block, masking `base` down to `bits`.
+        ///
+        /// - Precondition: `bits` is at most 32.
+        public init(base: V4, bits: UInt8) {
+            precondition(bits <= 32, "IPv4 prefix length out of range: \(bits)")
+            self.bits = bits
+            self.base = V4(value: base.value & Self.mask(ones: bits))
+        }
+
+        /// A mask whose logical high `bits` are 1 and whose remainder is 0.
+        static func mask(ones bits: UInt8) -> UInt32 {
+            bits == 0 ? 0 : ~UInt32.zero << (32 - UInt32(bits))
+        }
+    }
+}
+
+extension IP.Block {
+    /// The closed range of addresses the block covers.
+    ///
+    /// The upper bound is the block's **broadcast address**, reproducing
+    /// `swift-ip` 0.3.3 exactly. Arca's IP allocator treats this bound as
+    /// inclusive, which means it can allocate a subnet's broadcast address.
+    /// That defect predates this type, is tracked separately, and is
+    /// reproduced rather than fixed so the replacement stays
+    /// behaviour-identical to what it replaced.
+    public var range: ClosedRange<IP.V4> {
+        self.base ... IP.V4(value: self.base.value | ~Self.mask(ones: self.bits))
+    }
+
+    /// Returns whether `address` falls inside the block.
+    public func contains(_ address: IP.V4) -> Bool {
+        address.value & Self.mask(ones: self.bits) == self.base.value
+    }
+}
+
+extension IP.Block: CustomStringConvertible {
+    /// Formats the block in CIDR notation.
+    public var description: String { "\(self.base)/\(self.bits)" }
+}
+
+extension IP.Block: LosslessStringConvertible {
+    /// Parses a block in CIDR notation, masking the base address.
+    public init?(_ string: some StringProtocol) {
+        guard
+            let slash = string.lastIndex(of: "/"),
+            let base = IP.V4(string[..<slash]),
+            let bits = UInt8(string[string.index(after: slash)...]),
+            bits <= 32
+        else { return nil }
+
+        self.init(base: base, bits: bits)
+    }
+}

--- a/Sources/ArcaIP/IP.V4.swift
+++ b/Sources/ArcaIP/IP.V4.swift
@@ -1,0 +1,76 @@
+extension IP {
+    /// An IPv4 address, which is 32 bits wide.
+    public struct V4: Hashable, Sendable {
+        /// The logical value of the address: the high byte is the first octet.
+        ///
+        /// `swift-ip` stored big-endian raw bytes and computed this property.
+        /// Arca never read that raw storage, so this type stores the logical
+        /// value directly. One consequence is that `description` here is
+        /// endian-independent, where `swift-ip`'s was endian-*dependent* by its
+        /// own documentation. Arca is macOS-only and macOS is little-endian
+        /// everywhere, so the output is identical on every supported platform.
+        public var value: UInt32
+
+        /// Creates an address from its logical value.
+        public init(value: UInt32) {
+            self.value = value
+        }
+
+        /// Creates an address from its four octets, first octet first.
+        public init(_ a: UInt8, _ b: UInt8, _ c: UInt8, _ d: UInt8) {
+            self.value =
+                UInt32(a) << 24 | UInt32(b) << 16 | UInt32(c) << 8 | UInt32(d)
+        }
+    }
+}
+
+extension IP.V4: Comparable {
+    /// Compares two addresses by their logical value.
+    public static func < (a: Self, b: Self) -> Bool { a.value < b.value }
+}
+
+extension IP.V4: CustomStringConvertible {
+    /// Formats the address in dotted-decimal notation.
+    public var description: String {
+        """
+        \(self.value >> 24)\
+        .\(self.value >> 16 & 0xFF)\
+        .\(self.value >> 8 & 0xFF)\
+        .\(self.value & 0xFF)
+        """
+    }
+}
+
+extension IP.V4: LosslessStringConvertible {
+    /// Parses an address in dotted-decimal notation.
+    ///
+    /// Requires exactly four `.`-separated fields, each parsed by
+    /// `UInt8.init(_:)`. That parser accepts a leading `+` or `-` and leading
+    /// zeros, so `010.1.1.1`, `+1.2.3.4` and `1.2.3.-0` all parse. This
+    /// leniency is inherited from `swift-ip` 0.3.3 on purpose: rows already
+    /// written to Arca's SQLite state came through that parser, so a stricter
+    /// reader could fail to load real installed state.
+    public init?(_ description: some StringProtocol) {
+        guard
+            let firstDot = description.firstIndex(of: "."),
+            let a = UInt8(description[..<firstDot])
+        else { return nil }
+
+        let afterFirst = description.index(after: firstDot)
+        guard
+            let secondDot = description[afterFirst...].firstIndex(of: "."),
+            let b = UInt8(description[afterFirst ..< secondDot])
+        else { return nil }
+
+        let afterSecond = description.index(after: secondDot)
+        guard
+            let thirdDot = description[afterSecond...].firstIndex(of: "."),
+            let c = UInt8(description[afterSecond ..< thirdDot])
+        else { return nil }
+
+        let afterThird = description.index(after: thirdDot)
+        guard let d = UInt8(description[afterThird...]) else { return nil }
+
+        self.init(a, b, c, d)
+    }
+}

--- a/Sources/ArcaIP/IP.swift
+++ b/Sources/ArcaIP/IP.swift
@@ -1,0 +1,11 @@
+/// Namespace for IP addressing types.
+///
+/// This target replaced `swift-ip` 0.3.3, which Arca used for exactly two
+/// types. Its own `IP` target had no dependencies, but the package carried
+/// five more that pinned commits which no longer exist upstream, so the
+/// pinned Arca tree could not be built from a cold cache.
+///
+/// Behaviour is reproduced exactly rather than improved. The design and the
+/// evidence live in the Gas Can repository at
+/// `docs/superpowers/specs/2026-08-05-arca-internal-ip-type-design.md`.
+public enum IP {}

--- a/Sources/ContainerBridge/StateStore.swift
+++ b/Sources/ContainerBridge/StateStore.swift
@@ -2,7 +2,7 @@ import Foundation
 import SQLite
 import Logging
 import Containerization
-import IP
+import ArcaIP
 
 /// StateStore manages persistent container and network state in SQLite
 /// All operations are atomic and thread-safe via actor isolation

--- a/Sources/ContainerBridge/WireGuardNetworkBackend.swift
+++ b/Sources/ContainerBridge/WireGuardNetworkBackend.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Logging
 import Containerization
-import IP
+import ArcaIP
 
 /// WireGuard backend for Docker bridge networks
 ///
@@ -379,7 +379,7 @@ public actor WireGuardNetworkBackend {
             }
         } else {
             // Auto-allocate IP atomically (prevents race condition)
-            guard let block = IP.Block<IP.V4>(metadata.subnet) else {
+            guard let block = IP.Block(metadata.subnet) else {
                 throw NetworkManagerError.ipAllocationFailed("Invalid subnet format: \(metadata.subnet)")
             }
 
@@ -389,7 +389,7 @@ public actor WireGuardNetworkBackend {
 
             let rangeStart: Int64
             let rangeEnd: Int64
-            if let ipRangeStr = metadata.ipRange, let ipRange = IP.Block<IP.V4>(ipRangeStr) {
+            if let ipRangeStr = metadata.ipRange, let ipRange = IP.Block(ipRangeStr) {
                 rangeStart = Int64(ipRange.range.lowerBound.value)
                 rangeEnd = Int64(ipRange.range.upperBound.value)
             } else {
@@ -1007,7 +1007,7 @@ public actor WireGuardNetworkBackend {
     /// Uses smart IP reclamation - finds first available IP by querying allocated IPs from database
     private func allocateIP(networkID: String, subnet: String) async throws -> String {
         // Parse subnet using swift-ip for type safety
-        guard let block = IP.Block<IP.V4>(subnet) else {
+        guard let block = IP.Block(subnet) else {
             throw NetworkManagerError.ipAllocationFailed("Invalid subnet format: \(subnet)")
         }
 
@@ -1024,14 +1024,18 @@ public actor WireGuardNetworkBackend {
         // Check if ipRange is specified for this network to constrain allocation
         let (rangeStart, rangeEnd): (IP.V4, IP.V4)
         if let metadata = try await loadNetwork(id: networkID), let ipRangeStr = metadata.ipRange,
-           let ipRange = IP.Block<IP.V4>(ipRangeStr) {
+           let ipRange = IP.Block(ipRangeStr) {
             // Use ip-range to constrain allocation
             rangeStart = ipRange.range.lowerBound
             rangeEnd = ipRange.range.upperBound
         } else {
             // Use full subnet range (excluding network address and broadcast)
             rangeStart = startIP
-            rangeEnd = block.range.upperBound  // This is broadcast - 1 already
+            // NOTE: this bound is the broadcast address itself, not broadcast-1
+            // as this comment previously claimed, and the loop below is
+            // inclusive of it. Tracked as a separate defect; behaviour is
+            // deliberately unchanged here.
+            rangeEnd = block.range.upperBound
         }
 
         // Iterate through IP range to find first available
@@ -1070,7 +1074,7 @@ public actor WireGuardNetworkBackend {
     /// Calculate gateway IP from subnet CIDR
     private func calculateGateway(subnet: String) -> String {
         // For Docker compatibility, use .1 as gateway (e.g., 172.18.0.1 for 172.18.0.0/16)
-        guard let block = IP.Block<IP.V4>(subnet) else {
+        guard let block = IP.Block(subnet) else {
             return "172.18.0.1"  // Fallback
         }
 
@@ -1112,7 +1116,7 @@ public actor WireGuardNetworkBackend {
     /// Check if an IP address is within a subnet (CIDR)
     private func isIPInSubnet(_ ip: String, subnet: String) -> Bool {
         // Parse subnet and IP using swift-ip for type-safe checking
-        guard let block = IP.Block<IP.V4>(subnet),
+        guard let block = IP.Block(subnet),
               let address = IP.V4(ip) else {
             return false
         }

--- a/Tests/ArcaIPTests/BlockTests.swift
+++ b/Tests/ArcaIPTests/BlockTests.swift
@@ -1,0 +1,86 @@
+import Testing
+
+@testable import ArcaIP
+
+@Suite("IP.Block")
+struct BlockTests {
+    @Test("parses CIDR notation")
+    func parsesCIDR() {
+        let block = IP.Block("172.18.0.0/16")
+        #expect(block?.base.value == 0xAC12_0000)
+        #expect(block?.bits == 16)
+        #expect(String(describing: block!) == "172.18.0.0/16")
+    }
+
+    @Test("masks the base address on construction")
+    func masksBase() {
+        // swift-ip's `/` operator zero-masks, so a non-canonical base is
+        // silently canonicalised rather than rejected.
+        #expect(IP.Block("172.18.0.5/16")?.base.value == 0xAC12_0000)
+        #expect(String(describing: IP.Block("192.168.1.77/24")!) == "192.168.1.0/24")
+        #expect(IP.Block(base: IP.V4("10.9.8.7")!, bits: 8).base.value == 0x0A00_0000)
+    }
+
+    @Test("rejects malformed input")
+    func rejectsMalformed() {
+        #expect(IP.Block("172.18.0.0/33") == nil)
+        #expect(IP.Block("172.18.0.0") == nil)
+        #expect(IP.Block("bogus/16") == nil)
+        #expect(IP.Block("172.18.0.0/") == nil)
+        #expect(IP.Block("/16") == nil)
+        #expect(IP.Block("") == nil)
+    }
+
+    @Test("range lower bound is the network address")
+    func rangeLowerBound() {
+        #expect(IP.Block("172.18.0.0/16")!.range.lowerBound.value == 0xAC12_0000)
+        #expect(IP.Block("10.0.0.0/8")!.range.lowerBound.value == 0x0A00_0000)
+    }
+
+    // The upper bound is the BROADCAST address, not broadcast - 1. This
+    // reproduces swift-ip 0.3.3 exactly and is asserted here so the behaviour
+    // cannot drift silently.
+    //
+    // It is not an endorsement. WireGuardNetworkBackend.swift comments that
+    // this bound is "broadcast - 1 already"; that comment is wrong, and because
+    // Arca's allocator treats the bound as inclusive it can hand a container
+    // its subnet's broadcast address. Tracked as a separate Arca issue, and
+    // deliberately not fixed here so this replacement stays behaviour-identical.
+    @Test("range upper bound is the broadcast address, reproducing swift-ip")
+    func rangeUpperBoundIsBroadcast() {
+        #expect(IP.Block("172.18.0.0/16")!.range.upperBound.value == 0xAC12_FFFF)
+        #expect(IP.Block("10.0.0.0/8")!.range.upperBound.value == 0x0AFF_FFFF)
+        #expect(IP.Block("192.168.1.0/24")!.range.upperBound.value == 0xC0A8_01FF)
+    }
+
+    @Test("handles the /0 and /32 boundaries")
+    func boundaries() {
+        let all = IP.Block("0.0.0.0/0")!
+        #expect(all.range.lowerBound.value == 0x0000_0000)
+        #expect(all.range.upperBound.value == 0xFFFF_FFFF)
+        #expect(all.contains(IP.V4("8.8.8.8")!))
+
+        let host = IP.Block("1.2.3.4/32")!
+        #expect(host.range.lowerBound.value == 0x0102_0304)
+        #expect(host.range.upperBound.value == 0x0102_0304)
+        #expect(host.contains(IP.V4("1.2.3.4")!))
+        #expect(!host.contains(IP.V4("1.2.3.5")!))
+    }
+
+    @Test("containment checks the masked prefix")
+    func containment() {
+        let block = IP.Block("172.18.0.0/16")!
+        #expect(block.contains(IP.V4("172.18.0.0")!))
+        #expect(block.contains(IP.V4("172.18.5.9")!))
+        #expect(block.contains(IP.V4("172.18.255.255")!))
+        #expect(!block.contains(IP.V4("172.19.5.9")!))
+        #expect(!block.contains(IP.V4("172.17.255.255")!))
+    }
+
+    @Test("is hashable by base and prefix length")
+    func hashable() {
+        #expect(IP.Block("10.0.0.0/8") == IP.Block("10.0.0.0/8"))
+        #expect(IP.Block("10.0.0.0/8") != IP.Block("10.0.0.0/16"))
+        #expect(Set([IP.Block("10.0.0.0/8"), IP.Block("10.0.0.0/8")]).count == 1)
+    }
+}

--- a/Tests/ArcaIPTests/V4Tests.swift
+++ b/Tests/ArcaIPTests/V4Tests.swift
@@ -1,0 +1,66 @@
+import Testing
+
+@testable import ArcaIP
+
+@Suite("IP.V4")
+struct V4Tests {
+    @Test("parses dotted-decimal notation")
+    func parsesDottedDecimal() {
+        #expect(IP.V4("172.18.0.1")?.value == 0xAC12_0001)
+        #expect(IP.V4("0.0.0.0")?.value == 0x0000_0000)
+        #expect(IP.V4("255.255.255.255")?.value == 0xFFFF_FFFF)
+        #expect(IP.V4("127.0.0.1")?.value == 0x7F00_0001)
+    }
+
+    @Test("rejects malformed input")
+    func rejectsMalformed() {
+        #expect(IP.V4("1.2.3") == nil)
+        #expect(IP.V4("1.2.3.4.5") == nil)
+        #expect(IP.V4("1.2.3.256") == nil)
+        #expect(IP.V4(" 1.2.3.4") == nil)
+        #expect(IP.V4("1.2.3.4 ") == nil)
+        #expect(IP.V4("") == nil)
+        #expect(IP.V4("bogus") == nil)
+    }
+
+    // These three are inherited leniency, not oversights. swift-ip 0.3.3 parsed
+    // each octet with UInt8.init(_:), which accepts a leading sign and leading
+    // zeros. Arca's SQLite rows were written by that parser, so tightening this
+    // risks failing to load real installed state. See spec section 6.
+    @Test("reproduces swift-ip's parser leniency deliberately")
+    func reproducesLeniency() {
+        #expect(IP.V4("010.1.1.1")?.value == 0x0A01_0101)
+        #expect(IP.V4("+1.2.3.4")?.value == 0x0102_0304)
+        #expect(IP.V4("1.2.3.-0")?.value == 0x0102_0300)
+    }
+
+    @Test("formats dotted-decimal notation")
+    func formatsDottedDecimal() {
+        #expect(String(describing: IP.V4(value: 0xAC12_0001)) == "172.18.0.1")
+        #expect(String(describing: IP.V4(value: 0x0000_0000)) == "0.0.0.0")
+        #expect(String(describing: IP.V4(value: 0xFFFF_FFFF)) == "255.255.255.255")
+        #expect(String(describing: IP.V4(value: 0x7F00_0001)) == "127.0.0.1")
+    }
+
+    @Test("octet initialiser puts the first octet in the high byte")
+    func octetInitialiser() {
+        #expect(IP.V4(172, 18, 0, 1).value == 0xAC12_0001)
+        #expect(String(describing: IP.V4(192, 168, 1, 254)) == "192.168.1.254")
+    }
+
+    @Test("round-trips value through description")
+    func roundTrips() {
+        for value: UInt32 in [0, 1, 0x0102_0304, 0xAC12_0001, 0x7F00_0001, .max] {
+            let address = IP.V4(value: value)
+            #expect(IP.V4(String(describing: address))?.value == value)
+        }
+    }
+
+    @Test("orders by logical value")
+    func orders() {
+        #expect(IP.V4("10.0.0.1")! < IP.V4("10.0.0.2")!)
+        #expect(IP.V4("9.255.255.255")! < IP.V4("10.0.0.0")!)
+        #expect(IP.V4("1.2.3.4")! == IP.V4("1.2.3.4")!)
+        #expect(IP.V4("1.2.3.4")! != IP.V4("1.2.3.5")!)
+    }
+}


### PR DESCRIPTION
## Why

`swift-ip` 0.3.3 pins a transitive dependency graph (`swift-bson`, `swift-json`,
`swift-grammar`, `swift-hash`, `swift-unixtime`) whose git commits have been
rewritten/removed upstream by the `tayloraswift` org migration. A fresh clone
with a cold SwiftPM cache cannot resolve these commits, so the currently
pinned Arca commit **cannot be built on any machine that hasn't already
resolved these packages once**. This has been red on the downstream CI gate
since its first run; local development has hidden it behind warm caches.

This PR removes `swift-ip` entirely and replaces it with a small internal
type, `ArcaIP` (`IP.V4`, `IP.Block`), proven bit-for-bit equivalent to the
removed library's behavior.

## What changed

- `Sources/ContainerBridge/StateStore.swift`, `WireGuardNetworkBackend.swift`:
  `import IP` → `import ArcaIP`; `IP.Block<IP.V4>(` → `IP.Block(` (6 sites;
  `ArcaIP.IP.Block` is non-generic).
- `Package.swift`: `swift-ip` dependency removed; `ContainerBridge`'s product
  reference changed from `"IP"` (package `swift-ip`) to `"ArcaIP"`.
- `Package.resolved`: **6 identities removed** (`swift-ip`, `swift-bson`,
  `swift-json`, `swift-grammar`, `swift-hash`, `swift-unixtime`), **0
  additions**, no version movement on any surviving pin (swift-nio, gRPC,
  SQLite.swift unchanged). VERIFIED via `git diff` on the manifest (task-4
  report, section 1); `grep -c tayloraswift Package.resolved Package.swift` →
  `0` `0`.
- A known defect in the removed comment's math (the allocator range's upper
  bound is the broadcast address itself, not broadcast−1 as an old comment
  claimed) is **deliberately preserved**, not introduced by this change — the
  comment is corrected, the behavior is byte-identical, and the real fix is
  being tracked separately.

## Evidence

### 1. Differential harness — bit-for-bit equivalence

`ArcaIP` was checked against the actual `swift-ip` 0.3.3 source (revision
`ba4efb6457f69f5f483094aa1230e8e76cc4999c`, confirmed matching the expected
pin) with a differential harness comparing every public entry point across a
constructed input corpus.

```
checks=18580063 mismatches=0
HARNESS_RC=0 / RUN_SH_EXIT=0
```

18.58M comparisons, zero mismatches, clean exit.

**The harness itself was validated by two independent negative controls** —
proof it is not vacuously passing:

- A broken `IP.V4.description` (one-character shift-amount change,
  `>> 16` → `>> 15`) produced **10,418,664 mismatches** of 18,580,063 checks,
  harness exit 1.
- A broken `IP.Block.mask(ones:)` (masked one bit fewer than requested)
  produced **2,921,191 mismatches**, including `contains`-specific failures,
  harness exit 1.

Both breaks were caught immediately and by a wide margin; the real (unbroken)
tree was re-confirmed clean (`checks=18580063 mismatches=0`) after each
control.

### 2. Build and unit tests, anchored to `9bb1a7e`

Run against a clean worktree at
`9bb1a7e79e9c93471f4cd04f8397acec341f778c` (verified clean and at that SHA
immediately before and after):

| Command | Result |
| --- | --- |
| `swift build --configuration release --target ContainerBridge` | **rc=0**, 151.95s, 0 errors — this is exactly what the downstream CI engine-pin gate runs |
| `swift test --filter ArcaIPTests` | **rc=0**, 15/15 (`IP.V4` and `IP.Block` suites), including tests pinning the deliberately-preserved broadcast-address behavior and swift-ip's parser leniency |

### 3. Full-suite before/after comparison (test identity, not counts)

Both runs execute in a sandbox with no Arca daemon/Docker socket, so raw
counts are not a valid baseline; comparison is by distinct failing-test
identity.

| Tree | Distinct failing tests | 
| --- | --- |
| before (`bab182c`, unmodified) | 125 |
| after (this branch) | 125 |

The two sets differ by 10 tests in each direction — symmetric churn
consistent with environmental flakiness (no daemon/Docker socket in that
sandbox), not a regression. All 10 after-only failures were individually
inspected; every one traces to a missing daemon/Docker socket, none to an IP,
subnet, gateway, or CIDR assertion.

`NetworkIPAMTests` — the suite most able to catch a real IPAM regression —
fails on the **identical 14 tests for the identical environmental reasons**
on both sides. Zero IPAM tests changed state.

## Not in scope

- Merging — this PR is opened for review only.
- Fixing the pre-existing broadcast-address comment defect — tracked
  separately; this change preserves it exactly as found.

## Follow-up (tracked separately, not blocking this PR)

Full functional verification (cold-cache build proving the pinned commit is
buildable by a fresh clone, plus a daemon-backed functional pass exercising
subnet parsing/gateway calculation/IP allocation/subnet containment) is being
run in a separate step and will be reported alongside this PR.
