### PR TITLE
docs: mark the live path of the broadcast-allocation defect (#50)

### DIFF
--- a/Sources/ContainerBridge/StateStore.swift
+++ b/Sources/ContainerBridge/StateStore.swift
@@ -955,7 +955,13 @@ public actor StateStore {
     ///   - containerID: The container to allocate IP for
     ///   - networkID: The network to allocate IP on
     ///   - rangeStart: First IP in allocation range as integer
-    ///   - rangeEnd: Last IP in allocation range as integer
+    ///   - rangeEnd: Last IP in allocation range as integer. **Callers currently
+    ///     pass the subnet's broadcast address, and this method treats the bound
+    ///     as inclusive** — see `Vas-Solutus/arca#50`. This method does not
+    ///     validate `rangeStart <= rangeEnd`, and the fallback scan below is
+    ///     `for ip in rangeStart...rangeEnd`, a closed range: an inverted pair
+    ///     traps and kills the daemon. That is reachable today via a `/31` or
+    ///     `/32` subnet from `WireGuardNetworkBackend.attachContainer`.
     ///   - gatewayInt: Gateway IP as integer (to skip)
     ///   - macAddress: MAC address for the attachment
     ///   - aliases: DNS aliases for the attachment

--- a/Sources/ContainerBridge/WireGuardNetworkBackend.swift
+++ b/Sources/ContainerBridge/WireGuardNetworkBackend.swift
@@ -394,6 +394,23 @@ public actor WireGuardNetworkBackend {
                 rangeEnd = Int64(ipRange.range.upperBound.value)
             } else {
                 rangeStart = Int64(startIP.value)
+                // DEFECT (Vas-Solutus/arca#50), deliberately unfixed. This is
+                // the LIVE allocation path. `range.upperBound` is the subnet's
+                // broadcast address, not broadcast-1, and allocateAndReserveIP
+                // treats the bound as inclusive, so a container can be
+                // allocated its subnet's broadcast address.
+                //
+                // Worse on /31 and /32: rangeStart exceeds rangeEnd, so the
+                // first attach silently allocates an address outside the
+                // network and the second reaches `for ip in rangeStart...
+                // rangeEnd` in StateStore.allocateAndReserveIP — a closed range
+                // with lowerBound > upperBound — which traps and kills the
+                // daemon. Subnets are accepted verbatim with no prefix-length
+                // check (effectiveSubnet, ~line 178), so this is reachable from
+                // `docker network create --subnet 10.0.0.0/31`.
+                //
+                // Fix HERE, not in allocateIP() below: that function has no
+                // callers, though it carries a similar note.
                 rangeEnd = Int64(block.range.upperBound.value)
             }
 


### PR DESCRIPTION
Comment-only. No behaviour change; every changed line is a comment.

## Why

PR #49 corrected a false comment claiming `block.range.upperBound` was already `broadcast - 1`. It is the broadcast address. But the correction landed at `WireGuardNetworkBackend.swift:1034`, inside `allocateIP(networkID:subnet:)` — and **that function has no callers**.

VERIFIED: `grep -rn "allocateIP" Sources/ Tests/` returns exactly two hits, its definition at `:1008` and a prose mention in a comment at `:223`.

So the only in-tree marker for #50 sits in dead code, while the live path carries none. Anyone picking up #50 would follow the comment, fix `allocateIP`, watch the marker disappear, and ship believing the issue closed — with the real allocator untouched.

## What this adds

- A note at the **live** path, `WireGuardNetworkBackend.swift` in `attachContainer`, where `rangeEnd = Int64(block.range.upperBound.value)` is actually computed, pointing explicitly away from `allocateIP`.
- A note on `StateStore.allocateAndReserveIP`'s `rangeEnd` parameter doc, recording that the method treats the bound as inclusive and does not validate `rangeStart <= rangeEnd`.

## It also records that #50 is worse than first filed

`docker network create --subnet` takes the string verbatim with no prefix-length validation. On `--subnet 10.0.0.0/31`:

- `rangeStart` = `10.0.0.2`, `rangeEnd` = `10.0.0.1` — inverted.
- First attach silently allocates `10.0.0.2`, an address **outside the network**.
- Second attach reaches `for ip in rangeStart...rangeEnd` in `StateStore.allocateAndReserveIP` — a closed range with `lowerBound > upperBound`. Swift traps and **the daemon dies**, taking management of every running container with it.

`/32` behaves identically. Full trace in https://github.com/Vas-Solutus/arca/issues/50#issuecomment-5198558359

## Verification

`swift build --configuration release --target ContainerBridge` → exit 0, 0 errors.

The behaviour is deliberately still unfixed: it was preserved so the swift-ip replacement in #49 could be proven behaviourally identical by differential testing. Fixing it is #50's job, and the fix needs an explicit guard rather than arithmetic — `/31` and `/32` have no usable host range under this scheme.