### PR TITLE
Add the Gas Can sandbox engine: ArcaEngine and the arca-engine executable

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4fecaade70bdb045659873fae138e820064d1349413fa6031d6c5aaa9884f022",
+  "originHash" : "3ff3ee24a0701550eafc9731c9b8fe4129a241ed0489e53031d2738e9f690a8a",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grpc/grpc-swift-2.git",
       "state" : {
-        "revision" : "28cdd63ef88583ddc67d7bb179eab46fab465ce9",
-        "version" : "2.4.2"
+        "revision" : "f28854bc760a116e053fdfc4a48a9428c34625c0",
+        "version" : "2.3.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -108,7 +108,10 @@ let package = Package(
 
         // Gas Can's sandbox engine. Deliberately does NOT depend on DockerAPI or
         // ArcaDaemon: Gas Can builds only the targets it ships, and that absent
-        // edge is asserted by gascan's tests/release/engine-targets-contract.sh.
+        // edge is asserted by gascan's tests/release/engine-targets-check.sh,
+        // which walks the closure of both this target and the arca-engine
+        // executable below -- the executable is what Gas Can actually ships, so
+        // checking only this one would leave the shipped binary uncovered.
         .target(
             name: "ArcaEngine",
             dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -92,6 +92,24 @@ let package = Package(
             ]
         ),
 
+        // Gas Can's sandbox engine. Deliberately does NOT depend on DockerAPI or
+        // ArcaDaemon: Gas Can builds only the targets it ships, and that absent
+        // edge is asserted by gascan's tests/release/engine-targets-contract.sh.
+        .target(
+            name: "ArcaEngine",
+            dependencies: [
+                "SandboxEngineProto",
+                "ContainerBridge",
+                .product(name: "GRPC", package: "grpc-swift"),
+                .product(name: "Logging", package: "swift-log"),
+            ]
+        ),
+
+        .testTarget(
+            name: "ArcaEngineTests",
+            dependencies: ["ArcaEngine"]
+        ),
+
         // Internal IPv4/CIDR types. Zero dependencies by design: this target
         // replaced swift-ip, whose transitive graph pinned commits that no
         // longer exist upstream and made the tree impossible to build cold.

--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,20 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.4"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
         .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.23.0"),
+        // grpc-swift-2 is reached only transitively, through the containerization
+        // submodule (containerization/Package.swift declares it `from: "2.3.0"`).
+        // It is constrained here, at the root, because 2.4.x declares `traits: []`
+        // on swift-protobuf, and swift-protobuf 1.32.0 declares no traits at all --
+        // a combination Swift 6.3.3 rejects outright:
+        //
+        //   error: Disabled default traits by package 'grpc-swift-2' on package
+        //   'swift-protobuf' that declares no traits.
+        //
+        // The failure only appears when building an EXECUTABLE PRODUCT from a clean
+        // checkout; building library targets resolves without it, which is why this
+        // stayed hidden until Gas Can's pinned build began producing a binary.
+        // Remove this constraint once swift-protobuf declares traits.
+        .package(url: "https://github.com/grpc/grpc-swift-2.git", "2.3.0" ..< "2.4.0"),
         .package(url: "https://github.com/stephencelis/SQLite.swift.git", from: "0.15.4"),
         .package(url: "https://github.com/tsolomko/SWCompression.git", from: "4.8.0"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -110,6 +110,18 @@ let package = Package(
             dependencies: ["ArcaEngine"]
         ),
 
+        // The `arca-engine` executable: binds SandboxEngineService to a Unix
+        // socket. Deliberately does NOT depend on DockerAPI or ArcaDaemon, for
+        // the same reason ArcaEngine itself does not.
+        .executableTarget(
+            name: "arca-engine",
+            dependencies: [
+                "ArcaEngine",
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "Logging", package: "swift-log"),
+            ]
+        ),
+
         // Internal IPv4/CIDR types. Zero dependencies by design: this target
         // replaced swift-ip, whose transitive graph pinned commits that no
         // longer exist upstream and made the tree impossible to build cold.

--- a/Sources/ArcaEngine/EngineErrors.swift
+++ b/Sources/ArcaEngine/EngineErrors.swift
@@ -1,0 +1,64 @@
+import SandboxEngineProto
+
+/// The generated message type is plain data with no `Error` conformance;
+/// this lets it stand as the failure side of a `Result` without hand-editing
+/// generated code.
+extension Arca_Engine_V1_EngineError: Swift.Error {}
+
+/// The engine's entire error vocabulary.
+///
+/// NOT open to extension. Gas Can maps these with a table rather than a
+/// judgment, "so a new engine failure mode cannot quietly become an existing
+/// one" (proto/arca/engine/v1/engine.proto:62-65), and its table
+/// (crates/gascan-arca/src/error.rs:20-55) accepts exactly these twelve --
+/// anything else arrives as invalid_output naming the offender. Two further
+/// codes are not an engine's to raise: injected_failure belongs to Gas Can's
+/// fake runtime, and unsupported_version is the consumer's own refusal.
+public enum EngineErrorCode: String, CaseIterable, Sendable {
+    case commandIo = "command_io"
+    case commandFailed = "command_failed"
+    case invalidOutput = "invalid_output"
+    case helperError = "helper_error"
+    case unsupportedCapability = "unsupported_capability"
+    case ownershipMismatch = "ownership_mismatch"
+    case foreignResourceRefused = "foreign_resource_refused"
+    case invalidResourceIdentity = "invalid_resource_identity"
+    case resourceConflict = "resource_conflict"
+    case notFound = "not_found"
+    case invalidState = "invalid_state"
+    case unknownActualState = "unknown_actual_state"
+}
+
+/// `resource` names the thing the failure is about and is empty when it is not
+/// about one; `message` is prose and is never parsed. They are not
+/// interchangeable: two codes carry both fields, so a transposition survives
+/// every assertion weaker than an exact string comparison.
+public func engineError(
+    _ code: EngineErrorCode,
+    resource: String = "",
+    message: String
+) -> Arca_Engine_V1_EngineError {
+    var error = Arca_Engine_V1_EngineError()
+    error.code = code.rawValue
+    error.resource = resource
+    error.message = message
+    return error
+}
+
+/// Runs `body`, converting any thrown error into an `EngineError`.
+///
+/// This exists because an uncaught throw in a grpc-swift provider method becomes
+/// a gRPC status, and status codes are reserved for transport faults and carry
+/// no engine semantics (engine.proto:52-58). A status where an outcome belongs
+/// is a contract violation, not an error path.
+public func engineErrorCatching<T>(
+    _ code: EngineErrorCode,
+    resource: String = "",
+    _ body: () async throws -> T
+) async -> Result<T, Arca_Engine_V1_EngineError> {
+    do {
+        return .success(try await body())
+    } catch {
+        return .failure(engineError(code, resource: resource, message: "\(error)"))
+    }
+}

--- a/Sources/ArcaEngine/EngineServer.swift
+++ b/Sources/ArcaEngine/EngineServer.swift
@@ -1,0 +1,60 @@
+import Foundation
+import GRPC
+import NIOCore
+import NIOPosix
+
+/// Binds the sandbox-engine service to a Unix domain socket.
+public struct EngineServer {
+    /// Starts the engine on `socketPath`.
+    ///
+    /// A stale socket left by a killed engine is removed first: bind fails with
+    /// EADDRINUSE against a file whose listener is gone, and an engine that
+    /// cannot restart after a crash is worse than one that reclaims its own
+    /// path. Only a socket is removed -- refusing to unlink a regular file
+    /// keeps a mistyped path from destroying data.
+    ///
+    /// The socket is chmodded to 0600 immediately after `bind` returns, because
+    /// the socket carries the engine's entire authority. `bind` itself returns
+    /// an already-listening server, so there is a brief window between the
+    /// listener accepting and the mode change landing -- this call does not
+    /// close that window. The real control is the containing directory: the
+    /// caller (the `arca-engine` executable) creates it mode 0700 before
+    /// calling this, so nothing other than the socket's owner can even reach
+    /// the path to connect during that window.
+    public static func start(
+        socketPath: String,
+        service: SandboxEngineService,
+        group: EventLoopGroup
+    ) async throws -> Server {
+        try removeStaleSocket(at: socketPath)
+        let server = try await Server.insecure(group: group)
+            .withServiceProviders([service])
+            .bind(unixDomainSocketPath: socketPath)
+            .get()
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: Int16(0o600))],
+            ofItemAtPath: socketPath
+        )
+        return server
+    }
+
+    private static func removeStaleSocket(at path: String) throws {
+        var status = stat()
+        guard lstat(path, &status) == 0 else { return }
+        guard (status.st_mode & S_IFMT) == S_IFSOCK else {
+            throw EngineServerError.pathIsNotASocket(path)
+        }
+        try FileManager.default.removeItem(atPath: path)
+    }
+}
+
+public enum EngineServerError: Error, CustomStringConvertible {
+    case pathIsNotASocket(String)
+
+    public var description: String {
+        switch self {
+        case .pathIsNotASocket(let path):
+            return "refusing to replace \(path): it exists and is not a socket"
+        }
+    }
+}

--- a/Sources/ArcaEngine/EngineServer.swift
+++ b/Sources/ArcaEngine/EngineServer.swift
@@ -2,16 +2,55 @@ import Foundation
 import GRPC
 import NIOCore
 import NIOPosix
+#if canImport(Darwin)
+import Darwin
+#endif
 
-/// Binds the sandbox-engine service to a Unix domain socket.
-public struct EngineServer {
+/// A bound engine, together with the two resources whose lifetime is the
+/// server's: the exclusive claim on the socket path, and the socket file.
+///
+/// These are one type rather than three because their correct lifetimes are
+/// identical, and separating them is how the two defects this replaces came
+/// about: nothing owned the socket file, so nothing unlinked it on the way out,
+/// and nothing owned the path, so a second engine could take it from a first.
+public struct EngineServer: Sendable {
+    /// The bound gRPC server. Exposed because callers install their own
+    /// shutdown trigger against it.
+    public let server: Server
+
+    private let socketPath: String
+    private let lock: SocketPathLock
+
+    /// Completes when the server has finished closing, however that was
+    /// initiated.
+    public var onClose: EventLoopFuture<Void> { server.onClose }
+
     /// Starts the engine on `socketPath`.
     ///
-    /// A stale socket left by a killed engine is removed first: bind fails with
-    /// EADDRINUSE against a file whose listener is gone, and an engine that
-    /// cannot restart after a crash is worse than one that reclaims its own
-    /// path. Only a socket is removed -- refusing to unlink a regular file
-    /// keeps a mistyped path from destroying data.
+    /// Claiming the path comes first and is the load-bearing step. An earlier
+    /// revision decided "stale" from the file's type alone -- `lstat`, check
+    /// `S_IFSOCK`, unlink -- which cannot distinguish a socket a dead engine
+    /// left behind from one a live engine is serving on. A second engine
+    /// started on the same path therefore unlinked the first's socket and bound
+    /// its own, with no error and no warning; the first stayed alive holding
+    /// its StateStore handle and (in later milestones) live VMs, listening on
+    /// an inode nothing could dial again.
+    ///
+    /// Two checks replace it, because neither covers the other's gap:
+    ///
+    /// - An exclusive `flock` on a lockfile beside the socket. The kernel drops
+    ///   it when the holder dies, so "can I take this lock" *is* "did the last
+    ///   engine survive", with no heuristic in between. It is also atomic, which
+    ///   closes the window between deciding to unlink and binding -- two engines
+    ///   racing from a cold start cannot both pass it.
+    /// - A `connect()` probe of the existing socket. The lock only knows about
+    ///   engines that take it; the probe answers for anything else listening
+    ///   there, which is what stops a mistyped path pointing at another
+    ///   program's live socket from being unlinked.
+    ///
+    /// Only after both agree the path is free is a leftover socket removed, and
+    /// only if it is a socket -- refusing to unlink a regular file keeps a
+    /// mistyped path from destroying data.
     ///
     /// The socket is chmodded to 0600 immediately after `bind` returns, because
     /// the socket carries the engine's entire authority. `bind` itself returns
@@ -25,17 +64,78 @@ public struct EngineServer {
         socketPath: String,
         service: SandboxEngineService,
         group: EventLoopGroup
-    ) async throws -> Server {
+    ) async throws -> EngineServer {
+        let lock = try SocketPathLock.acquire(forSocketAt: socketPath)
         try removeStaleSocket(at: socketPath)
-        let server = try await Server.insecure(group: group)
-            .withServiceProviders([service])
-            .bind(unixDomainSocketPath: socketPath)
-            .get()
-        try FileManager.default.setAttributes(
-            [.posixPermissions: NSNumber(value: Int16(0o600))],
-            ofItemAtPath: socketPath
-        )
-        return server
+
+        let server: Server
+        do {
+            server = try await Server.insecure(group: group)
+                .withServiceProviders([service])
+                .bind(unixDomainSocketPath: socketPath)
+                .get()
+        } catch {
+            try? lock.release()
+            throw error
+        }
+
+        do {
+            try FileManager.default.setAttributes(
+                [.posixPermissions: NSNumber(value: Int16(0o600))],
+                ofItemAtPath: socketPath
+            )
+        } catch {
+            // `bind` returned an already-accepting server. Leaving it up on a
+            // path whose mode is unknown is the one outcome worse than failing
+            // to start, so unwind it before reporting.
+            try? await server.close().get()
+            try? lock.release()
+            throw error
+        }
+
+        return EngineServer(server: server, socketPath: socketPath, lock: lock)
+    }
+
+    /// Closes the server, makes sure the socket is gone, and releases the path.
+    ///
+    /// MEASURED: closing the server already unlinks the socket file. A probe
+    /// that closed the server and then stat'd the path found it absent before
+    /// this method's own removal step ran. `removeOwnSocket()` is therefore a
+    /// backstop for a close that does not get that far, not the mechanism, and
+    /// no test can distinguish its presence from its absence. It is kept
+    /// because the socket carries the engine's authority and the alternative is
+    /// depending on an undocumented side effect of a dependency -- and it is
+    /// documented as redundant so nobody later reads it as the working part.
+    ///
+    /// The defect this method exists for was that nothing called any of this:
+    /// the process had no shutdown path, so the only way it ended was by being
+    /// killed, which runs no close and therefore no unlink.
+    ///
+    /// Removing the socket is this process's to do: it was created by `bind`,
+    /// and the lock proves no one else has claimed the path since.
+    ///
+    /// The lockfile itself is deliberately *not* unlinked. Removing it would
+    /// let a later engine create a fresh file at the same path while a holder
+    /// still has the old inode locked, and two engines would each believe they
+    /// held the path exclusively. An advisory lock is a property of an inode,
+    /// so the inode has to outlive every holder.
+    public func shutDown() async throws {
+        // Requesting the close is idempotent on purpose: a caller that already
+        // triggered a graceful shutdown and awaited `onClose` still calls this
+        // for the cleanup half, and `close()` on a closed channel reports
+        // `alreadyClosed`. The promise is dropped rather than inspected because
+        // it is not the postcondition -- `onClose` is, and it is awaited next.
+        server.close(promise: nil)
+        try await onClose.get()
+        try removeOwnSocket()
+        try lock.release()
+    }
+
+    private func removeOwnSocket() throws {
+        var status = stat()
+        guard lstat(socketPath, &status) == 0 else { return }
+        guard (status.st_mode & S_IFMT) == S_IFSOCK else { return }
+        try FileManager.default.removeItem(atPath: socketPath)
     }
 
     private static func removeStaleSocket(at path: String) throws {
@@ -44,17 +144,157 @@ public struct EngineServer {
         guard (status.st_mode & S_IFMT) == S_IFSOCK else {
             throw EngineServerError.pathIsNotASocket(path)
         }
+        guard try !hasALiveListener(at: path) else {
+            throw EngineServerError.pathHasALiveListener(path)
+        }
         try FileManager.default.removeItem(atPath: path)
+    }
+
+    /// Whether anything is accepting connections on `path`.
+    ///
+    /// The socket is non-blocking so a listener whose accept backlog is full
+    /// answers `EAGAIN` immediately rather than parking engine startup on a
+    /// `connect` that may never return. A full backlog means a live listener,
+    /// so it counts as one. `ECONNREFUSED` is the answer for a socket file
+    /// whose listener is gone -- the stale case -- and `ENOENT` means it was
+    /// removed between the `lstat` above and here, which is equally free.
+    static func hasALiveListener(at path: String) throws -> Bool {
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        try encode(path, into: &address)
+
+        let descriptor = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard descriptor >= 0 else {
+            throw EngineServerError.systemCallFailed(name: "socket", path: path, code: errno)
+        }
+        defer { close(descriptor) }
+
+        guard fcntl(descriptor, F_SETFL, O_NONBLOCK) == 0 else {
+            throw EngineServerError.systemCallFailed(name: "fcntl", path: path, code: errno)
+        }
+
+        let result = withUnsafePointer(to: &address) { addressPointer -> Int32 in
+            addressPointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                connect(descriptor, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        if result == 0 { return true }
+
+        switch errno {
+        case ECONNREFUSED, ENOENT:
+            return false
+        case EAGAIN, EINPROGRESS:
+            return true
+        default:
+            throw EngineServerError.systemCallFailed(name: "connect", path: path, code: errno)
+        }
+    }
+
+    /// Copies `path` into `sun_path`, refusing a path that does not fit.
+    ///
+    /// `sockaddr_un.sun_path` holds at most 103 usable bytes plus a terminator.
+    /// A longer path is rejected here rather than truncated: a truncated path
+    /// would make the probe answer about a *different* socket, which is the one
+    /// way this check could report "free" about a path that is held.
+    private static func encode(_ path: String, into address: inout sockaddr_un) throws {
+        let bytes = Array(path.utf8)
+        let capacity = MemoryLayout.size(ofValue: address.sun_path) - 1
+        guard bytes.count <= capacity else {
+            throw EngineServerError.socketPathTooLong(path, limit: capacity)
+        }
+        withUnsafeMutableBytes(of: &address.sun_path) { rawPath in
+            let base = rawPath.baseAddress!.assumingMemoryBound(to: CChar.self)
+            for (index, byte) in bytes.enumerated() {
+                base[index] = CChar(bitPattern: byte)
+            }
+            base[bytes.count] = 0
+        }
+    }
+}
+
+/// An exclusive advisory lock on a socket path, held through a lockfile beside
+/// it.
+///
+/// `@unchecked Sendable` because the descriptor and path are `let`s and the one
+/// mutable field is a released-once flag touched only by the single owner that
+/// `acquire` hands the lock to -- `EngineServer`, whose own shutdown is
+/// sequential. It is not a general-purpose concurrent lock handle.
+final class SocketPathLock: @unchecked Sendable {
+    private let descriptor: Int32
+    let path: String
+    private var released = false
+
+    private init(descriptor: Int32, path: String) {
+        self.descriptor = descriptor
+        self.path = path
+    }
+
+    /// Takes the lock for `socketPath`, or reports who holds it.
+    ///
+    /// The holder writes its pid into the file after locking, purely so the
+    /// refusal can name a process. Reading it on the failure path is racy and
+    /// diagnostic only -- the lock, not the contents, is what decides.
+    static func acquire(forSocketAt socketPath: String) throws -> SocketPathLock {
+        let path = socketPath + ".lock"
+        let descriptor = open(path, O_CREAT | O_RDWR | O_CLOEXEC, 0o600)
+        guard descriptor >= 0 else {
+            throw EngineServerError.systemCallFailed(name: "open", path: path, code: errno)
+        }
+
+        guard flock(descriptor, LOCK_EX | LOCK_NB) == 0 else {
+            let code = errno
+            close(descriptor)
+            guard code == EWOULDBLOCK else {
+                throw EngineServerError.systemCallFailed(name: "flock", path: path, code: code)
+            }
+            throw EngineServerError.pathIsHeldByALiveEngine(
+                socketPath,
+                holder: (try? String(contentsOfFile: path, encoding: .utf8))?
+                    .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            )
+        }
+
+        let lock = SocketPathLock(descriptor: descriptor, path: path)
+        ftruncate(descriptor, 0)
+        _ = "\(getpid())\n".withCString { pointer in
+            write(descriptor, pointer, strlen(pointer))
+        }
+        return lock
+    }
+
+    func release() throws {
+        guard !released else { return }
+        released = true
+        guard close(descriptor) == 0 else {
+            throw EngineServerError.systemCallFailed(name: "close", path: path, code: errno)
+        }
+    }
+
+    deinit {
+        if !released { close(descriptor) }
     }
 }
 
 public enum EngineServerError: Error, CustomStringConvertible {
     case pathIsNotASocket(String)
+    case pathIsHeldByALiveEngine(String, holder: String)
+    case pathHasALiveListener(String)
+    case socketPathTooLong(String, limit: Int)
+    case systemCallFailed(name: String, path: String, code: Int32)
 
     public var description: String {
         switch self {
         case .pathIsNotASocket(let path):
             return "refusing to replace \(path): it exists and is not a socket"
+        case .pathIsHeldByALiveEngine(let path, let holder):
+            let who = holder.isEmpty ? "another engine" : "the engine with pid \(holder)"
+            return "refusing to serve on \(path): \(who) already holds it"
+        case .pathHasALiveListener(let path):
+            return "refusing to replace \(path): something is listening on it"
+        case .socketPathTooLong(let path, let limit):
+            return "socket path \(path) exceeds the \(limit)-byte sockaddr_un limit"
+        case .systemCallFailed(let name, let path, let code):
+            return "\(name) failed on \(path): \(String(cString: strerror(code))) (errno \(code))"
         }
     }
 }

--- a/Sources/ArcaEngine/EngineTranslation.swift
+++ b/Sources/ArcaEngine/EngineTranslation.swift
@@ -18,3 +18,39 @@ public func engineVersion(from string: String) -> Arca_Engine_V1_Version? {
     version.patch = patch
     return version
 }
+
+/// Splits an exact digest reference into the two fields the contract carries.
+///
+/// A tag is not representable on the wire, so a reference that is not an exact
+/// digest has nothing to map to and is refused. The hex is bare and lowercase,
+/// exactly 64 characters, with no "sha256:" prefix (engine.proto:179-185).
+public func imageDigest(fromReference reference: String) -> Arca_Engine_V1_ImageDigest? {
+    guard let separator = reference.range(of: "@sha256:", options: .backwards) else { return nil }
+    let repository = String(reference[reference.startIndex..<separator.lowerBound])
+    let hex = String(reference[separator.upperBound...])
+    guard !repository.isEmpty, hex.count == 64,
+          hex.allSatisfy({ $0.isNumber || ("a"..."f").contains($0) })
+    else { return nil }
+    var digest = Arca_Engine_V1_ImageDigest()
+    digest.repository = repository
+    digest.sha256Hex = hex
+    return digest
+}
+
+/// Maps ContainerBridge's status string onto the contract's three states.
+///
+/// UNSPECIFIED for anything unrecognised rather than a guess: a paused or
+/// restarting sandbox is neither running nor stopped, and reporting it as
+/// either would have a reconciler act on a guess -- destroying live work if
+/// the guess were wrong. UNSPECIFIED reaches the consumer as a hard
+/// UnknownActualState error naming the state
+/// (crates/gascan-arca/src/translate.rs:399-409), which is the correct
+/// outcome here, not a defect to route around.
+public func sandboxState(fromStatus status: String) -> Arca_Engine_V1_SandboxState {
+    switch status {
+    case "created": return .creating
+    case "running": return .running
+    case "exited", "dead": return .stopped
+    default: return .unspecified
+    }
+}

--- a/Sources/ArcaEngine/EngineTranslation.swift
+++ b/Sources/ArcaEngine/EngineTranslation.swift
@@ -1,0 +1,20 @@
+import SandboxEngineProto
+
+/// Reads the leading `major.minor.patch` of a version string.
+///
+/// Returns nil rather than guessing: Gas Can refuses to drive an engine version
+/// it does not recognise (contract §9), and a version invented from an
+/// unparseable string would defeat that refusal by making every engine look
+/// recognisable.
+public func engineVersion(from string: String) -> Arca_Engine_V1_Version? {
+    let core = string.split(separator: "-", maxSplits: 1).first.map(String.init) ?? string
+    let parts = core.split(separator: ".", omittingEmptySubsequences: false)
+    guard parts.count == 3 else { return nil }
+    guard let major = UInt32(parts[0]), let minor = UInt32(parts[1]), let patch = UInt32(parts[2])
+    else { return nil }
+    var version = Arca_Engine_V1_Version()
+    version.major = major
+    version.minor = minor
+    version.patch = patch
+    return version
+}

--- a/Sources/ArcaEngine/EngineTranslation.swift
+++ b/Sources/ArcaEngine/EngineTranslation.swift
@@ -54,3 +54,41 @@ public func sandboxState(fromStatus status: String) -> Arca_Engine_V1_SandboxSta
     default: return .unspecified
     }
 }
+
+/// The container's resource name, as the contract requires it.
+///
+/// ContainerBridge reports Docker-style names with a leading slash
+/// (Sources/ContainerBridge/ContainerManager.swift:725), but the consumer
+/// compares a container resource's name against the bare sandbox id
+/// (crates/gascan-core/src/runtime.rs:829-832). Reporting the slashed form
+/// would make every owned container look unrelated to the sandbox that owns
+/// it, and drift detection would silently see nothing.
+///
+/// Falls back to the id when there is no name to strip, because an empty
+/// resource name fails the consumer's identity validation and would take the
+/// whole ListResources call down with it.
+public func containerResourceName(names: [String], id: String) -> String {
+    guard let first = names.first else { return id }
+    let stripped = first.hasPrefix("/") ? String(first.dropFirst()) : first
+    return stripped.isEmpty ? id : stripped
+}
+
+/// One resource on the way out.
+///
+/// `owner` stays unset when the engine holds no labels for the resource, which
+/// is how a consumer sees one it does not own (engine.proto:169-173).
+public func resourceMessage(
+    kind: Arca_Engine_V1_ResourceKind,
+    name: String,
+    labels: [String: String]
+) -> Arca_Engine_V1_Resource {
+    Arca_Engine_V1_Resource.with { resource in
+        resource.identity = Arca_Engine_V1_ResourceIdentity.with {
+            $0.kind = kind
+            $0.name = name
+        }
+        if let owner = SandboxIdentity.owner(from: labels) {
+            resource.owner = owner
+        }
+    }
+}

--- a/Sources/ArcaEngine/SandboxEngineService.swift
+++ b/Sources/ArcaEngine/SandboxEngineService.swift
@@ -85,11 +85,46 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
         await capabilities(request: request)
     }
 
+    /// See the note on the `create(request:)` overload above.
+    func inspect(request: Arca_Engine_V1_InspectRequest) async -> Arca_Engine_V1_InspectResponse {
+        let name = SandboxIdentity.containerName(forSandboxId: request.sandboxID)
+        let found = await engineErrorCatching(.commandIo, resource: name) {
+            try await self.containerManager.getContainer(id: name)
+        }
+        switch found {
+        case .failure(let error):
+            return Arca_Engine_V1_InspectResponse.with { $0.error = error }
+        case .success(nil):
+            return Arca_Engine_V1_InspectResponse.with { $0.absent = Arca_Engine_V1_Absent() }
+        case .success(.some(let container)):
+            guard let digest = imageDigest(fromReference: container.image) else {
+                return Arca_Engine_V1_InspectResponse.with {
+                    $0.error = engineError(
+                        .invalidOutput,
+                        resource: name,
+                        message: "container image \(container.image) is not an exact digest reference"
+                    )
+                }
+            }
+            return Arca_Engine_V1_InspectResponse.with { response in
+                response.sandbox = Arca_Engine_V1_Sandbox.with { sandbox in
+                    sandbox.sandboxID = request.sandboxID
+                    sandbox.image = digest
+                    sandbox.state = sandboxState(fromStatus: container.state.status)
+                    if let owner = SandboxIdentity.owner(from: container.config.labels) {
+                        sandbox.owner = owner
+                    }
+                    sandbox.ports = []
+                }
+            }
+        }
+    }
+
     public func inspect(
         request: Arca_Engine_V1_InspectRequest,
         context: GRPCAsyncServerCallContext
     ) async throws -> Arca_Engine_V1_InspectResponse {
-        Arca_Engine_V1_InspectResponse.with { $0.error = Self.notImplemented("Inspect") }
+        await inspect(request: request)
     }
 
     /// Test seam: grpc-swift's `GRPCAsyncServerCallContext` has no public

--- a/Sources/ArcaEngine/SandboxEngineService.swift
+++ b/Sources/ArcaEngine/SandboxEngineService.swift
@@ -1,0 +1,174 @@
+import ContainerBridge
+import GRPC
+import Logging
+import SandboxEngineProto
+
+/// Arca's implementation of the published sandbox-engine contract.
+///
+/// Each method is a thin seam: translate in, call ContainerBridge, translate
+/// out. Business logic belongs in ContainerBridge and mapping belongs in
+/// EngineTranslation, so that this file stays readable as a list of the
+/// contract's eleven methods.
+public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvider {
+    public let interceptors: Arca_Engine_V1_SandboxEngineServerInterceptorFactoryProtocol? = nil
+
+    let containerManager: ContainerManager
+    let volumeManager: VolumeManager
+    let networkManager: NetworkManager
+    let imageManager: ImageManager
+    let execManager: ExecManager
+    let logger: Logger
+
+    public init(
+        containerManager: ContainerManager,
+        volumeManager: VolumeManager,
+        networkManager: NetworkManager,
+        imageManager: ImageManager,
+        execManager: ExecManager,
+        logger: Logger
+    ) {
+        self.containerManager = containerManager
+        self.volumeManager = volumeManager
+        self.networkManager = networkManager
+        self.imageManager = imageManager
+        self.execManager = execManager
+        self.logger = logger
+    }
+
+    /// The stated answer for an operation this build does not implement.
+    ///
+    /// unsupported_capability rather than a gRPC status: a status would tell the
+    /// consumer the engine is unreachable, which is a different and more
+    /// alarming fact than "this build cannot do that".
+    static func notImplemented(_ rpc: String) -> Arca_Engine_V1_EngineError {
+        engineError(
+            .unsupportedCapability,
+            message: "\(rpc) is not implemented by this engine build"
+        )
+    }
+
+    public func capabilities(
+        request: Arca_Engine_V1_CapabilitiesRequest,
+        context: GRPCAsyncServerCallContext
+    ) async throws -> Arca_Engine_V1_CapabilitiesResponse {
+        Arca_Engine_V1_CapabilitiesResponse.with { $0.error = Self.notImplemented("Capabilities") }
+    }
+
+    public func inspect(
+        request: Arca_Engine_V1_InspectRequest,
+        context: GRPCAsyncServerCallContext
+    ) async throws -> Arca_Engine_V1_InspectResponse {
+        Arca_Engine_V1_InspectResponse.with { $0.error = Self.notImplemented("Inspect") }
+    }
+
+    /// Test seam: grpc-swift's `GRPCAsyncServerCallContext` has no public
+    /// initialiser reachable from outside the GRPC module (its
+    /// `init(headers:logger:contextProvider:)` is `internal`), so a test
+    /// target cannot construct one to drive the protocol method directly.
+    /// This overload carries the actual logic; the protocol-conforming
+    /// method below just forwards to it, which is safe because none of the
+    /// not-implemented bodies read the context.
+    func create(request: Arca_Engine_V1_CreateRequest) async -> Arca_Engine_V1_CreateResponse {
+        Arca_Engine_V1_CreateResponse.with {
+            $0.failed = Arca_Engine_V1_CreateFailed.with { $0.error = Self.notImplemented("Create") }
+        }
+    }
+
+    public func create(
+        request: Arca_Engine_V1_CreateRequest,
+        context: GRPCAsyncServerCallContext
+    ) async throws -> Arca_Engine_V1_CreateResponse {
+        await create(request: request)
+    }
+
+    /// See the note on the `create(request:)` overload above.
+    func prepareImage(request: Arca_Engine_V1_PrepareImageRequest) async -> Arca_Engine_V1_PrepareImageResponse {
+        Arca_Engine_V1_PrepareImageResponse.with { $0.error = Self.notImplemented("PrepareImage") }
+    }
+
+    public func prepareImage(
+        request: Arca_Engine_V1_PrepareImageRequest,
+        context: GRPCAsyncServerCallContext
+    ) async throws -> Arca_Engine_V1_PrepareImageResponse {
+        await prepareImage(request: request)
+    }
+
+    /// See the note on the `create(request:)` overload above.
+    func createContainer(request: Arca_Engine_V1_CreateContainerRequest) async -> Arca_Engine_V1_CreateResponse {
+        Arca_Engine_V1_CreateResponse.with {
+            $0.failed = Arca_Engine_V1_CreateFailed.with {
+                $0.error = Self.notImplemented("CreateContainer")
+            }
+        }
+    }
+
+    public func createContainer(
+        request: Arca_Engine_V1_CreateContainerRequest,
+        context: GRPCAsyncServerCallContext
+    ) async throws -> Arca_Engine_V1_CreateResponse {
+        await createContainer(request: request)
+    }
+
+    /// See the note on the `create(request:)` overload above.
+    func start(request: Arca_Engine_V1_StartRequest) async -> Arca_Engine_V1_AckResponse {
+        Arca_Engine_V1_AckResponse.with { $0.error = Self.notImplemented("Start") }
+    }
+
+    public func start(
+        request: Arca_Engine_V1_StartRequest,
+        context: GRPCAsyncServerCallContext
+    ) async throws -> Arca_Engine_V1_AckResponse {
+        await start(request: request)
+    }
+
+    /// See the note on the `create(request:)` overload above.
+    func stop(request: Arca_Engine_V1_StopRequest) async -> Arca_Engine_V1_AckResponse {
+        Arca_Engine_V1_AckResponse.with { $0.error = Self.notImplemented("Stop") }
+    }
+
+    public func stop(
+        request: Arca_Engine_V1_StopRequest,
+        context: GRPCAsyncServerCallContext
+    ) async throws -> Arca_Engine_V1_AckResponse {
+        await stop(request: request)
+    }
+
+    /// See the note on the `create(request:)` overload above.
+    func remove(request: Arca_Engine_V1_RemoveRequest) async -> Arca_Engine_V1_AckResponse {
+        Arca_Engine_V1_AckResponse.with { $0.error = Self.notImplemented("Remove") }
+    }
+
+    public func remove(
+        request: Arca_Engine_V1_RemoveRequest,
+        context: GRPCAsyncServerCallContext
+    ) async throws -> Arca_Engine_V1_AckResponse {
+        await remove(request: request)
+    }
+
+    public func exec(
+        requestStream: GRPCAsyncRequestStream<Arca_Engine_V1_ExecClientFrame>,
+        responseStream: GRPCAsyncResponseStreamWriter<Arca_Engine_V1_ExecServerFrame>,
+        context: GRPCAsyncServerCallContext
+    ) async throws {
+        try await responseStream.send(
+            Arca_Engine_V1_ExecServerFrame.with { $0.error = Self.notImplemented("Exec") }
+        )
+    }
+
+    public func logs(
+        request: Arca_Engine_V1_LogsRequest,
+        responseStream: GRPCAsyncResponseStreamWriter<Arca_Engine_V1_LogsChunk>,
+        context: GRPCAsyncServerCallContext
+    ) async throws {
+        try await responseStream.send(
+            Arca_Engine_V1_LogsChunk.with { $0.error = Self.notImplemented("Logs") }
+        )
+    }
+
+    public func listResources(
+        request: Arca_Engine_V1_ListResourcesRequest,
+        context: GRPCAsyncServerCallContext
+    ) async throws -> Arca_Engine_V1_ListResourcesResponse {
+        Arca_Engine_V1_ListResourcesResponse.with { $0.error = Self.notImplemented("ListResources") }
+    }
+}

--- a/Sources/ArcaEngine/SandboxEngineService.swift
+++ b/Sources/ArcaEngine/SandboxEngineService.swift
@@ -47,11 +47,42 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
         )
     }
 
+    /// See the note on the `create(request:)` overload above.
+    ///
+    /// Every capability flag reports what this build implements. Milestone 1
+    /// implements no create and no exec, so every feature flag is false and
+    /// offline is unverified; later milestones flip each flag as they earn
+    /// it. A flag that is true before its code exists induces a consumer to
+    /// send a request the engine cannot honour.
+    func capabilities(request: Arca_Engine_V1_CapabilitiesRequest) async -> Arca_Engine_V1_CapabilitiesResponse {
+        guard let version = engineVersion(from: ArcaVersion.version) else {
+            return Arca_Engine_V1_CapabilitiesResponse.with {
+                $0.error = engineError(
+                    .invalidOutput,
+                    message: "engine version \(ArcaVersion.version) is not a readable semantic version"
+                )
+            }
+        }
+        return Arca_Engine_V1_CapabilitiesResponse.with { response in
+            response.capabilities = Arca_Engine_V1_Capabilities.with { capabilities in
+                capabilities.engineVersion = version
+                capabilities.contractMinor = 0
+                capabilities.projectMount = false
+                capabilities.namedVolumes = false
+                capabilities.tty = false
+                capabilities.signals = false
+                capabilities.loopbackPublish = false
+                capabilities.resourceLimits = false
+                capabilities.offline = .unverified
+            }
+        }
+    }
+
     public func capabilities(
         request: Arca_Engine_V1_CapabilitiesRequest,
         context: GRPCAsyncServerCallContext
     ) async throws -> Arca_Engine_V1_CapabilitiesResponse {
-        Arca_Engine_V1_CapabilitiesResponse.with { $0.error = Self.notImplemented("Capabilities") }
+        await capabilities(request: request)
     }
 
     public func inspect(

--- a/Sources/ArcaEngine/SandboxEngineService.swift
+++ b/Sources/ArcaEngine/SandboxEngineService.swift
@@ -5,13 +5,30 @@ import SandboxEngineProto
 
 /// Arca's implementation of the published sandbox-engine contract.
 ///
-/// Each method is a thin seam: translate in, call ContainerBridge, translate
-/// out. Business logic belongs in ContainerBridge and mapping belongs in
-/// EngineTranslation, so that this file stays readable as a list of the
+/// Each method is intended as a thin seam: translate in, call ContainerBridge,
+/// translate out. Business logic belongs in ContainerBridge and mapping belongs
+/// in EngineTranslation, so that this file stays readable as a list of the
 /// contract's eleven methods.
+///
+/// **In this build, one of the eleven is implemented: `Capabilities`.** The
+/// other ten answer `unsupported_capability` inside their response `oneof`.
+/// `Inspect` and `ListResources` joined that list deliberately rather than by
+/// omission -- see the note on each -- because this process does not call
+/// `initialize()` on any manager, and an uninitialised manager does not report
+/// "I cannot tell", it reports "nothing exists".
 public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvider {
     public let interceptors: Arca_Engine_V1_SandboxEngineServerInterceptorFactoryProtocol? = nil
 
+    // Held and, in this build, unread. Deliberate on both counts.
+    //
+    // Unread because the only two methods that consulted them could not report
+    // anything true without loaded state. Held because the dependency edge is
+    // itself a shipped property: gascan's tests/release/engine-targets-check.sh
+    // asserts that `arca-engine` and `ArcaEngine` reach neither `DockerAPI` nor
+    // `ArcaDaemon`, and that assertion measures something only while this
+    // target genuinely depends on ContainerBridge. Dropping these five to
+    // silence an unused-property reading would make the release gate pass for a
+    // reason that has nothing to do with what it exists to prove.
     let containerManager: ContainerManager
     let volumeManager: VolumeManager
     let networkManager: NetworkManager
@@ -86,38 +103,28 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
     }
 
     /// See the note on the `create(request:)` overload above.
+    ///
+    /// Unimplemented in this build, and that is a deliberate reversal.
+    ///
+    /// An earlier revision answered from `ContainerManager`. Because this
+    /// process never calls `ContainerManager.initialize()` -- see the reasoning
+    /// in `arca-engine`'s `ArcaEngineCommand.run()` -- the only two writers of
+    /// `ContainerManager.containers` never run, so that implementation could
+    /// return exactly one answer: `absent`. `engine.proto`'s `InspectResponse`
+    /// has three arms specifically so that "it is not there" stays
+    /// distinguishable from "I could not tell", and those "demand opposite
+    /// behaviour from a reconciler": on `absent` a consumer creates the
+    /// sandbox. An engine that answers `absent` for a sandbox that is running
+    /// induces a duplicate.
+    ///
+    /// `unsupported_capability` is the honest answer for a build that holds no
+    /// loaded state. It costs the consumer nothing it was getting -- the
+    /// previous answer carried no information -- and it cannot be mistaken for
+    /// an observation. The milestone that loads persisted state restores this
+    /// method along with the `Sandbox` translation in `EngineTranslation`,
+    /// which stays in the target, tested, for that purpose.
     func inspect(request: Arca_Engine_V1_InspectRequest) async -> Arca_Engine_V1_InspectResponse {
-        let name = SandboxIdentity.containerName(forSandboxId: request.sandboxID)
-        let found = await engineErrorCatching(.commandIo, resource: name) {
-            try await self.containerManager.getContainer(id: name)
-        }
-        switch found {
-        case .failure(let error):
-            return Arca_Engine_V1_InspectResponse.with { $0.error = error }
-        case .success(nil):
-            return Arca_Engine_V1_InspectResponse.with { $0.absent = Arca_Engine_V1_Absent() }
-        case .success(.some(let container)):
-            guard let digest = imageDigest(fromReference: container.image) else {
-                return Arca_Engine_V1_InspectResponse.with {
-                    $0.error = engineError(
-                        .invalidOutput,
-                        resource: name,
-                        message: "container image \(container.image) is not an exact digest reference"
-                    )
-                }
-            }
-            return Arca_Engine_V1_InspectResponse.with { response in
-                response.sandbox = Arca_Engine_V1_Sandbox.with { sandbox in
-                    sandbox.sandboxID = request.sandboxID
-                    sandbox.image = digest
-                    sandbox.state = sandboxState(fromStatus: container.state.status)
-                    if let owner = SandboxIdentity.owner(from: container.config.labels) {
-                        sandbox.owner = owner
-                    }
-                    sandbox.ports = []
-                }
-            }
-        }
+        Arca_Engine_V1_InspectResponse.with { $0.error = Self.notImplemented("Inspect") }
     }
 
     public func inspect(
@@ -233,42 +240,28 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
 
     /// See the note on the `create(request:)` overload above.
     ///
-    /// Unlabelled resources are reported, never filtered: a resource the
-    /// engine holds no labels for is exactly what a consumer needs to see to
-    /// notice drift, and hiding it here would defeat that silently
-    /// (engine.proto:389-391).
+    /// Unimplemented in this build, for the same reason as `inspect` and with a
+    /// sharper edge.
+    ///
+    /// `engine.proto`'s contract for this method is "Every resource the engine
+    /// holds, labelled or not", because a consumer's drift and leak detection
+    /// depends on seeing the unlabelled ones. An earlier revision walked
+    /// `ContainerManager`, `VolumeManager` and `NetworkManager`; without
+    /// `initialize()` all three are permanently empty -- containers and volumes
+    /// have no loaded rows, and `NetworkManager.listNetworks()` reads two
+    /// backends that are both nil -- so it returned `[]` under every input. An
+    /// empty `ResourceList` is not an error arm: it is a confident report of a
+    /// clean host, which is precisely the report that hides a leak.
+    ///
+    /// Two further defects sat behind that emptiness and would have surfaced
+    /// the moment state was loaded: `listContainers(all: true)` with no filters
+    /// drops every container labelled `com.arca.internal=true`, and
+    /// `NetworkManager.listNetworks()` swallows a WireGuard-backend failure
+    /// with `try?`, turning a real failure into a clean answer. Both must be
+    /// fixed in `ContainerBridge` before this method reports anything; a
+    /// silently incomplete list is worse than no list.
     func listResources(request: Arca_Engine_V1_ListResourcesRequest) async -> Arca_Engine_V1_ListResourcesResponse {
-        let collected = await engineErrorCatching(.commandIo) {
-            var resources: [Arca_Engine_V1_Resource] = []
-            for container in try await self.containerManager.listContainers(all: true) {
-                resources.append(
-                    resourceMessage(
-                        kind: .container,
-                        name: containerResourceName(names: container.names, id: container.id),
-                        labels: container.labels
-                    )
-                )
-            }
-            for volume in try await self.volumeManager.listVolumes() {
-                resources.append(
-                    resourceMessage(kind: .volume, name: volume.name, labels: volume.labels)
-                )
-            }
-            for network in await self.networkManager.listNetworks() {
-                resources.append(
-                    resourceMessage(kind: .network, name: network.name, labels: network.labels)
-                )
-            }
-            return resources
-        }
-        switch collected {
-        case .failure(let error):
-            return Arca_Engine_V1_ListResourcesResponse.with { $0.error = error }
-        case .success(let resources):
-            return Arca_Engine_V1_ListResourcesResponse.with { response in
-                response.resources = Arca_Engine_V1_ResourceList.with { $0.resources = resources }
-            }
-        }
+        Arca_Engine_V1_ListResourcesResponse.with { $0.error = Self.notImplemented("ListResources") }
     }
 
     public func listResources(

--- a/Sources/ArcaEngine/SandboxEngineService.swift
+++ b/Sources/ArcaEngine/SandboxEngineService.swift
@@ -231,10 +231,50 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
         )
     }
 
+    /// See the note on the `create(request:)` overload above.
+    ///
+    /// Unlabelled resources are reported, never filtered: a resource the
+    /// engine holds no labels for is exactly what a consumer needs to see to
+    /// notice drift, and hiding it here would defeat that silently
+    /// (engine.proto:389-391).
+    func listResources(request: Arca_Engine_V1_ListResourcesRequest) async -> Arca_Engine_V1_ListResourcesResponse {
+        let collected = await engineErrorCatching(.commandIo) {
+            var resources: [Arca_Engine_V1_Resource] = []
+            for container in try await self.containerManager.listContainers(all: true) {
+                resources.append(
+                    resourceMessage(
+                        kind: .container,
+                        name: containerResourceName(names: container.names, id: container.id),
+                        labels: container.labels
+                    )
+                )
+            }
+            for volume in try await self.volumeManager.listVolumes() {
+                resources.append(
+                    resourceMessage(kind: .volume, name: volume.name, labels: volume.labels)
+                )
+            }
+            for network in await self.networkManager.listNetworks() {
+                resources.append(
+                    resourceMessage(kind: .network, name: network.name, labels: network.labels)
+                )
+            }
+            return resources
+        }
+        switch collected {
+        case .failure(let error):
+            return Arca_Engine_V1_ListResourcesResponse.with { $0.error = error }
+        case .success(let resources):
+            return Arca_Engine_V1_ListResourcesResponse.with { response in
+                response.resources = Arca_Engine_V1_ResourceList.with { $0.resources = resources }
+            }
+        }
+    }
+
     public func listResources(
         request: Arca_Engine_V1_ListResourcesRequest,
         context: GRPCAsyncServerCallContext
     ) async throws -> Arca_Engine_V1_ListResourcesResponse {
-        Arca_Engine_V1_ListResourcesResponse.with { $0.error = Self.notImplemented("ListResources") }
+        await listResources(request: request)
     }
 }

--- a/Sources/ArcaEngine/SandboxIdentity.swift
+++ b/Sources/ArcaEngine/SandboxIdentity.swift
@@ -1,0 +1,41 @@
+import SandboxEngineProto
+
+/// The naming and labelling rules, in one place because Gas Can validates them
+/// exactly and a divergence fails every create rather than degrading.
+public enum SandboxIdentity {
+    public static let managedByLabelKey = "dev.gascan.managed-by"
+    public static let sandboxIdLabelKey = "dev.gascan.sandbox-id"
+
+    /// The container's name is the sandbox id, unchanged.
+    ///
+    /// gascan's validator builds the expected container identity as the
+    /// request's id (crates/gascan-core/src/runtime.rs:829-832). A prefix, a
+    /// suffix, or a normalisation makes every create fail client-side.
+    ///
+    /// Safe because ContainerBridge applies no container-name grammar
+    /// validation, and because a sandbox id always contains a hyphen -- which
+    /// keeps resolveContainerID from reading it as a hex short ID
+    /// (Sources/ContainerBridge/ContainerManager.swift:1930-1934).
+    public static func containerName(forSandboxId id: String) -> String { id }
+
+    /// Stored verbatim, echoed back, never interpreted. Deciding whether a
+    /// labelled resource is yours is the consumer's judgment
+    /// (engine.proto:144-148).
+    public static func labels(from owner: Arca_Engine_V1_OwnerLabels) -> [String: String] {
+        [managedByLabelKey: owner.managedBy, sandboxIdLabelKey: owner.sandboxID]
+    }
+
+    /// nil when the engine holds no labels for a resource, which is how a
+    /// consumer sees one it does not own. Both keys are required: a half
+    /// labelled resource would otherwise be reported claiming an empty
+    /// managed_by, which gascan's classifier would have to interpret.
+    public static func owner(from labels: [String: String]) -> Arca_Engine_V1_OwnerLabels? {
+        guard let managedBy = labels[managedByLabelKey],
+              let sandboxId = labels[sandboxIdLabelKey]
+        else { return nil }
+        var owner = Arca_Engine_V1_OwnerLabels()
+        owner.managedBy = managedBy
+        owner.sandboxID = sandboxId
+        return owner
+    }
+}

--- a/Sources/arca-engine/ArcaEngineCommand.swift
+++ b/Sources/arca-engine/ArcaEngineCommand.swift
@@ -35,23 +35,44 @@ struct ArcaEngineCommand: AsyncParsableCommand {
 
         let root = URL(fileURLWithPath: stateRoot)
 
-        // This milestone implements only Capabilities, Inspect, and
-        // ListResources -- none of which starts a VM -- so ContainerManager's
-        // initialize() is deliberately never called here. initialize()
-        // requires the kernel file to exist on disk, an "arca-vminit:latest"
-        // image already loaded by ArcaDaemon, and a live
-        // Containerization.VmnetNetwork (Sources/ContainerBridge/
-        // ContainerManager.swift:213-258); requiring all three would make this
-        // engine refuse to start anywhere a kernel or vminit image is absent,
-        // which defeats the point of this milestone -- a Rust client dialling
-        // a real, running engine. A later milestone that implements
-        // VM-starting RPCs will call initialize() here, gated by a
-        // --kernel-path option.
+        // initialize() is deliberately never called on any manager here, and
+        // the reason it cannot be is worth stating in full, because it decides
+        // which RPCs this build may implement.
         //
-        // Consequence: without initialize(), the engine reports only its
-        // in-memory view. It does not load or reconcile containers persisted
-        // by a previous run, so a restarted engine reports zero containers
-        // even if StateStore's database still has rows for them.
+        // ContainerManager.initialize() requires the kernel file to exist on
+        // disk, an "arca-vminit:latest" image already loaded by ArcaDaemon, and
+        // a live Containerization.VmnetNetwork (ContainerManager.swift:219-244).
+        // Requiring all three would make this engine refuse to start anywhere a
+        // kernel or vminit image is absent, which defeats the point of this
+        // milestone -- a Rust client dialling a real, running engine.
+        //
+        // Its second half is not merely unavailable, it is unsafe here.
+        // loadPersistedState() marks every container whose persisted status is
+        // "running" as exited with code 137 and writes that back to the
+        // StateStore (ContainerManager.swift:316-338). Against a --state-root
+        // that a live ArcaDaemon is also using -- ~/.arca being the natural
+        // choice -- this engine would declare the daemon's running containers
+        // dead. NetworkManager.initialize() is likewise a mutation: it ends in
+        // createDefaultNetworks(), which creates "bridge", "host" (vmnet
+        // driver) and "none" (NetworkManager.swift:87-88).
+        //
+        // The consequence is total, not restart-scoped, and not confined to
+        // containers. The only two writers of ContainerManager.containers are
+        // initialize()'s restore loop and createContainer, which this build
+        // answers unsupported_capability; VolumeManager.volumes is loaded only
+        // from initialize(); NetworkManager.listNetworks() reads two backends
+        // that initialize() is the sole populator of. All three are empty for
+        // the life of the process, under every input.
+        //
+        // So Inspect and ListResources answer unsupported_capability rather
+        // than "absent" and "nothing here" -- see the notes on each in
+        // SandboxEngineService. A later milestone gives ContainerBridge a
+        // read-only load path that neither starts a VM nor writes, calls it
+        // here behind a --kernel-path option, and restores both methods.
+        //
+        // The managers are still constructed and handed to the service: the
+        // dependency edge they create is a property gascan's release gate
+        // measures. See the note on SandboxEngineService's stored properties.
         let stateStore = try StateStore(
             path: root.appendingPathComponent("state.db").path,
             logger: logger
@@ -91,13 +112,95 @@ struct ArcaEngineCommand: AsyncParsableCommand {
         )
 
         let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-        let server = try await EngineServer.start(
+        try await serve(service: service, group: group, logger: logger)
+        try await group.shutdownGracefully()
+        logger.info("engine stopped", metadata: ["socket": "\(socketPath)"])
+    }
+
+    /// Runs the engine until it closes, and holds every object that references
+    /// an event loop.
+    ///
+    /// **This is a separate function so that those objects are released before
+    /// `run()` shuts the group down. Inlining it reintroduces a crash.**
+    /// MEASURED: with the server still live at group-shutdown time, the process
+    /// printed `ERROR: Cannot schedule tasks on an EventLoop that has already
+    /// shut down` on every run, and under `SWIFTNIO_STRICT=1` the same runs
+    /// died with `SelectableEventLoop.swift:483: Fatal error` and exit 133 --
+    /// NIO's own note says the error becomes a forced crash in a future
+    /// version. It was not a race: a run that slept 1.5s after the group
+    /// shutdown logged, survived the sleep, and then crashed on the way out of
+    /// `run()`, which is where the server was being deallocated. Scoping it
+    /// here so it is released first gives exit 0 with no diagnostic, verified
+    /// under `SWIFTNIO_STRICT=1`.
+    ///
+    /// The order matters and the alternatives do not help: awaiting the
+    /// teardown inside a `Task.detached`, dropping the redundant close, and
+    /// swapping the async `shutdownGracefully()` for a blocking
+    /// `syncShutdownGracefully()` on a Dispatch thread were each measured and
+    /// each still crashed.
+    private func serve(
+        service: SandboxEngineService,
+        group: MultiThreadedEventLoopGroup,
+        logger: Logger
+    ) async throws {
+        let engine = try await EngineServer.start(
             socketPath: socketPath,
             service: service,
             group: group
         )
         logger.info("engine listening", metadata: ["socket": "\(socketPath)"])
-        try await server.onClose.get()
+
+        // Held for the whole run: a DispatchSourceSignal stops delivering the
+        // moment it is deallocated, so a source that is not kept alive is a
+        // handler that silently never fires. Cancelling them here also drops
+        // the last references these closures hold to the engine.
+        let signals = Self.installShutdownHandler(logger: logger, for: engine)
+        defer { signals.forEach { $0.cancel() } }
+
+        try await engine.onClose.get()
+        try await engine.shutDown()
+    }
+
+    /// Turns SIGTERM and SIGINT into a graceful close, and a repeat of either
+    /// into an immediate one.
+    ///
+    /// Without this the process had no shutdown path at all: nothing closed the
+    /// server, nothing shut the event-loop group down, and nothing unlinked the
+    /// socket, so the only way it ended was by being killed -- which runs no
+    /// cleanup and leaves behind exactly the ambiguous socket file that
+    /// `EngineServer.start` then has to reason about.
+    ///
+    /// Each signal is set to `SIG_IGN` first. A `DispatchSourceSignal` observes
+    /// delivery, it does not replace the disposition, so leaving the default in
+    /// place would terminate the process before the handler ever ran.
+    ///
+    /// The escalation matters because a graceful shutdown waits for in-flight
+    /// RPCs, and a client holding a stream open can hold the engine open with
+    /// it. Without a second signal that forces the issue, "handles SIGTERM"
+    /// would be true and "can be stopped" would not.
+    private static func installShutdownHandler(
+        logger: Logger,
+        for engine: EngineServer
+    ) -> [DispatchSourceSignal] {
+        // One serial queue shared by both sources, so the two handlers can
+        // never run concurrently and `asked` needs no lock of its own.
+        let queue = DispatchQueue(label: "arca-engine.shutdown")
+        let asked = ShutdownRequests()
+        return [SIGTERM, SIGINT].map { number in
+            signal(number, SIG_IGN)
+            let source = DispatchSource.makeSignalSource(signal: number, queue: queue)
+            source.setEventHandler {
+                if asked.recordAndReportFirst() {
+                    logger.info("shutting down gracefully", metadata: ["signal": "\(number)"])
+                    engine.server.initiateGracefulShutdown(promise: nil)
+                } else {
+                    logger.notice("closing immediately", metadata: ["signal": "\(number)"])
+                    engine.server.close(promise: nil)
+                }
+            }
+            source.resume()
+            return source
+        }
     }
 
     /// Creates the socket's parent directory mode 0700 if it does not already
@@ -112,5 +215,20 @@ struct ArcaEngineCommand: AsyncParsableCommand {
             withIntermediateDirectories: true,
             attributes: [.posixPermissions: NSNumber(value: Int16(0o700))]
         )
+    }
+}
+
+/// Counts shutdown signals.
+///
+/// `@unchecked Sendable` because every access happens on the one serial queue
+/// `installShutdownHandler` gives both of its signal sources; it carries no
+/// synchronisation of its own and must not be used anywhere else.
+private final class ShutdownRequests: @unchecked Sendable {
+    private var seen = 0
+
+    /// Records a request and answers whether it was the first.
+    func recordAndReportFirst() -> Bool {
+        seen += 1
+        return seen == 1
     }
 }

--- a/Sources/arca-engine/ArcaEngineCommand.swift
+++ b/Sources/arca-engine/ArcaEngineCommand.swift
@@ -1,0 +1,116 @@
+import ArcaEngine
+import ArgumentParser
+import ContainerBridge
+import Foundation
+import Logging
+import NIOCore
+import NIOPosix
+
+@main
+struct ArcaEngineCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "arca-engine",
+        abstract: "Serves the arca.engine.v1 sandbox-engine contract over a Unix socket."
+    )
+
+    @Option(name: .customLong("socket-path"), help: "Path of the Unix socket to serve on.")
+    var socketPath: String
+
+    @Option(name: .customLong("state-root"), help: "Directory holding engine state.")
+    var stateRoot: String
+
+    @Option(name: .customLong("log-level"), help: "trace, debug, info, notice, warning, error.")
+    var logLevel: String = "info"
+
+    func run() async throws {
+        var logger = Logger(label: "arca-engine")
+        logger.logLevel = Logger.Level(rawValue: logLevel) ?? .info
+
+        // The socket's mode is set to 0600 immediately after bind (EngineServer),
+        // but bind returns an already-listening server, so there is a brief
+        // window before that lands. The containing directory is the real
+        // control for that window: nothing other than its owner can reach the
+        // path to connect if the directory itself is 0700.
+        try createSocketParentDirectory(for: socketPath)
+
+        let root = URL(fileURLWithPath: stateRoot)
+
+        // This milestone implements only Capabilities, Inspect, and
+        // ListResources -- none of which starts a VM -- so ContainerManager's
+        // initialize() is deliberately never called here. initialize()
+        // requires the kernel file to exist on disk, an "arca-vminit:latest"
+        // image already loaded by ArcaDaemon, and a live
+        // Containerization.VmnetNetwork (Sources/ContainerBridge/
+        // ContainerManager.swift:213-258); requiring all three would make this
+        // engine refuse to start anywhere a kernel or vminit image is absent,
+        // which defeats the point of this milestone -- a Rust client dialling
+        // a real, running engine. A later milestone that implements
+        // VM-starting RPCs will call initialize() here, gated by a
+        // --kernel-path option.
+        //
+        // Consequence: without initialize(), the engine reports only its
+        // in-memory view. It does not load or reconcile containers persisted
+        // by a previous run, so a restarted engine reports zero containers
+        // even if StateStore's database still has rows for them.
+        let stateStore = try StateStore(
+            path: root.appendingPathComponent("state.db").path,
+            logger: logger
+        )
+        let imageManager = try ImageManager(
+            logger: logger,
+            imageStorePath: root.appendingPathComponent("images")
+        )
+        let containerManager = ContainerManager(
+            imageManager: imageManager,
+            kernelPath: root.appendingPathComponent("vmlinux").path,
+            stateStore: stateStore,
+            logger: logger
+        )
+        let config = ArcaConfig(
+            kernelPath: root.appendingPathComponent("vmlinux").path,
+            socketPath: root.appendingPathComponent("arca.sock").path,
+            logLevel: logLevel
+        )
+
+        let service = SandboxEngineService(
+            containerManager: containerManager,
+            volumeManager: VolumeManager(
+                volumesBasePath: root.appendingPathComponent("volumes").path,
+                stateStore: stateStore,
+                logger: logger
+            ),
+            networkManager: NetworkManager(
+                config: config,
+                stateStore: stateStore,
+                containerManager: containerManager,
+                logger: logger
+            ),
+            imageManager: imageManager,
+            execManager: ExecManager(containerManager: containerManager, logger: logger),
+            logger: logger
+        )
+
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        let server = try await EngineServer.start(
+            socketPath: socketPath,
+            service: service,
+            group: group
+        )
+        logger.info("engine listening", metadata: ["socket": "\(socketPath)"])
+        try await server.onClose.get()
+    }
+
+    /// Creates the socket's parent directory mode 0700 if it does not already
+    /// exist. Existing directories are left with whatever mode they already
+    /// have -- this only strengthens a fresh directory, it does not tighten
+    /// one the caller chose to leave looser.
+    private func createSocketParentDirectory(for socketPath: String) throws {
+        let parent = URL(fileURLWithPath: socketPath).deletingLastPathComponent()
+        guard !FileManager.default.fileExists(atPath: parent.path) else { return }
+        try FileManager.default.createDirectory(
+            at: parent,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: NSNumber(value: Int16(0o700))]
+        )
+    }
+}

--- a/Tests/ArcaEngineTests/CapabilitiesTests.swift
+++ b/Tests/ArcaEngineTests/CapabilitiesTests.swift
@@ -1,0 +1,46 @@
+import GRPC
+import SandboxEngineProto
+import XCTest
+@testable import ArcaEngine
+
+final class CapabilitiesTests: XCTestCase {
+    func testVersionParsesTheLeadingSemverAndIgnoresAPrerelease() {
+        let version = engineVersion(from: "0.2.4-alpha")
+        XCTAssertEqual(version?.major, 0)
+        XCTAssertEqual(version?.minor, 2)
+        XCTAssertEqual(version?.patch, 4)
+    }
+
+    func testVersionRejectsAnythingItCannotReadRatherThanGuessing() {
+        XCTAssertNil(engineVersion(from: ""))
+        XCTAssertNil(engineVersion(from: "0.2"))
+        XCTAssertNil(engineVersion(from: "v0.2.4"))
+        XCTAssertNil(engineVersion(from: "0.2.x"))
+    }
+
+    /// This build implements no create and no exec, so it claims nothing. A
+    /// capability that is true before its code exists is how a consumer is
+    /// induced to send a request the engine cannot honour.
+    ///
+    /// Calls the context-free `capabilities(request:)` overload rather than
+    /// the protocol-conforming `capabilities(request:context:)`: grpc-swift's
+    /// `GRPCAsyncServerCallContext` has no public initialiser, so a test
+    /// target cannot construct one. See SandboxEngineService.swift.
+    func testThisBuildClaimsOnlyWhatItImplements() async throws {
+        let response = await SandboxEngineService.forTesting()
+            .capabilities(request: .init())
+
+        guard case .capabilities(let capabilities) = response.outcome else {
+            return XCTFail("Capabilities must answer with capabilities")
+        }
+        XCTAssertFalse(capabilities.projectMount)
+        XCTAssertFalse(capabilities.namedVolumes)
+        XCTAssertFalse(capabilities.tty)
+        XCTAssertFalse(capabilities.signals)
+        XCTAssertFalse(capabilities.loopbackPublish)
+        XCTAssertFalse(capabilities.resourceLimits)
+        XCTAssertEqual(capabilities.offline, .unverified)
+        XCTAssertEqual(capabilities.contractMinor, 0)
+        XCTAssertEqual(capabilities.engineVersion.minor, 2)
+    }
+}

--- a/Tests/ArcaEngineTests/EngineErrorsTests.swift
+++ b/Tests/ArcaEngineTests/EngineErrorsTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import ArcaEngine
+
+final class EngineErrorsTests: XCTestCase {
+    /// The consumer accepts exactly these twelve and maps anything else to
+    /// invalid_output, so the engine's vocabulary is not the engine's to widen.
+    /// See gascan crates/gascan-arca/src/error.rs:20-55.
+    func testCodeVocabularyIsExactlyTheTwelveTheConsumerAccepts() {
+        XCTAssertEqual(
+            Set(EngineErrorCode.allCases.map(\.rawValue)),
+            [
+                "command_io", "command_failed", "invalid_output", "helper_error",
+                "unsupported_capability", "ownership_mismatch", "foreign_resource_refused",
+                "invalid_resource_identity", "resource_conflict", "not_found",
+                "invalid_state", "unknown_actual_state",
+            ]
+        )
+    }
+
+    /// gascan asserts the exact rendered string per code because a
+    /// resource<->message transposition is invisible to a code check
+    /// (crates/gascan-arca/src/error.rs:137-207). Placement is the assertion.
+    func testResourceAndMessageLandInTheirOwnFields() {
+        let error = engineError(.invalidState, resource: "code-a1b2c3d4e5f6", message: "not running")
+        XCTAssertEqual(error.code, "invalid_state")
+        XCTAssertEqual(error.resource, "code-a1b2c3d4e5f6")
+        XCTAssertEqual(error.message, "not running")
+    }
+
+    func testCatchingConvertsAThrownErrorRatherThanLettingItEscape() async {
+        struct Boom: Error {}
+        let result = await engineErrorCatching(.commandIo, resource: "vol-a") {
+            throw Boom()
+        }
+        guard case .failure(let error) = result else {
+            return XCTFail("a thrown error must become an EngineError, not a success")
+        }
+        XCTAssertEqual(error.code, "command_io")
+        XCTAssertEqual(error.resource, "vol-a")
+        XCTAssertTrue(error.message.contains("Boom"), "must name the underlying error: \(error.message)")
+    }
+
+    func testCatchingPassesSuccessThrough() async {
+        let result = await engineErrorCatching(.commandIo, resource: "") { 41 + 1 }
+        guard case .success(let value) = result else {
+            return XCTFail("a non-throwing body must succeed")
+        }
+        XCTAssertEqual(value, 42)
+    }
+}

--- a/Tests/ArcaEngineTests/EngineServerTests.swift
+++ b/Tests/ArcaEngineTests/EngineServerTests.swift
@@ -22,7 +22,13 @@ final class EngineServerTests: XCTestCase {
     /// callback chained on the same future has run. The blocking `.wait()`
     /// forms don't return until that chain is fully drained.
     private var group: MultiThreadedEventLoopGroup!
-    private var server: Server?
+    private var engine: EngineServer?
+
+    /// Every path any test in this class handed to `EngineServer` or bound
+    /// itself. `/tmp` is not swept outside a reboot, so a test that leaves its
+    /// socket and lockfile behind grows the directory on every run of the suite
+    /// -- on a developer's machine and on CI alike.
+    private var createdPaths: [String] = []
 
     override func setUp() {
         super.setUp()
@@ -30,8 +36,13 @@ final class EngineServerTests: XCTestCase {
     }
 
     override func tearDown() {
-        XCTAssertNoThrow(try server?.close().wait())
+        XCTAssertNoThrow(try engine?.server.close().wait())
         XCTAssertNoThrow(try group.syncShutdownGracefully())
+        for path in createdPaths {
+            unlink(path)
+            unlink(path + ".lock")
+        }
+        createdPaths = []
         super.tearDown()
     }
 
@@ -41,16 +52,18 @@ final class EngineServerTests: XCTestCase {
     /// `/var/folders/...` long enough that a descriptive prefix plus a UUID
     /// overflows it. `/tmp` is short enough to leave headroom and is the
     /// conventional location for Unix domain sockets for exactly this reason.
-    private static func testSocketPath() -> String {
-        "/tmp/arca-engine-test-\(UUID().uuidString).sock"
+    private func testSocketPath() -> String {
+        let path = "/tmp/arca-engine-test-\(UUID().uuidString).sock"
+        createdPaths.append(path)
+        return path
     }
 
     /// The socket carries the engine's whole authority, so it must not be
     /// reachable by another user on a shared machine.
     func testTheSocketIsCreatedOwnerOnly() async throws {
-        let path = Self.testSocketPath()
+        let path = testSocketPath()
 
-        server = try await EngineServer.start(
+        engine = try await EngineServer.start(
             socketPath: path,
             service: .forTesting(),
             group: group
@@ -61,7 +74,7 @@ final class EngineServerTests: XCTestCase {
     }
 
     /// A stale socket file from a killed engine must not make the next start
-    /// fail. Removing it is safe only because the caller owns the path.
+    /// fail. Removing it is safe only because nothing is listening on it.
     ///
     /// The fixture must be an actual socket-typed file, not a plain file: a
     /// killed process leaves behind the socket special file it bound to,
@@ -70,25 +83,129 @@ final class EngineServerTests: XCTestCase {
     /// plain-file fixture here would be testing the opposite of "stale
     /// socket."
     func testAStaleSocketFileDoesNotBlockStartup() async throws {
-        let path = Self.testSocketPath()
-        try Self.createStaleSocketFile(at: path)
+        let path = testSocketPath()
+        try Self.bindSocket(at: path, listening: false)
 
-        server = try await EngineServer.start(
+        engine = try await EngineServer.start(
             socketPath: path,
             service: .forTesting(),
             group: group
         )
     }
 
-    /// Binds a raw AF_UNIX socket to `path` and closes it without unlinking,
-    /// leaving exactly the artifact a killed engine would: a socket-typed
-    /// file with nothing listening behind it.
-    private static func createStaleSocketFile(at path: String) throws {
+    /// A socket with something still listening on it is NOT stale, and taking
+    /// it would leave the incumbent alive on an inode nothing can dial again.
+    ///
+    /// This is the case the type check alone could not see: an `lstat` cannot
+    /// tell a dead engine's leftover from a live one's socket, and the earlier
+    /// implementation unlinked both.
+    func testALiveListenerOnThePathIsRefusedRatherThanUnlinked() async throws {
+        let path = testSocketPath()
+        let incumbent = try Self.bindSocket(at: path, listening: true)
+        defer { close(incumbent) }
+
+        do {
+            engine = try await EngineServer.start(
+                socketPath: path,
+                service: .forTesting(),
+                group: group
+            )
+            XCTFail("starting on a path with a live listener must fail")
+        } catch let error as EngineServerError {
+            guard case .pathHasALiveListener = error else {
+                return XCTFail("wrong refusal: \(error)")
+            }
+        }
+
+        // The incumbent's socket is still the one at the path.
+        var status = stat()
+        XCTAssertEqual(lstat(path, &status), 0, "the live socket must not have been unlinked")
+    }
+
+    /// Two engines cannot serve the same path. The lock, not the socket file,
+    /// is what decides -- it is held by a live process and released by a dead
+    /// one, with no inference in between.
+    func testASecondEngineIsRefusedWhileTheFirstIsAlive() async throws {
+        let path = testSocketPath()
+        engine = try await EngineServer.start(
+            socketPath: path,
+            service: .forTesting(),
+            group: group
+        )
+        let firstInode = try Self.inode(of: path)
+
+        let second = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { XCTAssertNoThrow(try second.syncShutdownGracefully()) }
+
+        do {
+            _ = try await EngineServer.start(
+                socketPath: path,
+                service: .forTesting(),
+                group: second
+            )
+            XCTFail("a second engine must not take a live engine's path")
+        } catch let error as EngineServerError {
+            guard case .pathIsHeldByALiveEngine(_, let holder) = error else {
+                return XCTFail("wrong refusal: \(error)")
+            }
+            XCTAssertEqual(holder, "\(getpid())", "the refusal must name the holder")
+        }
+
+        XCTAssertEqual(
+            try Self.inode(of: path),
+            firstInode,
+            "the first engine's socket must still be the one at the path"
+        )
+    }
+
+    /// After a shutdown the path is free for the next engine: no socket file,
+    /// and the lock released.
+    ///
+    /// The second assertion is the one with teeth. The socket's disappearance
+    /// is not this code's doing -- MEASURED: closing the server unlinks it, so
+    /// this half passes with `shutDown`'s own removal step deleted, and it is
+    /// asserted as a property of the shutdown rather than as proof of a line.
+    /// Releasing the lock has no other owner: with `lock.release()` removed the
+    /// successor below cannot start, which is what makes this test capable of
+    /// failing.
+    ///
+    /// What both halves together stand for is the artifact the old
+    /// implementation left on every single exit, because it had no shutdown
+    /// path at all.
+    func testAfterShuttingDownTheNextEngineCanTakeThePath() async throws {
+        let path = testSocketPath()
+        let first = try await EngineServer.start(
+            socketPath: path,
+            service: .forTesting(),
+            group: group
+        )
+
+        try await first.shutDown()
+
+        var status = stat()
+        XCTAssertNotEqual(lstat(path, &status), 0, "no socket may be left at the path")
+
+        let second = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let successor = try await EngineServer.start(
+            socketPath: path,
+            service: .forTesting(),
+            group: second
+        )
+        try await successor.shutDown()
+        try await second.shutdownGracefully()
+    }
+
+    /// Binds a raw AF_UNIX socket to `path`.
+    ///
+    /// Closed without unlinking and without listening, this leaves exactly the
+    /// artifact a killed engine would: a socket-typed file with nothing behind
+    /// it. Left open and listening, it is an incumbent engine.
+    @discardableResult
+    private static func bindSocket(at path: String, listening: Bool) throws -> Int32 {
         let descriptor = socket(AF_UNIX, SOCK_STREAM, 0)
         guard descriptor >= 0 else {
             throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
         }
-        defer { close(descriptor) }
 
         var address = sockaddr_un()
         address.sun_family = sa_family_t(AF_UNIX)
@@ -108,7 +225,28 @@ final class EngineServerTests: XCTestCase {
             }
         }
         guard bindResult == 0 else {
+            let code = errno
+            close(descriptor)
+            throw POSIXError(POSIXErrorCode(rawValue: code) ?? .EIO)
+        }
+
+        guard listening else {
+            close(descriptor)
+            return -1
+        }
+        guard Darwin.listen(descriptor, 1) == 0 else {
+            let code = errno
+            close(descriptor)
+            throw POSIXError(POSIXErrorCode(rawValue: code) ?? .EIO)
+        }
+        return descriptor
+    }
+
+    private static func inode(of path: String) throws -> UInt64 {
+        var status = stat()
+        guard lstat(path, &status) == 0 else {
             throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
         }
+        return status.st_ino
     }
 }

--- a/Tests/ArcaEngineTests/EngineServerTests.swift
+++ b/Tests/ArcaEngineTests/EngineServerTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import GRPC
+import NIOCore
+import NIOPosix
+import XCTest
+#if canImport(Darwin)
+import Darwin
+#endif
+@testable import ArcaEngine
+
+final class EngineServerTests: XCTestCase {
+    /// Held as instance state, not test-local, so `tearDown()` -- a
+    /// synchronous XCTest hook -- can close them with the blocking
+    /// `syncShutdownGracefully()`/`wait()` pair. Both are `noasync` (calling
+    /// them from inside an `async throws` test method is a compile error);
+    /// this is the same split grpc-swift's own async-context tests use
+    /// (GRPCNetworkFrameworkTests.swift's `tearDown()`). It also sidesteps a
+    /// real race: closing with `try await server.close().get()` followed
+    /// immediately by `try await group.shutdownGracefully()` intermittently
+    /// logged "Cannot schedule tasks on an EventLoop that has already shut
+    /// down" -- the async continuation for `close()` can resume before every
+    /// callback chained on the same future has run. The blocking `.wait()`
+    /// forms don't return until that chain is fully drained.
+    private var group: MultiThreadedEventLoopGroup!
+    private var server: Server?
+
+    override func setUp() {
+        super.setUp()
+        group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    }
+
+    override func tearDown() {
+        XCTAssertNoThrow(try server?.close().wait())
+        XCTAssertNoThrow(try group.syncShutdownGracefully())
+        super.tearDown()
+    }
+
+    /// `sockaddr_un.sun_path` holds at most 103 usable bytes (`SocketAddress.
+    /// init(unixDomainSocketPath:)`, swift-nio's SocketAddresses.swift:352),
+    /// and `NSTemporaryDirectory()` on macOS is a per-invocation path under
+    /// `/var/folders/...` long enough that a descriptive prefix plus a UUID
+    /// overflows it. `/tmp` is short enough to leave headroom and is the
+    /// conventional location for Unix domain sockets for exactly this reason.
+    private static func testSocketPath() -> String {
+        "/tmp/arca-engine-test-\(UUID().uuidString).sock"
+    }
+
+    /// The socket carries the engine's whole authority, so it must not be
+    /// reachable by another user on a shared machine.
+    func testTheSocketIsCreatedOwnerOnly() async throws {
+        let path = Self.testSocketPath()
+
+        server = try await EngineServer.start(
+            socketPath: path,
+            service: .forTesting(),
+            group: group
+        )
+
+        let mode = try FileManager.default.attributesOfItem(atPath: path)[.posixPermissions] as? NSNumber
+        XCTAssertEqual((mode?.uint16Value ?? 0) & 0o777, 0o600)
+    }
+
+    /// A stale socket file from a killed engine must not make the next start
+    /// fail. Removing it is safe only because the caller owns the path.
+    ///
+    /// The fixture must be an actual socket-typed file, not a plain file: a
+    /// killed process leaves behind the socket special file it bound to,
+    /// because nothing ever unlinked it. `EngineServer` itself refuses to
+    /// unlink a path that is not a socket (EngineServer.swift), so a
+    /// plain-file fixture here would be testing the opposite of "stale
+    /// socket."
+    func testAStaleSocketFileDoesNotBlockStartup() async throws {
+        let path = Self.testSocketPath()
+        try Self.createStaleSocketFile(at: path)
+
+        server = try await EngineServer.start(
+            socketPath: path,
+            service: .forTesting(),
+            group: group
+        )
+    }
+
+    /// Binds a raw AF_UNIX socket to `path` and closes it without unlinking,
+    /// leaving exactly the artifact a killed engine would: a socket-typed
+    /// file with nothing listening behind it.
+    private static func createStaleSocketFile(at path: String) throws {
+        let descriptor = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard descriptor >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        defer { close(descriptor) }
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = Array(path.utf8)
+        precondition(pathBytes.count <= 103, "socket path too long for sockaddr_un")
+        withUnsafeMutableBytes(of: &address.sun_path) { rawPath in
+            let base = rawPath.baseAddress!.assumingMemoryBound(to: CChar.self)
+            for (index, byte) in pathBytes.enumerated() {
+                base[index] = CChar(bitPattern: byte)
+            }
+            base[pathBytes.count] = 0
+        }
+
+        let bindResult = withUnsafePointer(to: &address) { addressPointer -> Int32 in
+            addressPointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                Darwin.bind(descriptor, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+    }
+}

--- a/Tests/ArcaEngineTests/InspectTests.swift
+++ b/Tests/ArcaEngineTests/InspectTests.swift
@@ -34,19 +34,34 @@ final class InspectTests: XCTestCase {
         XCTAssertEqual(sandboxState(fromStatus: "restarting"), .unspecified)
     }
 
-    /// Three arms, not two. "It is not there" and "I could not tell" demand
-    /// opposite behaviour from a reconciler (engine.proto:354-357).
+    /// Three arms, not two: "it is not there" and "I could not tell" demand
+    /// opposite behaviour from a reconciler (engine.proto:354-357). This build
+    /// is in the second position and must say so.
+    ///
+    /// The assertion that matters is the negative one. An earlier version of
+    /// this test asserted `.absent` and passed -- against a service whose
+    /// backing state is empty under every input, so `.absent` was the only
+    /// answer it could produce. It would have passed identically against
+    /// `{ .with { $0.absent = .init() } }` with ContainerBridge deleted, which
+    /// is to say it distinguished nothing. `absent` is the arm a reconciler
+    /// reads as "create it", so answering it without having looked is how a
+    /// running sandbox acquires a duplicate.
     ///
     /// Calls the context-free `inspect(request:)` overload rather than the
     /// protocol-conforming `inspect(request:context:)`: grpc-swift's
     /// `GRPCAsyncServerCallContext` has no public initialiser, so a test
     /// target cannot construct one. See SandboxEngineService.swift.
-    func testAnAbsentSandboxIsAnAnswerRatherThanAnError() async throws {
+    func testInspectRefusesToReportAbsenceItCannotObserve() async throws {
         let response = await SandboxEngineService.forTesting().inspect(
             request: Arca_Engine_V1_InspectRequest.with { $0.sandboxID = "absent-a1b2c3d4e5f6" }
         )
-        guard case .absent = response.outcome else {
-            return XCTFail("an unknown sandbox must be Absent, not an error: \(String(describing: response.outcome))")
+
+        if case .absent = response.outcome {
+            return XCTFail("a build that loads no state must not answer Absent")
         }
+        guard case .error(let error) = response.outcome else {
+            return XCTFail("Inspect must answer: \(String(describing: response.outcome))")
+        }
+        XCTAssertEqual(error.code, "unsupported_capability")
     }
 }

--- a/Tests/ArcaEngineTests/InspectTests.swift
+++ b/Tests/ArcaEngineTests/InspectTests.swift
@@ -1,0 +1,52 @@
+import GRPC
+import SandboxEngineProto
+import XCTest
+@testable import ArcaEngine
+
+final class InspectTests: XCTestCase {
+    /// gascan reassembles the canonical reference and asserts it is one, which
+    /// is what lets the daemon compare one observation against another by exact
+    /// string (crates/gascan-arca/src/translate.rs:333-336). A tag, or a digest
+    /// in another form, breaks reconciliation rather than looking untidy.
+    func testImageDigestSplitsRepositoryFromBareLowercaseHex() {
+        let digest = imageDigest(
+            fromReference: "ghcr.io/liquescent-development/gascan/workspace@sha256:"
+                + String(repeating: "a", count: 64)
+        )
+        XCTAssertEqual(digest?.repository, "ghcr.io/liquescent-development/gascan/workspace")
+        XCTAssertEqual(digest?.sha256Hex, String(repeating: "a", count: 64))
+    }
+
+    func testImageDigestRefusesAnythingThatIsNotAnExactDigestReference() {
+        XCTAssertNil(imageDigest(fromReference: "ubuntu:latest"))
+        XCTAssertNil(imageDigest(fromReference: "ubuntu"))
+        XCTAssertNil(imageDigest(fromReference: "ubuntu@sha256:abc"))
+        XCTAssertNil(imageDigest(fromReference: "ubuntu@sha512:" + String(repeating: "a", count: 64)))
+        XCTAssertNil(imageDigest(fromReference: "ubuntu@sha256:" + String(repeating: "A", count: 64)))
+    }
+
+    /// A paused or restarting sandbox is neither running nor stopped.
+    /// UNSPECIFIED reaches the consumer as a hard UnknownActualState error
+    /// naming the state (crates/gascan-arca/src/translate.rs:399-409) rather
+    /// than a guess that could have a reconciler destroy live work.
+    func testSandboxStateIsUnspecifiedForPausedAndRestarting() {
+        XCTAssertEqual(sandboxState(fromStatus: "paused"), .unspecified)
+        XCTAssertEqual(sandboxState(fromStatus: "restarting"), .unspecified)
+    }
+
+    /// Three arms, not two. "It is not there" and "I could not tell" demand
+    /// opposite behaviour from a reconciler (engine.proto:354-357).
+    ///
+    /// Calls the context-free `inspect(request:)` overload rather than the
+    /// protocol-conforming `inspect(request:context:)`: grpc-swift's
+    /// `GRPCAsyncServerCallContext` has no public initialiser, so a test
+    /// target cannot construct one. See SandboxEngineService.swift.
+    func testAnAbsentSandboxIsAnAnswerRatherThanAnError() async throws {
+        let response = await SandboxEngineService.forTesting().inspect(
+            request: Arca_Engine_V1_InspectRequest.with { $0.sandboxID = "absent-a1b2c3d4e5f6" }
+        )
+        guard case .absent = response.outcome else {
+            return XCTFail("an unknown sandbox must be Absent, not an error: \(String(describing: response.outcome))")
+        }
+    }
+}

--- a/Tests/ArcaEngineTests/ListResourcesTests.swift
+++ b/Tests/ArcaEngineTests/ListResourcesTests.swift
@@ -1,0 +1,80 @@
+import GRPC
+import SandboxEngineProto
+import XCTest
+@testable import ArcaEngine
+
+final class ListResourcesTests: XCTestCase {
+    /// On an empty engine this is an empty list, not an error. A reconciler
+    /// reads "nothing exists" from this and must not see a failure instead.
+    ///
+    /// Calls the context-free `listResources(request:)` overload rather than
+    /// the protocol-conforming `listResources(request:context:)`:
+    /// grpc-swift's `GRPCAsyncServerCallContext` has no public initialiser,
+    /// so a test target cannot construct one. See SandboxEngineService.swift.
+    func testAnEmptyEngineListsNoResourcesRatherThanFailing() async throws {
+        let response = await SandboxEngineService.forTesting()
+            .listResources(request: .init())
+
+        guard case .resources(let list) = response.outcome else {
+            return XCTFail("ListResources must answer with a list: \(String(describing: response.outcome))")
+        }
+        XCTAssertTrue(list.resources.isEmpty)
+    }
+
+    /// Unlabelled resources are NOT filtered out. gascan's drift detection
+    /// depends on seeing them, and hiding them engine-side would break it
+    /// silently (engine.proto:389-391). Asserted here on the mapping helper,
+    /// and again against a real engine in the live tier.
+    func testAnUnlabelledResourceMapsToOneWithNoOwner() {
+        let resource = resourceMessage(kind: .volume, name: "someone-elses-volume", labels: [:])
+        XCTAssertEqual(resource.identity.name, "someone-elses-volume")
+        XCTAssertEqual(resource.identity.kind, .volume)
+        XCTAssertFalse(resource.hasOwner)
+    }
+
+    func testALabelledResourceCarriesItsOwnerBack() {
+        let resource = resourceMessage(
+            kind: .container,
+            name: "web-a1b2c3d4e5f6",
+            labels: [
+                SandboxIdentity.managedByLabelKey: "gascan",
+                SandboxIdentity.sandboxIdLabelKey: "web-a1b2c3d4e5f6",
+            ]
+        )
+        XCTAssertTrue(resource.hasOwner)
+        XCTAssertEqual(resource.owner.managedBy, "gascan")
+        XCTAssertEqual(resource.owner.sandboxID, "web-a1b2c3d4e5f6")
+    }
+
+    /// ContainerBridge reports Docker-style names with a leading slash
+    /// (Sources/ContainerBridge/ContainerManager.swift:725), but the consumer
+    /// compares a container resource's name against the bare sandbox id
+    /// (crates/gascan-core/src/runtime.rs:829-832). This is the highest-risk
+    /// line in this task: an unstripped slash makes every owned container
+    /// look unrelated to the sandbox that owns it.
+    func testContainerResourceNameStripsTheLeadingSlash() {
+        XCTAssertEqual(
+            containerResourceName(names: ["/web-a1b2c3d4e5f6"], id: "abc"),
+            "web-a1b2c3d4e5f6"
+        )
+    }
+
+    func testContainerResourceNameLeavesAnAlreadyBareNameUnchanged() {
+        XCTAssertEqual(
+            containerResourceName(names: ["web-a1b2c3d4e5f6"], id: "abc"),
+            "web-a1b2c3d4e5f6"
+        )
+    }
+
+    func testContainerResourceNameFallsBackToTheIdWhenThereAreNoNames() {
+        XCTAssertEqual(containerResourceName(names: [], id: "abc"), "abc")
+    }
+
+    func testContainerResourceNameFallsBackToTheIdWhenTheOnlyNameIsBareSlash() {
+        XCTAssertEqual(containerResourceName(names: ["/"], id: "abc"), "abc")
+    }
+
+    func testContainerResourceNameStripsOnlyOneLeadingSlash() {
+        XCTAssertEqual(containerResourceName(names: ["//x"], id: "abc"), "/x")
+    }
+}

--- a/Tests/ArcaEngineTests/ListResourcesTests.swift
+++ b/Tests/ArcaEngineTests/ListResourcesTests.swift
@@ -4,21 +4,32 @@ import XCTest
 @testable import ArcaEngine
 
 final class ListResourcesTests: XCTestCase {
-    /// On an empty engine this is an empty list, not an error. A reconciler
-    /// reads "nothing exists" from this and must not see a failure instead.
+    /// An empty `ResourceList` is not an error arm -- it is a confident report
+    /// of a clean host, and this build cannot earn it.
+    ///
+    /// The assertion that matters is the negative one, for the same reason as
+    /// `InspectTests.testInspectRefusesToReportAbsenceItCannotObserve`. The
+    /// version this replaces asserted `list.resources.isEmpty` against a
+    /// service whose three managers are empty under every input; it would have
+    /// passed against a hardcoded empty list with ContainerBridge deleted.
+    /// gascan's drift and leak detection reads this method, and a clean report
+    /// from a host holding resources is the failure it cannot see.
     ///
     /// Calls the context-free `listResources(request:)` overload rather than
     /// the protocol-conforming `listResources(request:context:)`:
     /// grpc-swift's `GRPCAsyncServerCallContext` has no public initialiser,
     /// so a test target cannot construct one. See SandboxEngineService.swift.
-    func testAnEmptyEngineListsNoResourcesRatherThanFailing() async throws {
+    func testListResourcesRefusesToReportAnEmptinessItCannotObserve() async throws {
         let response = await SandboxEngineService.forTesting()
             .listResources(request: .init())
 
-        guard case .resources(let list) = response.outcome else {
-            return XCTFail("ListResources must answer with a list: \(String(describing: response.outcome))")
+        if case .resources = response.outcome {
+            return XCTFail("a build that loads no state must not report a resource list")
         }
-        XCTAssertTrue(list.resources.isEmpty)
+        guard case .error(let error) = response.outcome else {
+            return XCTFail("ListResources must answer: \(String(describing: response.outcome))")
+        }
+        XCTAssertEqual(error.code, "unsupported_capability")
     }
 
     /// Unlabelled resources are NOT filtered out. gascan's drift detection

--- a/Tests/ArcaEngineTests/SandboxEngineServiceTests.swift
+++ b/Tests/ArcaEngineTests/SandboxEngineServiceTests.swift
@@ -25,20 +25,86 @@ final class SandboxEngineServiceTests: XCTestCase {
         XCTAssertTrue(error.message.contains("Start"), "must name the RPC: \(error.message)")
     }
 
-    /// Every response type sets its oneof. An unset outcome is representable in
-    /// proto3 and reaches the consumer as invalid_output
-    /// (crates/gascan-arca/src/translate.rs:291-293).
-    func testEveryUnimplementedResponseSetsItsOutcome() async throws {
+    /// Every unimplemented response carries an `unsupported_capability` error
+    /// naming its RPC.
+    ///
+    /// This replaces a version that asserted only `XCTAssertNotNil(outcome)`.
+    /// An outcome is non-nil whenever *any* arm is set, so that test passed if
+    /// every one of these methods had answered `ok` -- the precise inversion of
+    /// what its name claimed. The code and the RPC name are what a consumer
+    /// reads, so they are what this asserts.
+    ///
+    /// The eight unary methods only. `Exec` and `Logs` send their error inside
+    /// a stream frame, and `GRPCAsyncResponseStreamWriter` has no initialiser a
+    /// test target can reach; gascan's live tier drives both against a real
+    /// engine over a real socket.
+    func testEveryUnimplementedUnaryMethodAnswersUnsupportedCapability() async throws {
         let service = SandboxEngineService.forTesting()
-        let stopOutcome = await service.stop(request: .init()).outcome
-        let removeOutcome = await service.remove(request: .init()).outcome
-        let createOutcome = await service.create(request: .init()).outcome
-        let createContainerOutcome = await service.createContainer(request: .init()).outcome
-        let prepareImageOutcome = await service.prepareImage(request: .init()).outcome
-        XCTAssertNotNil(stopOutcome)
-        XCTAssertNotNil(removeOutcome)
-        XCTAssertNotNil(createOutcome)
-        XCTAssertNotNil(createContainerOutcome)
-        XCTAssertNotNil(prepareImageOutcome)
+
+        let answers: [(rpc: String, error: Arca_Engine_V1_EngineError?)] = [
+            ("Inspect", engineError(await service.inspect(request: .init()).outcome)),
+            ("ListResources", engineError(await service.listResources(request: .init()).outcome)),
+            ("Create", engineError(await service.create(request: .init()).outcome)),
+            ("CreateContainer", engineError(await service.createContainer(request: .init()).outcome)),
+            ("PrepareImage", engineError(await service.prepareImage(request: .init()).outcome)),
+            ("Start", engineError(await service.start(request: .init()).outcome)),
+            ("Stop", engineError(await service.stop(request: .init()).outcome)),
+            ("Remove", engineError(await service.remove(request: .init()).outcome)),
+        ]
+
+        XCTAssertEqual(answers.count, 8, "the ten-method contract has eight unary methods left")
+        for (rpc, error) in answers {
+            guard let error else {
+                XCTFail("\(rpc) must answer with an error outcome, and did not")
+                continue
+            }
+            XCTAssertEqual(error.code, "unsupported_capability", "\(rpc) answered \(error.code)")
+            XCTAssertTrue(
+                error.message.contains(rpc),
+                "\(rpc)'s message must name the RPC: \(error.message)"
+            )
+        }
     }
+}
+
+// Reads the `EngineError` out of whichever arm a response type puts it in, so
+// the table above can be one list rather than eight near-copies. `nil` means
+// the response did not answer with an error, which for an unimplemented method
+// is itself the failure -- hence optional rather than a trap.
+
+private func engineError(
+    _ outcome: Arca_Engine_V1_InspectResponse.OneOf_Outcome?
+) -> Arca_Engine_V1_EngineError? {
+    if case .error(let error) = outcome { return error }
+    return nil
+}
+
+private func engineError(
+    _ outcome: Arca_Engine_V1_ListResourcesResponse.OneOf_Outcome?
+) -> Arca_Engine_V1_EngineError? {
+    if case .error(let error) = outcome { return error }
+    return nil
+}
+
+private func engineError(
+    _ outcome: Arca_Engine_V1_AckResponse.OneOf_Outcome?
+) -> Arca_Engine_V1_EngineError? {
+    if case .error(let error) = outcome { return error }
+    return nil
+}
+
+private func engineError(
+    _ outcome: Arca_Engine_V1_PrepareImageResponse.OneOf_Outcome?
+) -> Arca_Engine_V1_EngineError? {
+    if case .error(let error) = outcome { return error }
+    return nil
+}
+
+/// Create is the one shape that nests: its failure arm is a `CreateFailed`,
+/// which carries the error alongside the resources a partial create made.
+private func engineError(
+    _ outcome: Arca_Engine_V1_CreateResponse.OneOf_Outcome?
+) -> Arca_Engine_V1_EngineError? {
+    if case .failed(let failed) = outcome { return failed.error }
+    return nil
 }

--- a/Tests/ArcaEngineTests/SandboxEngineServiceTests.swift
+++ b/Tests/ArcaEngineTests/SandboxEngineServiceTests.swift
@@ -1,0 +1,44 @@
+import GRPC
+import SandboxEngineProto
+import XCTest
+@testable import ArcaEngine
+
+final class SandboxEngineServiceTests: XCTestCase {
+    /// An unimplemented method must still ANSWER. Returning a gRPC status
+    /// instead would be a transport fault by the contract's reading, and the
+    /// consumer would report an unreachable engine rather than an unsupported
+    /// operation.
+    ///
+    /// Calls the context-free `start(request:)` overload rather than the
+    /// protocol-conforming `start(request:context:)`: grpc-swift's
+    /// `GRPCAsyncServerCallContext` has no public initialiser, so a test
+    /// target cannot construct one. See SandboxEngineService.swift.
+    func testUnimplementedMethodsAnswerWithUnsupportedCapabilityNamingTheRpc() async throws {
+        let service = SandboxEngineService.forTesting()
+        let response = await service.start(
+            request: Arca_Engine_V1_StartRequest.with { $0.sandboxID = "web-a1b2c3d4e5f6" }
+        )
+        guard case .error(let error) = response.outcome else {
+            return XCTFail("an unimplemented method must answer with an error outcome")
+        }
+        XCTAssertEqual(error.code, "unsupported_capability")
+        XCTAssertTrue(error.message.contains("Start"), "must name the RPC: \(error.message)")
+    }
+
+    /// Every response type sets its oneof. An unset outcome is representable in
+    /// proto3 and reaches the consumer as invalid_output
+    /// (crates/gascan-arca/src/translate.rs:291-293).
+    func testEveryUnimplementedResponseSetsItsOutcome() async throws {
+        let service = SandboxEngineService.forTesting()
+        let stopOutcome = await service.stop(request: .init()).outcome
+        let removeOutcome = await service.remove(request: .init()).outcome
+        let createOutcome = await service.create(request: .init()).outcome
+        let createContainerOutcome = await service.createContainer(request: .init()).outcome
+        let prepareImageOutcome = await service.prepareImage(request: .init()).outcome
+        XCTAssertNotNil(stopOutcome)
+        XCTAssertNotNil(removeOutcome)
+        XCTAssertNotNil(createOutcome)
+        XCTAssertNotNil(createContainerOutcome)
+        XCTAssertNotNil(prepareImageOutcome)
+    }
+}

--- a/Tests/ArcaEngineTests/SandboxIdentityTests.swift
+++ b/Tests/ArcaEngineTests/SandboxIdentityTests.swift
@@ -1,0 +1,45 @@
+import SandboxEngineProto
+import XCTest
+@testable import ArcaEngine
+
+final class SandboxIdentityTests: XCTestCase {
+    /// The container's name IS the sandbox id. gascan builds the expected
+    /// identity as request.id.to_string() and validates created resources
+    /// against it (crates/gascan-core/src/runtime.rs:829-832), so any other
+    /// name fails every create client-side.
+    func testContainerNameIsTheSandboxIdVerbatim() {
+        XCTAssertEqual(
+            SandboxIdentity.containerName(forSandboxId: "web-a1b2c3d4e5f6"),
+            "web-a1b2c3d4e5f6"
+        )
+    }
+
+    /// Labels are stored verbatim and never interpreted (engine.proto:144-148).
+    /// Round-tripping is the whole contract.
+    func testOwnerLabelsRoundTripUnchanged() {
+        var owner = Arca_Engine_V1_OwnerLabels()
+        owner.managedBy = "gascan"
+        owner.sandboxID = "web-a1b2c3d4e5f6"
+
+        let recovered = SandboxIdentity.owner(from: SandboxIdentity.labels(from: owner))
+
+        XCTAssertEqual(recovered?.managedBy, "gascan")
+        XCTAssertEqual(recovered?.sandboxID, "web-a1b2c3d4e5f6")
+    }
+
+    /// A resource the engine holds no labels for is how a consumer sees one it
+    /// does not own (engine.proto:169-173). Absent, not empty: an OwnerLabels
+    /// with two empty strings would claim managed_by "" and defeat gascan's
+    /// ownership classifier.
+    func testUnlabelledResourcesHaveNoOwnerRatherThanAnEmptyOne() {
+        XCTAssertNil(SandboxIdentity.owner(from: [:]))
+        XCTAssertNil(SandboxIdentity.owner(from: ["com.example.other": "x"]))
+    }
+
+    /// A half-labelled resource is not ours and must not be reported as though
+    /// it were partially ours.
+    func testAPartiallyLabelledResourceHasNoOwner() {
+        XCTAssertNil(SandboxIdentity.owner(from: [SandboxIdentity.managedByLabelKey: "gascan"]))
+        XCTAssertNil(SandboxIdentity.owner(from: [SandboxIdentity.sandboxIdLabelKey: "web-a1b2c3d4e5f6"]))
+    }
+}

--- a/Tests/ArcaEngineTests/TestSupport.swift
+++ b/Tests/ArcaEngineTests/TestSupport.swift
@@ -1,0 +1,58 @@
+import ContainerBridge
+import Foundation
+import Logging
+@testable import ArcaEngine
+
+extension SandboxEngineService {
+    /// A service over real ContainerBridge managers against a throwaway state
+    /// root. Nothing in Tasks 1-6's tests starts a VM; these managers exist
+    /// because the service holds them, not because the tests drive them.
+    ///
+    /// `StateStore` and `ImageManager` construction is force-tried: a failure
+    /// here means the on-disk test fixture (a fresh temp directory) could not
+    /// be created, which should fail the test run loudly rather than surface
+    /// as an ordinary assertion failure.
+    static func forTesting() -> SandboxEngineService {
+        let logger = Logger(label: "arca-engine-tests")
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("arca-engine-tests-\(UUID().uuidString)")
+
+        let stateStore = try! StateStore(
+            path: root.appendingPathComponent("state.db").path,
+            logger: logger
+        )
+        let imageManager = try! ImageManager(
+            logger: logger,
+            imageStorePath: root.appendingPathComponent("images")
+        )
+        let containerManager = ContainerManager(
+            imageManager: imageManager,
+            kernelPath: root.appendingPathComponent("vmlinux").path,
+            stateStore: stateStore,
+            logger: logger
+        )
+        let config = ArcaConfig(
+            kernelPath: root.appendingPathComponent("vmlinux").path,
+            socketPath: root.appendingPathComponent("arca.sock").path,
+            logLevel: "info"
+        )
+
+        return SandboxEngineService(
+            containerManager: containerManager,
+            volumeManager: VolumeManager(
+                volumesBasePath: root.appendingPathComponent("volumes").path,
+                stateStore: stateStore,
+                logger: logger
+            ),
+            networkManager: NetworkManager(
+                config: config,
+                stateStore: stateStore,
+                containerManager: containerManager,
+                logger: logger
+            ),
+            imageManager: imageManager,
+            execManager: ExecManager(containerManager: containerManager, logger: logger),
+            logger: logger
+        )
+    }
+}


### PR DESCRIPTION
Adds `ArcaEngine` and the `arca-engine` executable: Gas Can's sandbox engine, serving the
eleven-method `SandboxEngine` contract from `proto/arca/engine/v1/engine.proto` over a Unix
socket.

Consumed by `Liquescent-Development/gascan#69`, which pins this branch by the signed tag
`gascan-engine-m1.1` at `b3390b8`.

## What it does

**One method is real: `Capabilities`.** The other ten answer `unsupported_capability`
inside their response `oneof` until later milestones fill them in.

An earlier revision of this branch said three were real, counting `Inspect` and
`ListResources`. They were wired over `ContainerBridge` but could not report anything: this
process calls `initialize()` on no manager, and every insertion site for the containers,
volumes and networks those two read lives inside `initialize()` or inside a method that
answers `unsupported_capability`. Each could therefore return exactly one answer under
every input — `absent`, and an empty list. Neither is an error arm. `absent` is the arm a
reconciler reads as "create it", so answering it without having looked is how a running
sandbox acquires a duplicate; an empty `ResourceList` is a confident report of a clean host,
which is the report that hides a leak.

That last point is a contract, not an implementation detail. gRPC status codes are reserved
for transport faults, so no Swift error may escape a provider method: a status would reach
the consumer as an unreachable engine, which is a different fact from "this build cannot do
that", and would send a reconciler down the wrong path. Every method catches everything and
answers in its response.

`Capabilities` reports only what this build implements. Every feature flag is false and
`offline` is `ISOLATION_UNVERIFIED`, because this milestone creates nothing and execs
nothing. Later milestones flip flags as they earn them.

`EngineError.code` is drawn from a fixed twelve-value table, because the Rust client accepts
no others and maps anything else to `invalid_output`.

## Deliberately absent dependencies

`ArcaEngine` and `arca-engine` depend on neither `DockerAPI` nor `ArcaDaemon`. A
Docker-shaped API on the engine socket would be a policy-bypass surface sitting beside the
policy gate, so that absent edge is load-bearing rather than incidental.

Gas Can asserts it from its side (`tests/release/engine-targets-check.sh`), walking the
transitive target closure of both this library target and the executable, and it is proven
capable of failing by mutation rather than assumed.

## Verification

- `swift test --filter ArcaEngineTests` — 30 tests, 0 failures.
- The engine genuinely runs: `arca-engine --socket-path … --state-root …` logs
  `engine listening` and creates the socket `srw-------`.
- Gas Can's live tier drives a real instance of this binary over gRPC and confirms, among
  other things, that it accepts the client's placeholder authority and that an unimplemented
  method answers in its outcome rather than as a status.

`8fc1ca5` constrains grpc-swift-2 to `>=2.3.0 <2.4.0`. 2.4.x declares `traits: []` on
swift-protobuf, which declares none, and Swift 6.3.3 rejects that combination — but only
when building an executable product from a clean checkout, which is why it stayed hidden
until Gas Can's pinned build first produced a binary. Why this source tree resolves 2.4.2
where an identical clean clone cannot is still unexplained and worth revisiting.

Each commit was independently reviewed before the next was written.

## The adversarial review, and what it changed

An independent adversarial review of this branch at `f5fde96` found 1 Critical, 6 Important
and 8 Minor. **The Critical and every Important are addressed in `16abeec` and `b3390b8`.
The eight Minors are not.**

**C1 — `Inspect` and `ListResources` could never report anything.** Resolved as described
above. Calling `initialize()` instead was considered and rejected for this milestone on
evidence the review had not reached: its restore loop *writes*, marking every persisted
`running` container exited with code 137 (`ContainerManager.swift:316-338`), so an engine
pointed at a state root a live `ArcaDaemon` shares — `~/.arca` being the natural choice —
would declare that daemon's running containers dead. `NetworkManager.initialize()` is
likewise a mutation: it ends in `createDefaultNetworks()`, which creates a vmnet network.
A later milestone gives `ContainerBridge` a read-only load path that neither starts a VM
nor writes.

**This dissolved I3, I4 and I5** — the internal-container filter, the hardcoded empty
`ports`, and the digest check running ahead of the owner-label read are all properties of
answers that no longer exist. Each is recorded on the method it belonged to, so whoever
restores those methods must fix them first rather than rediscover them.

**I1 — a second engine silently stole the socket path from a live first.** The guard
decided "stale" from the file's type alone, which cannot distinguish a dead engine's
leftover from a live engine's socket. Replaced by two checks that cover each other's gaps:
an exclusive `flock` on a lockfile beside the socket — the kernel drops it when the holder
dies, so "can I take this lock" *is* "did the last engine survive", and it is atomic, which
also closes the TOCTOU between deciding to unlink and binding — and a non-blocking
`connect()` probe, which answers for anything else listening there.

**I2 — there was no shutdown path at all.** SIGTERM and SIGINT now trigger a graceful
close, and a repeat of either forces an immediate one, because a graceful shutdown waits
for in-flight RPCs and a client holding a stream open could otherwise hold the engine open
with it.

**I6 — three tests that could not fail.** `testEveryUnimplementedResponseSetsItsOutcome`
asserted only `XCTAssertNotNil(outcome)`, which passes if every method answered `ok`; it now
walks all eight unary methods and asserts the code and the RPC name. The `Inspect` and
`ListResources` tests asserted an absence and an emptiness against state that was empty
under every input, and now assert the negative that matters.

### How the fixes were checked

Each new guard was reverted alone and the test that names it re-run, so none of them is an
instrument that cannot fail:

- removing the `connect()` probe → the live-listener test fails, the path is stolen
- removing the `flock` → the second-engine test fails on the wrong refusal
- removing `lock.release()` → the successor engine cannot start

Against `.build/release/arca-engine` under `SWIFTNIO_STRICT=1`: SIGTERM and SIGINT each
exit 0 with the socket gone and no diagnostic; a second engine is refused with `the engine
with pid N already holds it` while the first stays alive and its socket inode is unchanged;
and a successor takes the path once the first stops.

Two measurements are recorded in the source because they contradict what the code looks
like it is doing. Closing the server already unlinks the socket, so `shutDown()`'s own
removal step is a backstop no test can distinguish. And the event-loop group must be shut
down only after everything referencing it is released — with the server still live, every
run printed `Cannot schedule tasks on an EventLoop that has already shut down`, and under
`SWIFTNIO_STRICT=1` the same runs died with exit 133.

