### PR TITLE
chore: stop generating the submodule's Go code from Arca's script

### DIFF
--- a/scripts/generate-grpc.sh
+++ b/scripts/generate-grpc.sh
@@ -46,7 +46,6 @@ fi
 # WireGuard Service
 # ============================================================================
 WG_PROTO="$ARCA_SERVICES_DIR/proto/wireguard/wireguard.proto"
-WG_GO_DIR="$ARCA_SERVICES_DIR/proto/wireguard"
 
 echo ""
 echo "→ Generating Swift code for WireGuard Service..."
@@ -60,25 +59,11 @@ else
     echo "  ⚠ Skipping - proto file not found: $WG_PROTO"
 fi
 
-echo ""
-echo "→ Generating Go code for WireGuard Service..."
-if [ -f "$WG_PROTO" ] && command -v protoc-gen-go &> /dev/null && command -v protoc-gen-go-grpc &> /dev/null; then
-    protoc "$WG_PROTO" \
-        --proto_path="$(dirname "$WG_PROTO")" \
-        --go_out="$WG_GO_DIR" \
-        --go_opt=paths=source_relative \
-        --go-grpc_out="$WG_GO_DIR" \
-        --go-grpc_opt=paths=source_relative
-    echo "  ✓ Generated Go code in $WG_GO_DIR"
-else
-    echo "  ⚠ Skipping - proto file or Go plugins not found"
-fi
 
 # ============================================================================
 # Filesystem Service
 # ============================================================================
 FS_PROTO="$ARCA_SERVICES_DIR/proto/filesystem/filesystem.proto"
-FS_GO_DIR="$ARCA_SERVICES_DIR/proto/filesystem"
 
 echo ""
 echo "→ Generating Swift code for Filesystem Service..."
@@ -92,25 +77,11 @@ else
     echo "  ⚠ Skipping - proto file not found: $FS_PROTO"
 fi
 
-echo ""
-echo "→ Generating Go code for Filesystem Service..."
-if [ -f "$FS_PROTO" ] && command -v protoc-gen-go &> /dev/null && command -v protoc-gen-go-grpc &> /dev/null; then
-    protoc "$FS_PROTO" \
-        --proto_path="$(dirname "$FS_PROTO")" \
-        --go_out="$FS_GO_DIR" \
-        --go_opt=paths=source_relative \
-        --go-grpc_out="$FS_GO_DIR" \
-        --go-grpc_opt=paths=source_relative
-    echo "  ✓ Generated Go code in $FS_GO_DIR"
-else
-    echo "  ⚠ Skipping - proto file or Go plugins not found"
-fi
 
 # ============================================================================
 # Process Service
 # ============================================================================
 PROC_PROTO="$ARCA_SERVICES_DIR/proto/process/process.proto"
-PROC_GO_DIR="$ARCA_SERVICES_DIR/proto/process"
 
 echo ""
 echo "→ Generating Swift code for Process Service..."
@@ -124,19 +95,6 @@ else
     echo "  ⚠ Skipping - proto file not found: $PROC_PROTO"
 fi
 
-echo ""
-echo "→ Generating Go code for Process Service..."
-if [ -f "$PROC_PROTO" ] && command -v protoc-gen-go &> /dev/null && command -v protoc-gen-go-grpc &> /dev/null; then
-    protoc "$PROC_PROTO" \
-        --proto_path="$(dirname "$PROC_PROTO")" \
-        --go_out="$PROC_GO_DIR" \
-        --go_opt=paths=source_relative \
-        --go-grpc_out="$PROC_GO_DIR" \
-        --go-grpc_opt=paths=source_relative
-    echo "  ✓ Generated Go code in $PROC_GO_DIR"
-else
-    echo "  ⚠ Skipping - proto file or Go plugins not found"
-fi
 
 # ============================================================================
 # Sandbox Engine Service — the published contract to Arca's consumers


### PR DESCRIPTION
`generate-grpc.sh` wrote Go into `containerization/vminitd/extensions/arca-services`, which belongs to a **different repository** (`Vas-Solutus/arca-containerization`).

That repository already regenerates its own Go as part of each proto change — see `4cc6163` *"Add GenerateHostsFile RPC"*, which lands the RPC and its generated Go together. So this script was redoing work its owner already does, and the only observable effect here was a dirty submodule someone had to notice and revert.

## Ownership now matches reality

| | Lives in | Generated by |
|---|---|---|
| the `.proto` files | arca-containerization | — |
| the `.pb.go` guest code | arca-containerization | its own repo (unchanged) |
| the `.swift` host code | Arca | this script |

## This does not fix the root cause, and the difference matters

The Swift went stale because **nothing in Arca runs when the submodule's protos move** — that is how `filesystem.{pb,grpc}.swift` came to be missing four RPCs until #54.

The remedy is a *"generated code is current"* check: run the generator, then `git diff --exit-code`. It is deliberately **not** added here, for the same reason the `buf breaking` check was not — Arca has no CI, so the check would be inert, and **an inert check is worse than a recorded one because it reads as coverage.** Booked against P2.3.

## Verified

| Check | Result |
|---|---|
| `shellcheck scripts/generate-grpc.sh` | clean |
| `./scripts/generate-grpc.sh` | **rc=0** |
| `git status --porcelain` | only this script |
| `git -C containerization status --porcelain` | **empty** |

That last row is the point. Before this change, the same command modified **four tracked Swift files and six `.pb.go` files across two repositories.**

## Merge method

Merge commit only. Never squash or rebase.