### PR TITLE
chore: regenerate the checked-in Swift from the current protos

### DIFF
--- a/Sources/ContainerBridge/Generated/filesystem.grpc.swift
+++ b/Sources/ContainerBridge/Generated/filesystem.grpc.swift
@@ -48,6 +48,26 @@ public protocol Arca_Filesystem_V1_FilesystemServiceClientProtocol: GRPCClient {
     _ request: Arca_Filesystem_V1_CreateBindMountRequest,
     callOptions: CallOptions?
   ) -> UnaryCall<Arca_Filesystem_V1_CreateBindMountRequest, Arca_Filesystem_V1_CreateBindMountResponse>
+
+  func statPath(
+    _ request: Arca_Filesystem_V1_StatPathRequest,
+    callOptions: CallOptions?
+  ) -> UnaryCall<Arca_Filesystem_V1_StatPathRequest, Arca_Filesystem_V1_StatPathResponse>
+
+  func createVolumeOverlay(
+    _ request: Arca_Filesystem_V1_CreateVolumeOverlayRequest,
+    callOptions: CallOptions?
+  ) -> UnaryCall<Arca_Filesystem_V1_CreateVolumeOverlayRequest, Arca_Filesystem_V1_CreateVolumeOverlayResponse>
+
+  func createDirectMount(
+    _ request: Arca_Filesystem_V1_CreateDirectMountRequest,
+    callOptions: CallOptions?
+  ) -> UnaryCall<Arca_Filesystem_V1_CreateDirectMountRequest, Arca_Filesystem_V1_CreateDirectMountResponse>
+
+  func generateHostsFile(
+    _ request: Arca_Filesystem_V1_GenerateHostsFileRequest,
+    callOptions: CallOptions?
+  ) -> UnaryCall<Arca_Filesystem_V1_GenerateHostsFileRequest, Arca_Filesystem_V1_GenerateHostsFileResponse>
 }
 
 extension Arca_Filesystem_V1_FilesystemServiceClientProtocol {
@@ -173,6 +193,88 @@ extension Arca_Filesystem_V1_FilesystemServiceClientProtocol {
       interceptors: self.interceptors?.makeCreateBindMountInterceptors() ?? []
     )
   }
+
+  /// Stat path - check if a path exists and get metadata
+  /// Used for HEAD requests on archive endpoint
+  ///
+  /// - Parameters:
+  ///   - request: Request to send to StatPath.
+  ///   - callOptions: Call options.
+  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
+  public func statPath(
+    _ request: Arca_Filesystem_V1_StatPathRequest,
+    callOptions: CallOptions? = nil
+  ) -> UnaryCall<Arca_Filesystem_V1_StatPathRequest, Arca_Filesystem_V1_StatPathResponse> {
+    return self.makeUnaryCall(
+      path: Arca_Filesystem_V1_FilesystemServiceClientMetadata.Methods.statPath.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeStatPathInterceptors() ?? []
+    )
+  }
+
+  /// Create volume overlay - create OverlayFS mount for a volume
+  /// Overlays an EXT4 upper layer on top of VirtioFS lower layer
+  /// This provides full POSIX compliance (Unix sockets, chmod) while maintaining
+  /// read access to host files via VirtioFS
+  /// Used for bind mounts that need both host file access AND POSIX compliance
+  ///
+  /// - Parameters:
+  ///   - request: Request to send to CreateVolumeOverlay.
+  ///   - callOptions: Call options.
+  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
+  public func createVolumeOverlay(
+    _ request: Arca_Filesystem_V1_CreateVolumeOverlayRequest,
+    callOptions: CallOptions? = nil
+  ) -> UnaryCall<Arca_Filesystem_V1_CreateVolumeOverlayRequest, Arca_Filesystem_V1_CreateVolumeOverlayResponse> {
+    return self.makeUnaryCall(
+      path: Arca_Filesystem_V1_FilesystemServiceClientMetadata.Methods.createVolumeOverlay.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeCreateVolumeOverlayInterceptors() ?? []
+    )
+  }
+
+  /// Create direct volume mount - bind mount EXT4 directory to container path
+  /// Creates a directory on the writable EXT4 filesystem and bind mounts it
+  /// Provides full POSIX compliance without OverlayFS (allows nested overlays)
+  /// Used for named volumes (local driver) that don't need host file access
+  ///
+  /// - Parameters:
+  ///   - request: Request to send to CreateDirectMount.
+  ///   - callOptions: Call options.
+  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
+  public func createDirectMount(
+    _ request: Arca_Filesystem_V1_CreateDirectMountRequest,
+    callOptions: CallOptions? = nil
+  ) -> UnaryCall<Arca_Filesystem_V1_CreateDirectMountRequest, Arca_Filesystem_V1_CreateDirectMountResponse> {
+    return self.makeUnaryCall(
+      path: Arca_Filesystem_V1_FilesystemServiceClientMetadata.Methods.createDirectMount.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeCreateDirectMountInterceptors() ?? []
+    )
+  }
+
+  /// Generate /etc/hosts file for container
+  /// Creates the standard Docker hosts file with localhost entries and container hostname
+  /// Docker generates this file; we need to do the same for compatibility
+  ///
+  /// - Parameters:
+  ///   - request: Request to send to GenerateHostsFile.
+  ///   - callOptions: Call options.
+  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
+  public func generateHostsFile(
+    _ request: Arca_Filesystem_V1_GenerateHostsFileRequest,
+    callOptions: CallOptions? = nil
+  ) -> UnaryCall<Arca_Filesystem_V1_GenerateHostsFileRequest, Arca_Filesystem_V1_GenerateHostsFileResponse> {
+    return self.makeUnaryCall(
+      path: Arca_Filesystem_V1_FilesystemServiceClientMetadata.Methods.generateHostsFile.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeGenerateHostsFileInterceptors() ?? []
+    )
+  }
 }
 
 @available(*, deprecated)
@@ -268,6 +370,26 @@ public protocol Arca_Filesystem_V1_FilesystemServiceAsyncClientProtocol: GRPCCli
     _ request: Arca_Filesystem_V1_CreateBindMountRequest,
     callOptions: CallOptions?
   ) -> GRPCAsyncUnaryCall<Arca_Filesystem_V1_CreateBindMountRequest, Arca_Filesystem_V1_CreateBindMountResponse>
+
+  func makeStatPathCall(
+    _ request: Arca_Filesystem_V1_StatPathRequest,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncUnaryCall<Arca_Filesystem_V1_StatPathRequest, Arca_Filesystem_V1_StatPathResponse>
+
+  func makeCreateVolumeOverlayCall(
+    _ request: Arca_Filesystem_V1_CreateVolumeOverlayRequest,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncUnaryCall<Arca_Filesystem_V1_CreateVolumeOverlayRequest, Arca_Filesystem_V1_CreateVolumeOverlayResponse>
+
+  func makeCreateDirectMountCall(
+    _ request: Arca_Filesystem_V1_CreateDirectMountRequest,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncUnaryCall<Arca_Filesystem_V1_CreateDirectMountRequest, Arca_Filesystem_V1_CreateDirectMountResponse>
+
+  func makeGenerateHostsFileCall(
+    _ request: Arca_Filesystem_V1_GenerateHostsFileRequest,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncUnaryCall<Arca_Filesystem_V1_GenerateHostsFileRequest, Arca_Filesystem_V1_GenerateHostsFileResponse>
 }
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
@@ -351,6 +473,54 @@ extension Arca_Filesystem_V1_FilesystemServiceAsyncClientProtocol {
       interceptors: self.interceptors?.makeCreateBindMountInterceptors() ?? []
     )
   }
+
+  public func makeStatPathCall(
+    _ request: Arca_Filesystem_V1_StatPathRequest,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncUnaryCall<Arca_Filesystem_V1_StatPathRequest, Arca_Filesystem_V1_StatPathResponse> {
+    return self.makeAsyncUnaryCall(
+      path: Arca_Filesystem_V1_FilesystemServiceClientMetadata.Methods.statPath.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeStatPathInterceptors() ?? []
+    )
+  }
+
+  public func makeCreateVolumeOverlayCall(
+    _ request: Arca_Filesystem_V1_CreateVolumeOverlayRequest,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncUnaryCall<Arca_Filesystem_V1_CreateVolumeOverlayRequest, Arca_Filesystem_V1_CreateVolumeOverlayResponse> {
+    return self.makeAsyncUnaryCall(
+      path: Arca_Filesystem_V1_FilesystemServiceClientMetadata.Methods.createVolumeOverlay.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeCreateVolumeOverlayInterceptors() ?? []
+    )
+  }
+
+  public func makeCreateDirectMountCall(
+    _ request: Arca_Filesystem_V1_CreateDirectMountRequest,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncUnaryCall<Arca_Filesystem_V1_CreateDirectMountRequest, Arca_Filesystem_V1_CreateDirectMountResponse> {
+    return self.makeAsyncUnaryCall(
+      path: Arca_Filesystem_V1_FilesystemServiceClientMetadata.Methods.createDirectMount.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeCreateDirectMountInterceptors() ?? []
+    )
+  }
+
+  public func makeGenerateHostsFileCall(
+    _ request: Arca_Filesystem_V1_GenerateHostsFileRequest,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncUnaryCall<Arca_Filesystem_V1_GenerateHostsFileRequest, Arca_Filesystem_V1_GenerateHostsFileResponse> {
+    return self.makeAsyncUnaryCall(
+      path: Arca_Filesystem_V1_FilesystemServiceClientMetadata.Methods.generateHostsFile.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeGenerateHostsFileInterceptors() ?? []
+    )
+  }
 }
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
@@ -426,6 +596,54 @@ extension Arca_Filesystem_V1_FilesystemServiceAsyncClientProtocol {
       interceptors: self.interceptors?.makeCreateBindMountInterceptors() ?? []
     )
   }
+
+  public func statPath(
+    _ request: Arca_Filesystem_V1_StatPathRequest,
+    callOptions: CallOptions? = nil
+  ) async throws -> Arca_Filesystem_V1_StatPathResponse {
+    return try await self.performAsyncUnaryCall(
+      path: Arca_Filesystem_V1_FilesystemServiceClientMetadata.Methods.statPath.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeStatPathInterceptors() ?? []
+    )
+  }
+
+  public func createVolumeOverlay(
+    _ request: Arca_Filesystem_V1_CreateVolumeOverlayRequest,
+    callOptions: CallOptions? = nil
+  ) async throws -> Arca_Filesystem_V1_CreateVolumeOverlayResponse {
+    return try await self.performAsyncUnaryCall(
+      path: Arca_Filesystem_V1_FilesystemServiceClientMetadata.Methods.createVolumeOverlay.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeCreateVolumeOverlayInterceptors() ?? []
+    )
+  }
+
+  public func createDirectMount(
+    _ request: Arca_Filesystem_V1_CreateDirectMountRequest,
+    callOptions: CallOptions? = nil
+  ) async throws -> Arca_Filesystem_V1_CreateDirectMountResponse {
+    return try await self.performAsyncUnaryCall(
+      path: Arca_Filesystem_V1_FilesystemServiceClientMetadata.Methods.createDirectMount.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeCreateDirectMountInterceptors() ?? []
+    )
+  }
+
+  public func generateHostsFile(
+    _ request: Arca_Filesystem_V1_GenerateHostsFileRequest,
+    callOptions: CallOptions? = nil
+  ) async throws -> Arca_Filesystem_V1_GenerateHostsFileResponse {
+    return try await self.performAsyncUnaryCall(
+      path: Arca_Filesystem_V1_FilesystemServiceClientMetadata.Methods.generateHostsFile.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeGenerateHostsFileInterceptors() ?? []
+    )
+  }
 }
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
@@ -464,6 +682,18 @@ public protocol Arca_Filesystem_V1_FilesystemServiceClientInterceptorFactoryProt
 
   /// - Returns: Interceptors to use when invoking 'createBindMount'.
   func makeCreateBindMountInterceptors() -> [ClientInterceptor<Arca_Filesystem_V1_CreateBindMountRequest, Arca_Filesystem_V1_CreateBindMountResponse>]
+
+  /// - Returns: Interceptors to use when invoking 'statPath'.
+  func makeStatPathInterceptors() -> [ClientInterceptor<Arca_Filesystem_V1_StatPathRequest, Arca_Filesystem_V1_StatPathResponse>]
+
+  /// - Returns: Interceptors to use when invoking 'createVolumeOverlay'.
+  func makeCreateVolumeOverlayInterceptors() -> [ClientInterceptor<Arca_Filesystem_V1_CreateVolumeOverlayRequest, Arca_Filesystem_V1_CreateVolumeOverlayResponse>]
+
+  /// - Returns: Interceptors to use when invoking 'createDirectMount'.
+  func makeCreateDirectMountInterceptors() -> [ClientInterceptor<Arca_Filesystem_V1_CreateDirectMountRequest, Arca_Filesystem_V1_CreateDirectMountResponse>]
+
+  /// - Returns: Interceptors to use when invoking 'generateHostsFile'.
+  func makeGenerateHostsFileInterceptors() -> [ClientInterceptor<Arca_Filesystem_V1_GenerateHostsFileRequest, Arca_Filesystem_V1_GenerateHostsFileResponse>]
 }
 
 public enum Arca_Filesystem_V1_FilesystemServiceClientMetadata {
@@ -477,6 +707,10 @@ public enum Arca_Filesystem_V1_FilesystemServiceClientMetadata {
       Arca_Filesystem_V1_FilesystemServiceClientMetadata.Methods.readArchive,
       Arca_Filesystem_V1_FilesystemServiceClientMetadata.Methods.writeArchive,
       Arca_Filesystem_V1_FilesystemServiceClientMetadata.Methods.createBindMount,
+      Arca_Filesystem_V1_FilesystemServiceClientMetadata.Methods.statPath,
+      Arca_Filesystem_V1_FilesystemServiceClientMetadata.Methods.createVolumeOverlay,
+      Arca_Filesystem_V1_FilesystemServiceClientMetadata.Methods.createDirectMount,
+      Arca_Filesystem_V1_FilesystemServiceClientMetadata.Methods.generateHostsFile,
     ]
   )
 
@@ -514,6 +748,30 @@ public enum Arca_Filesystem_V1_FilesystemServiceClientMetadata {
     public static let createBindMount = GRPCMethodDescriptor(
       name: "CreateBindMount",
       path: "/arca.filesystem.v1.FilesystemService/CreateBindMount",
+      type: GRPCCallType.unary
+    )
+
+    public static let statPath = GRPCMethodDescriptor(
+      name: "StatPath",
+      path: "/arca.filesystem.v1.FilesystemService/StatPath",
+      type: GRPCCallType.unary
+    )
+
+    public static let createVolumeOverlay = GRPCMethodDescriptor(
+      name: "CreateVolumeOverlay",
+      path: "/arca.filesystem.v1.FilesystemService/CreateVolumeOverlay",
+      type: GRPCCallType.unary
+    )
+
+    public static let createDirectMount = GRPCMethodDescriptor(
+      name: "CreateDirectMount",
+      path: "/arca.filesystem.v1.FilesystemService/CreateDirectMount",
+      type: GRPCCallType.unary
+    )
+
+    public static let generateHostsFile = GRPCMethodDescriptor(
+      name: "GenerateHostsFile",
+      path: "/arca.filesystem.v1.FilesystemService/GenerateHostsFile",
       type: GRPCCallType.unary
     )
   }

--- a/Sources/ContainerBridge/Generated/filesystem.pb.swift
+++ b/Sources/ContainerBridge/Generated/filesystem.pb.swift
@@ -17,7 +17,11 @@
 // - Archive operations (tar creation/extraction for buildx)
 // - OverlayFS upperdir enumeration (for docker diff)
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import SwiftProtobuf
 
 // If the compiler emits an error on this type, it is because this file
@@ -25,13 +29,13 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
 /// Request to check service readiness
-public struct Arca_Filesystem_V1_ReadyRequest: Sendable {
+public nonisolated struct Arca_Filesystem_V1_ReadyRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -42,7 +46,7 @@ public struct Arca_Filesystem_V1_ReadyRequest: Sendable {
 }
 
 /// Response indicating service readiness
-public struct Arca_Filesystem_V1_ReadyResponse: Sendable {
+public nonisolated struct Arca_Filesystem_V1_ReadyResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -62,7 +66,7 @@ public struct Arca_Filesystem_V1_ReadyResponse: Sendable {
 }
 
 /// Request to sync filesystem (flush all cached writes)
-public struct Arca_Filesystem_V1_SyncFilesystemRequest: Sendable {
+public nonisolated struct Arca_Filesystem_V1_SyncFilesystemRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -72,7 +76,7 @@ public struct Arca_Filesystem_V1_SyncFilesystemRequest: Sendable {
   public init() {}
 }
 
-public struct Arca_Filesystem_V1_SyncFilesystemResponse: Sendable {
+public nonisolated struct Arca_Filesystem_V1_SyncFilesystemResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -89,7 +93,7 @@ public struct Arca_Filesystem_V1_SyncFilesystemResponse: Sendable {
 }
 
 /// Request to enumerate OverlayFS upperdir for container diff
-public struct Arca_Filesystem_V1_EnumerateUpperdirRequest: Sendable {
+public nonisolated struct Arca_Filesystem_V1_EnumerateUpperdirRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -99,7 +103,7 @@ public struct Arca_Filesystem_V1_EnumerateUpperdirRequest: Sendable {
   public init() {}
 }
 
-public struct Arca_Filesystem_V1_EnumerateUpperdirResponse: Sendable {
+public nonisolated struct Arca_Filesystem_V1_EnumerateUpperdirResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -119,7 +123,7 @@ public struct Arca_Filesystem_V1_EnumerateUpperdirResponse: Sendable {
 }
 
 /// Represents a file, directory, or whiteout in the OverlayFS upperdir
-public struct Arca_Filesystem_V1_UpperdirEntry: Sendable {
+public nonisolated struct Arca_Filesystem_V1_UpperdirEntry: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -146,7 +150,7 @@ public struct Arca_Filesystem_V1_UpperdirEntry: Sendable {
 }
 
 /// Request to read archive from filesystem path
-public struct Arca_Filesystem_V1_ReadArchiveRequest: Sendable {
+public nonisolated struct Arca_Filesystem_V1_ReadArchiveRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -162,7 +166,7 @@ public struct Arca_Filesystem_V1_ReadArchiveRequest: Sendable {
   public init() {}
 }
 
-public struct Arca_Filesystem_V1_ReadArchiveResponse: Sendable {
+public nonisolated struct Arca_Filesystem_V1_ReadArchiveResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -178,11 +182,11 @@ public struct Arca_Filesystem_V1_ReadArchiveResponse: Sendable {
 
   /// File stat information (for X-Docker-Container-Path-Stat header)
   public var stat: Arca_Filesystem_V1_PathStat {
-    get {return _stat ?? Arca_Filesystem_V1_PathStat()}
+    get {_stat ?? Arca_Filesystem_V1_PathStat()}
     set {_stat = newValue}
   }
   /// Returns true if `stat` has been explicitly set.
-  public var hasStat: Bool {return self._stat != nil}
+  public var hasStat: Bool {self._stat != nil}
   /// Clears the value of `stat`. Subsequent reads from it will return its default value.
   public mutating func clearStat() {self._stat = nil}
 
@@ -194,7 +198,7 @@ public struct Arca_Filesystem_V1_ReadArchiveResponse: Sendable {
 }
 
 /// File stat information for archived paths
-public struct Arca_Filesystem_V1_PathStat: Sendable {
+public nonisolated struct Arca_Filesystem_V1_PathStat: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -220,7 +224,7 @@ public struct Arca_Filesystem_V1_PathStat: Sendable {
 }
 
 /// Request to write archive to filesystem path
-public struct Arca_Filesystem_V1_WriteArchiveRequest: Sendable {
+public nonisolated struct Arca_Filesystem_V1_WriteArchiveRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -239,7 +243,7 @@ public struct Arca_Filesystem_V1_WriteArchiveRequest: Sendable {
   public init() {}
 }
 
-public struct Arca_Filesystem_V1_WriteArchiveResponse: Sendable {
+public nonisolated struct Arca_Filesystem_V1_WriteArchiveResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -256,7 +260,7 @@ public struct Arca_Filesystem_V1_WriteArchiveResponse: Sendable {
 }
 
 /// Request to create a bind mount inside the container
-public struct Arca_Filesystem_V1_CreateBindMountRequest: Sendable {
+public nonisolated struct Arca_Filesystem_V1_CreateBindMountRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -280,7 +284,186 @@ public struct Arca_Filesystem_V1_CreateBindMountRequest: Sendable {
   public init() {}
 }
 
-public struct Arca_Filesystem_V1_CreateBindMountResponse: Sendable {
+public nonisolated struct Arca_Filesystem_V1_CreateBindMountResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Success status
+  public var success: Bool = false
+
+  /// Error message if success = false
+  public var error: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+/// Request to stat a path (check existence and get metadata)
+public nonisolated struct Arca_Filesystem_V1_StatPathRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Container ID (for resolving /run/container/{id}/rootfs path)
+  public var containerID: String = String()
+
+  /// Path to stat (e.g., "/tmp/myfile.txt")
+  public var path: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public nonisolated struct Arca_Filesystem_V1_StatPathResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Success status
+  public var success: Bool = false
+
+  /// Error message if success = false
+  public var error: String = String()
+
+  /// File stat information
+  public var stat: Arca_Filesystem_V1_PathStat {
+    get {_stat ?? Arca_Filesystem_V1_PathStat()}
+    set {_stat = newValue}
+  }
+  /// Returns true if `stat` has been explicitly set.
+  public var hasStat: Bool {self._stat != nil}
+  /// Clears the value of `stat`. Subsequent reads from it will return its default value.
+  public mutating func clearStat() {self._stat = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _stat: Arca_Filesystem_V1_PathStat? = nil
+}
+
+/// Request to create an OverlayFS mount for a volume
+/// This overlays an EXT4 writable layer on top of a VirtioFS layer
+/// Provides full POSIX compliance (Unix sockets, chmod) for volumes
+public nonisolated struct Arca_Filesystem_V1_CreateVolumeOverlayRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Container ID (for resolving container rootfs path)
+  public var containerID: String = String()
+
+  /// Lower layer path - where VirtioFS should be mounted in guest
+  /// e.g., "/mnt/arca-volumes/{hash}/data"
+  /// Go will mount the VirtioFS here if not already mounted
+  public var lowerPath: String = String()
+
+  /// Upper layer identifier - volume name for creating subdirs
+  /// Used to create /mnt/vdb/volume-overlays/{upper_device}/upper and work
+  public var upperDevice: String = String()
+
+  /// Target mount path relative to container root
+  /// e.g., "/var/lib/rancher/k3s"
+  /// Will be resolved to /run/container/{container_id}/rootfs{target}
+  public var target: String = String()
+
+  /// VirtioFS tag for mounting the share if not already mounted
+  /// This is the hash of the host source path used by the hypervisor
+  public var virtiofsTag: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public nonisolated struct Arca_Filesystem_V1_CreateVolumeOverlayResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Success status
+  public var success: Bool = false
+
+  /// Error message if success = false
+  public var error: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+/// Request to create a direct EXT4 bind mount for a volume
+/// This creates a directory on the writable EXT4 filesystem and bind mounts it
+/// to the container target path. No OverlayFS involved - allows nested overlays.
+public nonisolated struct Arca_Filesystem_V1_CreateDirectMountRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Container ID (for resolving container rootfs path)
+  public var containerID: String = String()
+
+  /// Volume name - used to create /mnt/writable/volumes/{volume_name}
+  public var volumeName: String = String()
+
+  /// Target mount path relative to container root
+  /// e.g., "/var/lib/rancher/k3s"
+  /// Will be resolved to /run/container/{container_id}/rootfs{target}
+  public var target: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public nonisolated struct Arca_Filesystem_V1_CreateDirectMountResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Success status
+  public var success: Bool = false
+
+  /// Error message if success = false
+  public var error: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+/// Request to generate /etc/hosts file for a container
+/// Docker generates this file with localhost entries and container hostname
+public nonisolated struct Arca_Filesystem_V1_GenerateHostsFileRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// Container ID (for resolving container rootfs path)
+  public var containerID: String = String()
+
+  /// Container hostname (typically the short container ID or user-specified hostname)
+  public var hostname: String = String()
+
+  /// Container's IP address (e.g., "10.89.0.2")
+  public var ipAddress: String = String()
+
+  /// Container name (without leading slash, e.g., "my-container")
+  public var containerName: String = String()
+
+  /// Extra hosts to add (from --add-host flag)
+  /// Format: "hostname:ip"
+  public var extraHosts: [String] = []
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public nonisolated struct Arca_Filesystem_V1_GenerateHostsFileResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -298,9 +481,9 @@ public struct Arca_Filesystem_V1_CreateBindMountResponse: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "arca.filesystem.v1"
+fileprivate nonisolated let _protobuf_package = "arca.filesystem.v1"
 
-extension Arca_Filesystem_V1_ReadyRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Filesystem_V1_ReadyRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ReadyRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -319,7 +502,7 @@ extension Arca_Filesystem_V1_ReadyRequest: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Arca_Filesystem_V1_ReadyResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Filesystem_V1_ReadyResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ReadyResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}ready\0\u{1}version\0\u{3}uptime_ms\0")
 
@@ -359,7 +542,7 @@ extension Arca_Filesystem_V1_ReadyResponse: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Arca_Filesystem_V1_SyncFilesystemRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Filesystem_V1_SyncFilesystemRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".SyncFilesystemRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -378,7 +561,7 @@ extension Arca_Filesystem_V1_SyncFilesystemRequest: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Arca_Filesystem_V1_SyncFilesystemResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Filesystem_V1_SyncFilesystemResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".SyncFilesystemResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{1}error\0")
 
@@ -413,7 +596,7 @@ extension Arca_Filesystem_V1_SyncFilesystemResponse: SwiftProtobuf.Message, Swif
   }
 }
 
-extension Arca_Filesystem_V1_EnumerateUpperdirRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Filesystem_V1_EnumerateUpperdirRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".EnumerateUpperdirRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -432,7 +615,7 @@ extension Arca_Filesystem_V1_EnumerateUpperdirRequest: SwiftProtobuf.Message, Sw
   }
 }
 
-extension Arca_Filesystem_V1_EnumerateUpperdirResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Filesystem_V1_EnumerateUpperdirResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".EnumerateUpperdirResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{1}error\0\u{1}entries\0")
 
@@ -472,7 +655,7 @@ extension Arca_Filesystem_V1_EnumerateUpperdirResponse: SwiftProtobuf.Message, S
   }
 }
 
-extension Arca_Filesystem_V1_UpperdirEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Filesystem_V1_UpperdirEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".UpperdirEntry"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}path\0\u{1}type\0\u{1}size\0\u{1}mtime\0\u{1}mode\0")
 
@@ -522,7 +705,7 @@ extension Arca_Filesystem_V1_UpperdirEntry: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Arca_Filesystem_V1_ReadArchiveRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Filesystem_V1_ReadArchiveRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ReadArchiveRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}container_id\0\u{1}path\0")
 
@@ -557,7 +740,7 @@ extension Arca_Filesystem_V1_ReadArchiveRequest: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Arca_Filesystem_V1_ReadArchiveResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Filesystem_V1_ReadArchiveResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ReadArchiveResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{1}error\0\u{3}tar_data\0\u{1}stat\0")
 
@@ -606,7 +789,7 @@ extension Arca_Filesystem_V1_ReadArchiveResponse: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Arca_Filesystem_V1_PathStat: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Filesystem_V1_PathStat: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".PathStat"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}size\0\u{1}mode\0\u{1}mtime\0\u{3}link_target\0")
 
@@ -656,7 +839,7 @@ extension Arca_Filesystem_V1_PathStat: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Arca_Filesystem_V1_WriteArchiveRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Filesystem_V1_WriteArchiveRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WriteArchiveRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}container_id\0\u{1}path\0\u{3}tar_data\0")
 
@@ -696,7 +879,7 @@ extension Arca_Filesystem_V1_WriteArchiveRequest: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Arca_Filesystem_V1_WriteArchiveResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Filesystem_V1_WriteArchiveResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WriteArchiveResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{1}error\0")
 
@@ -731,7 +914,7 @@ extension Arca_Filesystem_V1_WriteArchiveResponse: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Arca_Filesystem_V1_CreateBindMountRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Filesystem_V1_CreateBindMountRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".CreateBindMountRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}container_id\0\u{1}source\0\u{1}target\0\u{3}read_only\0")
 
@@ -776,7 +959,7 @@ extension Arca_Filesystem_V1_CreateBindMountRequest: SwiftProtobuf.Message, Swif
   }
 }
 
-extension Arca_Filesystem_V1_CreateBindMountResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Filesystem_V1_CreateBindMountResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".CreateBindMountResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{1}error\0")
 
@@ -804,6 +987,330 @@ extension Arca_Filesystem_V1_CreateBindMountResponse: SwiftProtobuf.Message, Swi
   }
 
   public static func ==(lhs: Arca_Filesystem_V1_CreateBindMountResponse, rhs: Arca_Filesystem_V1_CreateBindMountResponse) -> Bool {
+    if lhs.success != rhs.success {return false}
+    if lhs.error != rhs.error {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Arca_Filesystem_V1_StatPathRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".StatPathRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}container_id\0\u{1}path\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.containerID) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.path) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.containerID.isEmpty {
+      try visitor.visitSingularStringField(value: self.containerID, fieldNumber: 1)
+    }
+    if !self.path.isEmpty {
+      try visitor.visitSingularStringField(value: self.path, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Arca_Filesystem_V1_StatPathRequest, rhs: Arca_Filesystem_V1_StatPathRequest) -> Bool {
+    if lhs.containerID != rhs.containerID {return false}
+    if lhs.path != rhs.path {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Arca_Filesystem_V1_StatPathResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".StatPathResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{1}error\0\u{1}stat\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularBoolField(value: &self.success) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.error) }()
+      case 3: try { try decoder.decodeSingularMessageField(value: &self._stat) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    if self.success != false {
+      try visitor.visitSingularBoolField(value: self.success, fieldNumber: 1)
+    }
+    if !self.error.isEmpty {
+      try visitor.visitSingularStringField(value: self.error, fieldNumber: 2)
+    }
+    try { if let v = self._stat {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    } }()
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Arca_Filesystem_V1_StatPathResponse, rhs: Arca_Filesystem_V1_StatPathResponse) -> Bool {
+    if lhs.success != rhs.success {return false}
+    if lhs.error != rhs.error {return false}
+    if lhs._stat != rhs._stat {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Arca_Filesystem_V1_CreateVolumeOverlayRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".CreateVolumeOverlayRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}container_id\0\u{3}lower_path\0\u{3}upper_device\0\u{1}target\0\u{3}virtiofs_tag\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.containerID) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.lowerPath) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.upperDevice) }()
+      case 4: try { try decoder.decodeSingularStringField(value: &self.target) }()
+      case 5: try { try decoder.decodeSingularStringField(value: &self.virtiofsTag) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.containerID.isEmpty {
+      try visitor.visitSingularStringField(value: self.containerID, fieldNumber: 1)
+    }
+    if !self.lowerPath.isEmpty {
+      try visitor.visitSingularStringField(value: self.lowerPath, fieldNumber: 2)
+    }
+    if !self.upperDevice.isEmpty {
+      try visitor.visitSingularStringField(value: self.upperDevice, fieldNumber: 3)
+    }
+    if !self.target.isEmpty {
+      try visitor.visitSingularStringField(value: self.target, fieldNumber: 4)
+    }
+    if !self.virtiofsTag.isEmpty {
+      try visitor.visitSingularStringField(value: self.virtiofsTag, fieldNumber: 5)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Arca_Filesystem_V1_CreateVolumeOverlayRequest, rhs: Arca_Filesystem_V1_CreateVolumeOverlayRequest) -> Bool {
+    if lhs.containerID != rhs.containerID {return false}
+    if lhs.lowerPath != rhs.lowerPath {return false}
+    if lhs.upperDevice != rhs.upperDevice {return false}
+    if lhs.target != rhs.target {return false}
+    if lhs.virtiofsTag != rhs.virtiofsTag {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Arca_Filesystem_V1_CreateVolumeOverlayResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".CreateVolumeOverlayResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{1}error\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularBoolField(value: &self.success) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.error) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.success != false {
+      try visitor.visitSingularBoolField(value: self.success, fieldNumber: 1)
+    }
+    if !self.error.isEmpty {
+      try visitor.visitSingularStringField(value: self.error, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Arca_Filesystem_V1_CreateVolumeOverlayResponse, rhs: Arca_Filesystem_V1_CreateVolumeOverlayResponse) -> Bool {
+    if lhs.success != rhs.success {return false}
+    if lhs.error != rhs.error {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Arca_Filesystem_V1_CreateDirectMountRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".CreateDirectMountRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}container_id\0\u{3}volume_name\0\u{1}target\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.containerID) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.volumeName) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.target) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.containerID.isEmpty {
+      try visitor.visitSingularStringField(value: self.containerID, fieldNumber: 1)
+    }
+    if !self.volumeName.isEmpty {
+      try visitor.visitSingularStringField(value: self.volumeName, fieldNumber: 2)
+    }
+    if !self.target.isEmpty {
+      try visitor.visitSingularStringField(value: self.target, fieldNumber: 3)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Arca_Filesystem_V1_CreateDirectMountRequest, rhs: Arca_Filesystem_V1_CreateDirectMountRequest) -> Bool {
+    if lhs.containerID != rhs.containerID {return false}
+    if lhs.volumeName != rhs.volumeName {return false}
+    if lhs.target != rhs.target {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Arca_Filesystem_V1_CreateDirectMountResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".CreateDirectMountResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{1}error\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularBoolField(value: &self.success) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.error) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.success != false {
+      try visitor.visitSingularBoolField(value: self.success, fieldNumber: 1)
+    }
+    if !self.error.isEmpty {
+      try visitor.visitSingularStringField(value: self.error, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Arca_Filesystem_V1_CreateDirectMountResponse, rhs: Arca_Filesystem_V1_CreateDirectMountResponse) -> Bool {
+    if lhs.success != rhs.success {return false}
+    if lhs.error != rhs.error {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Arca_Filesystem_V1_GenerateHostsFileRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".GenerateHostsFileRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}container_id\0\u{1}hostname\0\u{3}ip_address\0\u{3}container_name\0\u{3}extra_hosts\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.containerID) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.hostname) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.ipAddress) }()
+      case 4: try { try decoder.decodeSingularStringField(value: &self.containerName) }()
+      case 5: try { try decoder.decodeRepeatedStringField(value: &self.extraHosts) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.containerID.isEmpty {
+      try visitor.visitSingularStringField(value: self.containerID, fieldNumber: 1)
+    }
+    if !self.hostname.isEmpty {
+      try visitor.visitSingularStringField(value: self.hostname, fieldNumber: 2)
+    }
+    if !self.ipAddress.isEmpty {
+      try visitor.visitSingularStringField(value: self.ipAddress, fieldNumber: 3)
+    }
+    if !self.containerName.isEmpty {
+      try visitor.visitSingularStringField(value: self.containerName, fieldNumber: 4)
+    }
+    if !self.extraHosts.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.extraHosts, fieldNumber: 5)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Arca_Filesystem_V1_GenerateHostsFileRequest, rhs: Arca_Filesystem_V1_GenerateHostsFileRequest) -> Bool {
+    if lhs.containerID != rhs.containerID {return false}
+    if lhs.hostname != rhs.hostname {return false}
+    if lhs.ipAddress != rhs.ipAddress {return false}
+    if lhs.containerName != rhs.containerName {return false}
+    if lhs.extraHosts != rhs.extraHosts {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Arca_Filesystem_V1_GenerateHostsFileResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".GenerateHostsFileResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{1}error\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularBoolField(value: &self.success) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.error) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.success != false {
+      try visitor.visitSingularBoolField(value: self.success, fieldNumber: 1)
+    }
+    if !self.error.isEmpty {
+      try visitor.visitSingularStringField(value: self.error, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Arca_Filesystem_V1_GenerateHostsFileResponse, rhs: Arca_Filesystem_V1_GenerateHostsFileResponse) -> Bool {
     if lhs.success != rhs.success {return false}
     if lhs.error != rhs.error {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}

--- a/Sources/ContainerBridge/Generated/wireguard.pb.swift
+++ b/Sources/ContainerBridge/Generated/wireguard.pb.swift
@@ -18,13 +18,13 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
 /// Request to check service readiness
-public struct Arca_Wireguard_V1_ReadyRequest: Sendable {
+public nonisolated struct Arca_Wireguard_V1_ReadyRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -35,7 +35,7 @@ public struct Arca_Wireguard_V1_ReadyRequest: Sendable {
 }
 
 /// Response indicating service readiness
-public struct Arca_Wireguard_V1_ReadyResponse: Sendable {
+public nonisolated struct Arca_Wireguard_V1_ReadyResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -55,7 +55,7 @@ public struct Arca_Wireguard_V1_ReadyResponse: Sendable {
 }
 
 /// Request to add a network to the container
-public struct Arca_Wireguard_V1_AddNetworkRequest: Sendable {
+public nonisolated struct Arca_Wireguard_V1_AddNetworkRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -104,7 +104,7 @@ public struct Arca_Wireguard_V1_AddNetworkRequest: Sendable {
   public init() {}
 }
 
-public struct Arca_Wireguard_V1_AddNetworkResponse: Sendable {
+public nonisolated struct Arca_Wireguard_V1_AddNetworkResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -137,7 +137,7 @@ public struct Arca_Wireguard_V1_AddNetworkResponse: Sendable {
 }
 
 /// Request to remove a network from the container
-public struct Arca_Wireguard_V1_RemoveNetworkRequest: Sendable {
+public nonisolated struct Arca_Wireguard_V1_RemoveNetworkRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -153,7 +153,7 @@ public struct Arca_Wireguard_V1_RemoveNetworkRequest: Sendable {
   public init() {}
 }
 
-public struct Arca_Wireguard_V1_RemoveNetworkResponse: Sendable {
+public nonisolated struct Arca_Wireguard_V1_RemoveNetworkResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -173,7 +173,7 @@ public struct Arca_Wireguard_V1_RemoveNetworkResponse: Sendable {
 }
 
 /// Request WireGuard status
-public struct Arca_Wireguard_V1_GetStatusRequest: Sendable {
+public nonisolated struct Arca_Wireguard_V1_GetStatusRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -183,7 +183,7 @@ public struct Arca_Wireguard_V1_GetStatusRequest: Sendable {
   public init() {}
 }
 
-public struct Arca_Wireguard_V1_GetStatusResponse: Sendable {
+public nonisolated struct Arca_Wireguard_V1_GetStatusResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -205,7 +205,7 @@ public struct Arca_Wireguard_V1_GetStatusResponse: Sendable {
   public init() {}
 }
 
-public struct Arca_Wireguard_V1_InterfaceStatus: Sendable {
+public nonisolated struct Arca_Wireguard_V1_InterfaceStatus: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -230,7 +230,7 @@ public struct Arca_Wireguard_V1_InterfaceStatus: Sendable {
   public init() {}
 }
 
-public struct Arca_Wireguard_V1_PeerStatus: Sendable {
+public nonisolated struct Arca_Wireguard_V1_PeerStatus: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -255,11 +255,11 @@ public struct Arca_Wireguard_V1_PeerStatus: Sendable {
 
   /// Transfer statistics
   public var stats: Arca_Wireguard_V1_TransferStats {
-    get {return _stats ?? Arca_Wireguard_V1_TransferStats()}
+    get {_stats ?? Arca_Wireguard_V1_TransferStats()}
     set {_stats = newValue}
   }
   /// Returns true if `stats` has been explicitly set.
-  public var hasStats: Bool {return self._stats != nil}
+  public var hasStats: Bool {self._stats != nil}
   /// Clears the value of `stats`. Subsequent reads from it will return its default value.
   public mutating func clearStats() {self._stats = nil}
 
@@ -270,7 +270,7 @@ public struct Arca_Wireguard_V1_PeerStatus: Sendable {
   fileprivate var _stats: Arca_Wireguard_V1_TransferStats? = nil
 }
 
-public struct Arca_Wireguard_V1_TransferStats: Sendable {
+public nonisolated struct Arca_Wireguard_V1_TransferStats: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -290,7 +290,7 @@ public struct Arca_Wireguard_V1_TransferStats: Sendable {
 }
 
 /// Request for vmnet endpoint information
-public struct Arca_Wireguard_V1_GetVmnetEndpointRequest: Sendable {
+public nonisolated struct Arca_Wireguard_V1_GetVmnetEndpointRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -300,7 +300,7 @@ public struct Arca_Wireguard_V1_GetVmnetEndpointRequest: Sendable {
   public init() {}
 }
 
-public struct Arca_Wireguard_V1_GetVmnetEndpointResponse: Sendable {
+public nonisolated struct Arca_Wireguard_V1_GetVmnetEndpointResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -320,7 +320,7 @@ public struct Arca_Wireguard_V1_GetVmnetEndpointResponse: Sendable {
 }
 
 /// Request to add a peer to a WireGuard interface
-public struct Arca_Wireguard_V1_AddPeerRequest: Sendable {
+public nonisolated struct Arca_Wireguard_V1_AddPeerRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -354,7 +354,7 @@ public struct Arca_Wireguard_V1_AddPeerRequest: Sendable {
   public init() {}
 }
 
-public struct Arca_Wireguard_V1_AddPeerResponse: Sendable {
+public nonisolated struct Arca_Wireguard_V1_AddPeerResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -374,7 +374,7 @@ public struct Arca_Wireguard_V1_AddPeerResponse: Sendable {
 }
 
 /// Request to remove a peer from a WireGuard interface
-public struct Arca_Wireguard_V1_RemovePeerRequest: Sendable {
+public nonisolated struct Arca_Wireguard_V1_RemovePeerRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -396,7 +396,7 @@ public struct Arca_Wireguard_V1_RemovePeerRequest: Sendable {
   public init() {}
 }
 
-public struct Arca_Wireguard_V1_RemovePeerResponse: Sendable {
+public nonisolated struct Arca_Wireguard_V1_RemovePeerResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -416,7 +416,7 @@ public struct Arca_Wireguard_V1_RemovePeerResponse: Sendable {
 }
 
 /// Request to publish a port (expose container port on host)
-public struct Arca_Wireguard_V1_PublishPortRequest: Sendable {
+public nonisolated struct Arca_Wireguard_V1_PublishPortRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -438,7 +438,7 @@ public struct Arca_Wireguard_V1_PublishPortRequest: Sendable {
   public init() {}
 }
 
-public struct Arca_Wireguard_V1_PublishPortResponse: Sendable {
+public nonisolated struct Arca_Wireguard_V1_PublishPortResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -455,7 +455,7 @@ public struct Arca_Wireguard_V1_PublishPortResponse: Sendable {
 }
 
 /// Request to unpublish a port (remove port exposure)
-public struct Arca_Wireguard_V1_UnpublishPortRequest: Sendable {
+public nonisolated struct Arca_Wireguard_V1_UnpublishPortRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -471,7 +471,7 @@ public struct Arca_Wireguard_V1_UnpublishPortRequest: Sendable {
   public init() {}
 }
 
-public struct Arca_Wireguard_V1_UnpublishPortResponse: Sendable {
+public nonisolated struct Arca_Wireguard_V1_UnpublishPortResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -488,7 +488,7 @@ public struct Arca_Wireguard_V1_UnpublishPortResponse: Sendable {
 }
 
 /// Request to dump nftables state for debugging
-public struct Arca_Wireguard_V1_DumpNftablesRequest: Sendable {
+public nonisolated struct Arca_Wireguard_V1_DumpNftablesRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -498,7 +498,7 @@ public struct Arca_Wireguard_V1_DumpNftablesRequest: Sendable {
   public init() {}
 }
 
-public struct Arca_Wireguard_V1_DumpNftablesResponse: Sendable {
+public nonisolated struct Arca_Wireguard_V1_DumpNftablesResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -520,9 +520,9 @@ public struct Arca_Wireguard_V1_DumpNftablesResponse: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "arca.wireguard.v1"
+fileprivate nonisolated let _protobuf_package = "arca.wireguard.v1"
 
-extension Arca_Wireguard_V1_ReadyRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Wireguard_V1_ReadyRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ReadyRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -541,7 +541,7 @@ extension Arca_Wireguard_V1_ReadyRequest: SwiftProtobuf.Message, SwiftProtobuf._
   }
 }
 
-extension Arca_Wireguard_V1_ReadyResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Wireguard_V1_ReadyResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ReadyResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}ready\0\u{1}version\0\u{3}uptime_ms\0")
 
@@ -581,7 +581,7 @@ extension Arca_Wireguard_V1_ReadyResponse: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Arca_Wireguard_V1_AddNetworkRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Wireguard_V1_AddNetworkRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AddNetworkRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}network_id\0\u{3}network_index\0\u{3}private_key\0\u{3}listen_port\0\u{3}peer_endpoint\0\u{3}peer_public_key\0\u{3}ip_address\0\u{3}network_cidr\0\u{1}gateway\0\u{3}host_ip\0\u{3}extra_hosts\0\u{3}container_id\0")
 
@@ -666,7 +666,7 @@ extension Arca_Wireguard_V1_AddNetworkRequest: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Arca_Wireguard_V1_AddNetworkResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Wireguard_V1_AddNetworkResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AddNetworkResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{1}error\0\u{3}total_networks\0\u{3}wg_interface\0\u{3}eth_interface\0\u{3}public_key\0\u{3}namespace_path\0")
 
@@ -726,7 +726,7 @@ extension Arca_Wireguard_V1_AddNetworkResponse: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Arca_Wireguard_V1_RemoveNetworkRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Wireguard_V1_RemoveNetworkRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".RemoveNetworkRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}network_id\0\u{3}network_index\0")
 
@@ -761,7 +761,7 @@ extension Arca_Wireguard_V1_RemoveNetworkRequest: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Arca_Wireguard_V1_RemoveNetworkResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Wireguard_V1_RemoveNetworkResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".RemoveNetworkResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{1}error\0\u{3}remaining_networks\0")
 
@@ -801,7 +801,7 @@ extension Arca_Wireguard_V1_RemoveNetworkResponse: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Arca_Wireguard_V1_GetStatusRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Wireguard_V1_GetStatusRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetStatusRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -820,7 +820,7 @@ extension Arca_Wireguard_V1_GetStatusRequest: SwiftProtobuf.Message, SwiftProtob
   }
 }
 
-extension Arca_Wireguard_V1_GetStatusResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Wireguard_V1_GetStatusResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetStatusResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}version\0\u{3}network_count\0\u{1}interfaces\0\u{1}peers\0")
 
@@ -865,7 +865,7 @@ extension Arca_Wireguard_V1_GetStatusResponse: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Arca_Wireguard_V1_InterfaceStatus: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Wireguard_V1_InterfaceStatus: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".InterfaceStatus"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}network_id\0\u{1}name\0\u{3}public_key\0\u{3}listen_port\0\u{3}ip_addresses\0")
 
@@ -915,7 +915,7 @@ extension Arca_Wireguard_V1_InterfaceStatus: SwiftProtobuf.Message, SwiftProtobu
   }
 }
 
-extension Arca_Wireguard_V1_PeerStatus: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Wireguard_V1_PeerStatus: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".PeerStatus"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}network_id\0\u{3}interface_name\0\u{3}public_key\0\u{1}endpoint\0\u{3}allowed_ips\0\u{3}latest_handshake\0\u{1}stats\0")
 
@@ -979,7 +979,7 @@ extension Arca_Wireguard_V1_PeerStatus: SwiftProtobuf.Message, SwiftProtobuf._Me
   }
 }
 
-extension Arca_Wireguard_V1_TransferStats: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Wireguard_V1_TransferStats: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".TransferStats"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}bytes_received\0\u{3}bytes_sent\0\u{3}persistent_keepalive\0")
 
@@ -1019,7 +1019,7 @@ extension Arca_Wireguard_V1_TransferStats: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Arca_Wireguard_V1_GetVmnetEndpointRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Wireguard_V1_GetVmnetEndpointRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetVmnetEndpointRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1038,7 +1038,7 @@ extension Arca_Wireguard_V1_GetVmnetEndpointRequest: SwiftProtobuf.Message, Swif
   }
 }
 
-extension Arca_Wireguard_V1_GetVmnetEndpointResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Wireguard_V1_GetVmnetEndpointResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetVmnetEndpointResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{1}error\0\u{1}endpoint\0")
 
@@ -1078,7 +1078,7 @@ extension Arca_Wireguard_V1_GetVmnetEndpointResponse: SwiftProtobuf.Message, Swi
   }
 }
 
-extension Arca_Wireguard_V1_AddPeerRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Wireguard_V1_AddPeerRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AddPeerRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}network_id\0\u{3}network_index\0\u{3}peer_public_key\0\u{3}peer_endpoint\0\u{3}peer_ip_address\0\u{3}peer_name\0\u{3}peer_container_id\0\u{3}peer_aliases\0")
 
@@ -1143,7 +1143,7 @@ extension Arca_Wireguard_V1_AddPeerRequest: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Arca_Wireguard_V1_AddPeerResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Wireguard_V1_AddPeerResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AddPeerResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{1}error\0\u{3}total_peers\0")
 
@@ -1183,7 +1183,7 @@ extension Arca_Wireguard_V1_AddPeerResponse: SwiftProtobuf.Message, SwiftProtobu
   }
 }
 
-extension Arca_Wireguard_V1_RemovePeerRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Wireguard_V1_RemovePeerRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".RemovePeerRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}network_id\0\u{3}network_index\0\u{3}peer_public_key\0\u{3}peer_name\0")
 
@@ -1228,7 +1228,7 @@ extension Arca_Wireguard_V1_RemovePeerRequest: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Arca_Wireguard_V1_RemovePeerResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Wireguard_V1_RemovePeerResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".RemovePeerResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{1}error\0\u{3}remaining_peers\0")
 
@@ -1268,7 +1268,7 @@ extension Arca_Wireguard_V1_RemovePeerResponse: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Arca_Wireguard_V1_PublishPortRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Wireguard_V1_PublishPortRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".PublishPortRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}protocol\0\u{3}host_port\0\u{3}container_ip\0\u{3}container_port\0")
 
@@ -1313,7 +1313,7 @@ extension Arca_Wireguard_V1_PublishPortRequest: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Arca_Wireguard_V1_PublishPortResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Wireguard_V1_PublishPortResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".PublishPortResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{1}error\0")
 
@@ -1348,7 +1348,7 @@ extension Arca_Wireguard_V1_PublishPortResponse: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Arca_Wireguard_V1_UnpublishPortRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Wireguard_V1_UnpublishPortRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".UnpublishPortRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}protocol\0\u{3}host_port\0")
 
@@ -1383,7 +1383,7 @@ extension Arca_Wireguard_V1_UnpublishPortRequest: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Arca_Wireguard_V1_UnpublishPortResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Wireguard_V1_UnpublishPortResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".UnpublishPortResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{1}error\0")
 
@@ -1418,7 +1418,7 @@ extension Arca_Wireguard_V1_UnpublishPortResponse: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Arca_Wireguard_V1_DumpNftablesRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Wireguard_V1_DumpNftablesRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".DumpNftablesRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1437,7 +1437,7 @@ extension Arca_Wireguard_V1_DumpNftablesRequest: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Arca_Wireguard_V1_DumpNftablesResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Wireguard_V1_DumpNftablesResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".DumpNftablesResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{1}error\0\u{1}ruleset\0")
 

--- a/Sources/ContainerBridge/Process/Generated/process.pb.swift
+++ b/Sources/ContainerBridge/Process/Generated/process.pb.swift
@@ -15,13 +15,13 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
 /// Request to check service readiness
-public struct Arca_Process_V1_ReadyRequest: Sendable {
+public nonisolated struct Arca_Process_V1_ReadyRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -32,7 +32,7 @@ public struct Arca_Process_V1_ReadyRequest: Sendable {
 }
 
 /// Response indicating service readiness
-public struct Arca_Process_V1_ReadyResponse: Sendable {
+public nonisolated struct Arca_Process_V1_ReadyResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -51,7 +51,7 @@ public struct Arca_Process_V1_ReadyResponse: Sendable {
   public init() {}
 }
 
-public struct Arca_Process_V1_StartProcessRequest: Sendable {
+public nonisolated struct Arca_Process_V1_StartProcessRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -61,7 +61,7 @@ public struct Arca_Process_V1_StartProcessRequest: Sendable {
   public init() {}
 }
 
-public struct Arca_Process_V1_StartProcessResponse: Sendable {
+public nonisolated struct Arca_Process_V1_StartProcessResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -80,7 +80,7 @@ public struct Arca_Process_V1_StartProcessResponse: Sendable {
   public init() {}
 }
 
-public struct Arca_Process_V1_GetProcessStatusRequest: Sendable {
+public nonisolated struct Arca_Process_V1_GetProcessStatusRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -90,7 +90,7 @@ public struct Arca_Process_V1_GetProcessStatusRequest: Sendable {
   public init() {}
 }
 
-public struct Arca_Process_V1_GetProcessStatusResponse: Sendable {
+public nonisolated struct Arca_Process_V1_GetProcessStatusResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -109,7 +109,7 @@ public struct Arca_Process_V1_GetProcessStatusResponse: Sendable {
   public init() {}
 }
 
-public struct Arca_Process_V1_ListProcessesRequest: Sendable {
+public nonisolated struct Arca_Process_V1_ListProcessesRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -123,7 +123,7 @@ public struct Arca_Process_V1_ListProcessesRequest: Sendable {
   public init() {}
 }
 
-public struct Arca_Process_V1_ListProcessesResponse: Sendable {
+public nonisolated struct Arca_Process_V1_ListProcessesResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -140,7 +140,7 @@ public struct Arca_Process_V1_ListProcessesResponse: Sendable {
   public init() {}
 }
 
-public struct Arca_Process_V1_ProcessInfo: Sendable {
+public nonisolated struct Arca_Process_V1_ProcessInfo: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -155,9 +155,9 @@ public struct Arca_Process_V1_ProcessInfo: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "arca.process.v1"
+fileprivate nonisolated let _protobuf_package = "arca.process.v1"
 
-extension Arca_Process_V1_ReadyRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Process_V1_ReadyRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ReadyRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -176,7 +176,7 @@ extension Arca_Process_V1_ReadyRequest: SwiftProtobuf.Message, SwiftProtobuf._Me
   }
 }
 
-extension Arca_Process_V1_ReadyResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Process_V1_ReadyResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ReadyResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}ready\0\u{1}version\0\u{3}uptime_ms\0")
 
@@ -216,7 +216,7 @@ extension Arca_Process_V1_ReadyResponse: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Arca_Process_V1_StartProcessRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Process_V1_StartProcessRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".StartProcessRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -235,7 +235,7 @@ extension Arca_Process_V1_StartProcessRequest: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Arca_Process_V1_StartProcessResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Process_V1_StartProcessResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".StartProcessResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{3}error_message\0\u{1}pid\0")
 
@@ -275,7 +275,7 @@ extension Arca_Process_V1_StartProcessResponse: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Arca_Process_V1_GetProcessStatusRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Process_V1_GetProcessStatusRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetProcessStatusRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -294,7 +294,7 @@ extension Arca_Process_V1_GetProcessStatusRequest: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Arca_Process_V1_GetProcessStatusResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Process_V1_GetProcessStatusResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GetProcessStatusResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}state\0\u{1}pid\0\u{3}exit_code\0")
 
@@ -334,7 +334,7 @@ extension Arca_Process_V1_GetProcessStatusResponse: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Arca_Process_V1_ListProcessesRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Process_V1_ListProcessesRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListProcessesRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}ps_args\0")
 
@@ -364,7 +364,7 @@ extension Arca_Process_V1_ListProcessesRequest: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Arca_Process_V1_ListProcessesResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Process_V1_ListProcessesResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListProcessesResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}titles\0\u{1}processes\0")
 
@@ -399,7 +399,7 @@ extension Arca_Process_V1_ListProcessesResponse: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Arca_Process_V1_ProcessInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Arca_Process_V1_ProcessInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ProcessInfo"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}values\0")
 


### PR DESCRIPTION
The generated Swift under `Sources/ContainerBridge/` had drifted from the protos it is generated from. Running `scripts/generate-grpc.sh` reproduces this diff exactly.

Found while wiring the engine codegen in #53, and deliberately kept out of that branch.

## Two kinds of drift, and the second is not cosmetic

| File | Change |
|---|---|
| `wireguard.pb.swift`, `process.pb.swift` | `nonisolated` annotations from `protoc-gen-swift` 1.38.1 — the committed output predates the installed plugin |
| `filesystem.pb.swift`, `filesystem.grpc.swift` | **four RPCs and eight message types that were never generated at all** — `StatPath`, `CreateVolumeOverlay`, `CreateDirectMount`, `GenerateHostsFile` |

The second is why this is a commit rather than a note. **A checked-in generated file that does not match its source is a trap with no warning on it**: the next person to run the generator gets an 867-line diff they did not cause and cannot easily attribute.

The new surface is client stubs with no callers, so nothing changes behaviour.

## Verified

| Check | Result |
|---|---|
| `swift build --target ContainerBridge` | **rc=0**, 0 errors |
| `swift build` (all targets) | **rc=0**, 0 errors, links `Arca` |
| Toolchain | `protoc` 35.1, `protoc-gen-swift` 1.38.1, `protoc-gen-grpc-swift` 1.27.0 |

## Scope

Swift only, deliberately. The same script also rewrites **six `.pb.go` files inside the `containerization` submodule**, which is a separate repository — changing those needs a commit there plus a gitlink bump here. Whether this script should be regenerating another repository's output at all is a real question this PR does not answer.

This does not disturb the `gascan-engine-proto-v1` pin, which is at `77b293e` and predates this commit.

## Merge method

Merge commit only. Never squash or rebase.