### PR TITLE
P5.1 milestone 2 — engine state ownership and the sandbox lifecycle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,6 +269,8 @@ test: codesign
 	@codesign --force --sign - --entitlements $(ENTITLEMENTS) $(BUILD_DIR)/Arca
 	@echo "Signing ArcaTestHelper binary..."
 	@codesign --force --sign - --entitlements $(ENTITLEMENTS) $(BUILD_DIR)/ArcaTestHelper
+	@echo "Signing $(ENGINE) binary..."
+	@codesign --force --sign - --entitlements $(ENTITLEMENTS) $(BUILD_DIR)/$(ENGINE)
 	@echo "Signing test binaries..."
 	@codesign --force --sign - --entitlements $(ENTITLEMENTS) .build/debug/ArcaPackageTests.xctest/Contents/MacOS/ArcaPackageTests 2>/dev/null || true
 	@echo "✓ All binaries signed"

--- a/Makefile
+++ b/Makefile
@@ -265,6 +265,23 @@ test: codesign
 	@rm -f ~/.arca/state.db
 	@echo "Building tests..."
 	@swift build --build-tests
+# The three re-sign lines below are defence in depth. They fix nothing this
+# target does: MEASURED, `make test` links Arca, ArcaTestHelper and arca-engine
+# in the `codesign:` prerequisite's `swift build`, and the `swift build
+# --build-tests` above then links `ArcaPackageTests` alone -- so the executables
+# are never relinked here and never lose the signature they were just given.
+# Deleting the $(ENGINE) line changed nothing: from all three binaries stripped,
+# the same run still ended with all three carrying the entitlement, and
+# `Executed 63 tests, with 0 failures`.
+#
+# What they do defend is a direct `swift build --build-tests` with no plain
+# `swift build` before it, which a developer does run. MEASURED from all three
+# signed: CHANGING a ContainerBridge source -- `make gen-buildinfo` rewrites one
+# -- and running that alone links all three executables and leaves every one of
+# them with no entitlements at all. A bare `touch` does not do it; SwiftPM keys
+# on content, and that build emitted the module without relinking anything.
+# An unsigned $(ENGINE) is the expensive one to meet -- it fails on
+# vmnet_return_t(rawValue: 1002), which reads as a memory fault and is not one.
 	@echo "Re-signing Arca binary (swift build --build-tests may have rebuilt it)..."
 	@codesign --force --sign - --entitlements $(ENTITLEMENTS) $(BUILD_DIR)/Arca
 	@echo "Signing ArcaTestHelper binary..."

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ endif
 # Binary names
 BINARY = Arca
 TEST_HELPER = ArcaTestHelper
+ENGINE = arca-engine
 
 # Installation directory
 INSTALL_DIR = /usr/local/bin
@@ -57,11 +58,22 @@ $(BUILD_DIR)/$(BINARY): gen-buildinfo $(SOURCES) Package.swift
 	@swift build $(SWIFT_BUILD_FLAGS)
 
 # Codesign the binaries with entitlements
-codesign: $(BUILD_DIR)/$(BINARY) $(BUILD_DIR)/$(TEST_HELPER)
+#
+# $(ENGINE) belongs here for the same reason $(BINARY) does, and was missing:
+# ContainerManager.initialize() constructs a Containerization.VmnetNetwork, and
+# vmnet refuses without com.apple.security.virtualization. MEASURED with the
+# signature as the only variable -- stripped of entitlements the engine exits 1
+# on "failed to create vmnet network with status vmnet_return_t(rawValue: 1002)"
+# and creates no socket. 1002 is VMNET_MEM_FAILURE in vmnet.h, which sends
+# whoever debugs it looking for a memory fault; re-signed with $(ENTITLEMENTS)
+# the same binary initialises all three managers and serves on its socket.
+codesign: $(BUILD_DIR)/$(BINARY) $(BUILD_DIR)/$(TEST_HELPER) $(BUILD_DIR)/$(ENGINE)
 	@echo "Code signing $(BINARY) with entitlements (identity: $(CODESIGN_IDENTITY))..."
 	@codesign --force --sign "$(CODESIGN_IDENTITY)" --options runtime --timestamp --entitlements $(ENTITLEMENTS) $(BUILD_DIR)/$(BINARY)
 	@echo "Code signing $(TEST_HELPER) with entitlements..."
 	@codesign --force --sign "$(CODESIGN_IDENTITY)" --options runtime --timestamp --entitlements $(ENTITLEMENTS) $(BUILD_DIR)/$(TEST_HELPER)
+	@echo "Code signing $(ENGINE) with entitlements..."
+	@codesign --force --sign "$(CODESIGN_IDENTITY)" --options runtime --timestamp --entitlements $(ENTITLEMENTS) $(BUILD_DIR)/$(ENGINE)
 	@echo "✓ Code signing complete"
 
 # Debug build (default)

--- a/Package.swift
+++ b/Package.swift
@@ -59,6 +59,13 @@ let package = Package(
                 .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "Logging", package: "swift-log"),
+                // ArcaDaemon.swift imports Containerization directly, for
+                // ImageStore.default.path. Declared rather than left to reach
+                // the module transitively through ContainerBridge: a transitive
+                // import compiles until ContainerBridge stops depending on
+                // Containerization, and then the breakage lands on whoever
+                // edited ContainerBridge rather than here.
+                .product(name: "Containerization", package: "containerization"),
                 "DockerAPI",
                 "ContainerBridge",
             ]

--- a/Sources/ArcaDaemon/ArcaDaemon.swift
+++ b/Sources/ArcaDaemon/ArcaDaemon.swift
@@ -94,8 +94,15 @@ public final class ArcaDaemon: @unchecked Sendable {
 
             // Delete the existing initfs.ext4 file to force regeneration from our custom vminit
             // Without this, the old initfs.ext4 (which may be from a different vminit) gets reused
-            let initfsPath = FileManager.default.homeDirectoryForCurrentUser
-                .appendingPathComponent("Library/Application Support/com.apple.containerization/initfs.ext4")
+            //
+            // Bound to the store this daemon actually loads into, rather than
+            // spelled out from the home directory a second time: Containerization
+            // builds initfs.ext4 at the image store's own path, so the two are the
+            // same file only for as long as the two spellings agree. Unchanged in
+            // effect -- the ImageManager above is constructed with no path, so its
+            // store is ImageStore.default, rooted at Application Support's
+            // com.apple.containerization (ImageStore.swift:55-64).
+            let initfsPath = imageManager.storeRoot.appendingPathComponent("initfs.ext4")
             if FileManager.default.fileExists(atPath: initfsPath.path) {
                 logger.debug("Deleting existing initfs.ext4 to force regeneration")
                 do {

--- a/Sources/ArcaDaemon/ArcaDaemon.swift
+++ b/Sources/ArcaDaemon/ArcaDaemon.swift
@@ -167,6 +167,26 @@ public final class ArcaDaemon: @unchecked Sendable {
         let eventManager = EventManager(logger: logger)
         self.eventManager = eventManager
 
+        // The log root this daemon has always used, now stated here instead of
+        // derived inside ContainerLogManager -- where every ContainerManager
+        // got it, whatever state root it was built for.
+        //
+        // `url(for:in:appropriateFor:create:)` and not `urls(for:in:).first!`:
+        // the force-unwrap the comment below warns about was still live in
+        // ContainerLogManager, and this is the throwing spelling of the same
+        // lookup. Same directory as before -- Application Support in the user
+        // domain, then `com.apple.arca/logs` -- so nothing this daemon reads or
+        // writes moves.
+        let applicationSupport = try FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: false
+        )
+        let daemonLogRoot = applicationSupport
+            .appendingPathComponent("com.apple.arca")
+            .appendingPathComponent("logs")
+
         // Initialize ContainerManager with kernel path from config
         let containerManager = ContainerManager(
             imageManager: imageManager,
@@ -179,6 +199,7 @@ public final class ArcaDaemon: @unchecked Sendable {
             layerCachePath: URL(
                 fileURLWithPath: NSString(string: "~/.arca/layers").expandingTildeInPath
             ),
+            logRoot: daemonLogRoot,
             stateStore: stateStore,
             logger: logger
         )

--- a/Sources/ArcaDaemon/ArcaDaemon.swift
+++ b/Sources/ArcaDaemon/ArcaDaemon.swift
@@ -3,6 +3,7 @@ import Logging
 import NIOHTTP1
 import DockerAPI
 import ContainerBridge
+import Containerization
 
 /// The main Arca daemon that implements the Docker Engine API server
 public final class ArcaDaemon: @unchecked Sendable {
@@ -163,6 +164,14 @@ public final class ArcaDaemon: @unchecked Sendable {
         let containerManager = ContainerManager(
             imageManager: imageManager,
             kernelPath: config.kernelPath,
+            // ImageStore.default.path rather than a re-derivation of Apple's
+            // path: re-deriving it would silently diverge the day Apple changes
+            // it, and a hand-rolled `urls(for:in:)[0]` traps on an empty array
+            // where ImageStore.defaultRoot() throws.
+            imageStoreRoot: ImageStore.default.path,
+            layerCachePath: URL(
+                fileURLWithPath: NSString(string: "~/.arca/layers").expandingTildeInPath
+            ),
             stateStore: stateStore,
             logger: logger
         )

--- a/Sources/ArcaEngine/EngineCreate.swift
+++ b/Sources/ArcaEngine/EngineCreate.swift
@@ -1,0 +1,298 @@
+import ContainerBridge
+import SandboxEngineProto
+
+/// Everything `ContainerManager.createContainer` is given for one sandbox,
+/// translated once and in one place.
+///
+/// **This type exists to make the pure half of `Create` provable.**
+/// `createContainer` guards on `nativeManager` (`ContainerManager.swift:1659`),
+/// which is assigned only inside `initialize()`, which constructs a live
+/// `Containerization.VmnetNetwork` and needs the virtualization entitlement --
+/// so no test in this target may reach the call. Every decision that turns a
+/// `CreateRequest` into these arguments is a decision that can be wrong
+/// independently of whether a VM boots, and holding them in a value lets each
+/// one be asserted directly rather than inferred from a sandbox that ran.
+///
+/// It is not a second construction path. `create(request:)` builds exactly one
+/// of these and passes exactly these fields; there is no arrangement in which a
+/// test's spec and the engine's spec can differ.
+package struct SandboxContainerSpec {
+    /// The reference `createContainer` resolves the image by AND records as
+    /// `ContainerInfo.image`. One string doing both jobs is the constraint that
+    /// decided Problem 1 -- see `heldImageReferences(for:)`.
+    package let image: String
+    package let name: String
+    package let env: [String]
+    package let labels: [String: String]
+    package let networkMode: String
+    package let binds: [String]
+    package let portBindings: [String: [PortBinding]]
+    package let memory: Int64?
+    package let nanoCpus: Int64?
+    package let user: String?
+}
+
+/// One create request as ContainerBridge arguments, or the first thing about it
+/// this engine will not do.
+///
+/// **Every field of `CreateRequest` is either translated here or refused here.**
+/// Silently dropping one is the failure this whole milestone is arranged
+/// against: an engine that ignores `resources` reports a successful `Create`,
+/// and `Inspect` -- which reports what the store holds -- then agrees with it,
+/// so nothing downstream can tell that no limit was applied. The sibling backend
+/// takes the same position and is the precedent for which fields are refused
+/// rather than approximated (`crates/gascan-apple/src/translate.rs:172-233`).
+///
+/// The codes are chosen for what the consumer does with them
+/// (`crates/gascan-arca/src/error.rs`): `invalid_resource_identity` for a name
+/// this engine cannot accept as an identity, `invalid_state` for a request field
+/// that is well-formed as a string but not as a request, and
+/// `unsupported_capability` for the three things this engine cannot do at all.
+/// A capability refusal is a final answer about the build; an identity refusal
+/// is a final answer about the request. Collapsing them would make a consumer
+/// retry the one it should give up on.
+///
+/// `image` is a parameter rather than something derived here because resolving
+/// it requires the image store, and this function is deliberately pure.
+package func sandboxContainerSpec(
+    for request: Arca_Engine_V1_CreateRequest,
+    image: String
+) -> Result<SandboxContainerSpec, Arca_Engine_V1_EngineError> {
+    let name = SandboxIdentity.containerName(forSandboxId: request.sandboxID)
+
+    if let reason = SandboxIdentity.refusalReason(forSandboxId: request.sandboxID) {
+        return .failure(engineError(
+            .invalidResourceIdentity, resource: request.sandboxID, message: reason
+        ))
+    }
+
+    // Well-formedness, not interpretation. The engine stores labels verbatim and
+    // never decides whether a labelled resource is the caller's
+    // (engine.proto:143-148), so there is deliberately NO comparison of
+    // `owner.sandboxID` against `request.sandboxID` here -- that judgment is the
+    // consumer's and it makes it itself (`translate.rs:421-425`). What this does
+    // refuse is a half-set `OwnerLabels`, because every resource below is
+    // reported back carrying these labels and gascan discards a created resource
+    // whose ownership does not read as its own (`runtime.rs:962-975`). An
+    // engine that created three volumes under empty labels would report them and
+    // have the report thrown away -- a leak with a success next to it.
+    guard !request.owner.managedBy.isEmpty, !request.owner.sandboxID.isEmpty else {
+        return .failure(engineError(
+            .invalidResourceIdentity,
+            resource: name,
+            message: "create requires both owner labels; this request carries "
+                + "managed_by '\(request.owner.managedBy)' and sandbox_id "
+                + "'\(request.owner.sandboxID)', and a resource created under a half-set "
+                + "owner is one the consumer cannot recognise as its own"
+        ))
+    }
+    let labels = SandboxIdentity.labels(from: request.owner)
+
+    // The one mount, and it is not optional. `ProjectMount` is singular in the
+    // contract because "a project root is permitted and nothing else"
+    // (engine.proto:190-193); an unset message arrives with both paths empty,
+    // which would silently create a sandbox with no project in it.
+    guard request.project.hostPath.hasPrefix("/"), request.project.guestPath.hasPrefix("/") else {
+        return .failure(engineError(
+            .invalidState,
+            resource: name,
+            message: "the project mount needs an absolute host path and an absolute guest "
+                + "path; this request carries '\(request.project.hostPath)' and "
+                + "'\(request.project.guestPath)'"
+        ))
+    }
+    var binds = ["\(request.project.hostPath):\(request.project.guestPath)"]
+
+    for volume in request.volumes {
+        guard !volume.name.isEmpty else {
+            return .failure(engineError(
+                .invalidResourceIdentity,
+                resource: name,
+                message: "a volume in this request carries no name"
+            ))
+        }
+        guard volume.guestPath.hasPrefix("/") else {
+            return .failure(engineError(
+                .invalidState,
+                resource: volume.name,
+                message: "volume \(volume.name) needs an absolute guest path and carries "
+                    + "'\(volume.guestPath)'"
+            ))
+        }
+        binds.append("\(volume.name):\(volume.guestPath)")
+    }
+
+    // Keyed by guest port, so two mappings on one guest port would collapse into
+    // whichever the iteration reached last -- a published port the consumer
+    // asked for and never hears was dropped. The consumer refuses a repeated
+    // HOST port on its own side (`translate.rs:120-125`) and says nothing about
+    // the guest side, so this is the only place a guest-port collision can be
+    // caught. Both directions are refused here rather than one.
+    var portBindings: [String: [PortBinding]] = [:]
+    var hostPorts: Set<UInt32> = []
+    for port in request.ports {
+        guard (1...65535).contains(port.guestPort), (1...65535).contains(port.hostPort) else {
+            return .failure(engineError(
+                .invalidState,
+                resource: name,
+                message: "port mapping \(port.hostPort):\(port.guestPort) names a number that "
+                    + "is not a port"
+            ))
+        }
+        guard hostPorts.insert(port.hostPort).inserted else {
+            return .failure(engineError(
+                .invalidState,
+                resource: name,
+                message: "host port \(port.hostPort) is mapped twice"
+            ))
+        }
+        // Loopback is implied by the contract and is not a field
+        // (engine.proto:207-209). It is also what makes the mapping work at all:
+        // `PortMapManager.shouldSpawnProxy(for:)` spawns the userspace proxy
+        // only for a loopback host address, so a binding recorded as 0.0.0.0 --
+        // `PortBinding`'s own default (`Types.swift:303`) -- takes the
+        // nftables-only path instead.
+        let key = "\(port.guestPort)/tcp"
+        guard portBindings[key] == nil else {
+            return .failure(engineError(
+                .invalidState,
+                resource: name,
+                message: "guest port \(port.guestPort) is mapped twice, and a container's "
+                    + "port bindings are keyed by guest port, so one of the two would be lost"
+            ))
+        }
+        portBindings[key] = [PortBinding(hostIp: "127.0.0.1", hostPort: "\(port.hostPort)")]
+    }
+
+    // `NAME=value` is the only shape ContainerBridge accepts, so a name that
+    // already contains `=` would arrive in the guest as a different variable
+    // than the one that was asked for.
+    var env: [String] = []
+    for variable in request.environment {
+        guard !variable.name.isEmpty, !variable.name.contains("=") else {
+            return .failure(engineError(
+                .invalidState,
+                resource: name,
+                message: "environment variable name '\(variable.name)' is empty or contains "
+                    + "'=', and environment is passed as NAME=value"
+            ))
+        }
+        env.append("\(variable.name)=\(variable.value)")
+    }
+
+    // Two limits this engine applies and two it cannot. Refused rather than
+    // dropped, and refused as `unsupported_capability` rather than as a bad
+    // request, because the request is not wrong -- this build is short. The
+    // Apple backend refuses the same two (`translate.rs:214-219`).
+    if request.resources.hasDiskBytes {
+        return .failure(engineError(
+            .unsupportedCapability,
+            resource: name,
+            message: "this engine cannot apply a disk limit"
+        ))
+    }
+    if request.resources.hasProcessCount {
+        return .failure(engineError(
+            .unsupportedCapability,
+            resource: name,
+            message: "this engine cannot apply a process-count limit"
+        ))
+    }
+
+    // `nanoCpus` is Docker's unit and the one ContainerBridge takes: whole CPUs
+    // times 1e9. Multiplied in Int64 after widening, because a `UInt32` count
+    // times a billion leaves 32 bits far behind.
+    let nanoCpus = request.resources.hasCpus ? Int64(request.resources.cpus) * 1_000_000_000 : nil
+    let memory = request.resources.hasMemoryBytes ? Int64(request.resources.memoryBytes) : nil
+
+    let user: String
+    switch request.user {
+    case .workspace: user = "workspace"
+    case .root: user = "root"
+    default:
+        return .failure(engineError(
+            .invalidState,
+            resource: name,
+            message: "create must name the user the workspace process runs as, and this "
+                + "request names none"
+        ))
+    }
+
+    // **`init: true` is honoured by Arca's architecture rather than by a flag,
+    // and `init: false` is the case this engine cannot serve.** Every Arca
+    // container is a VM whose PID 1 is vminitd (`ContainerManager.swift:1946`,
+    // "Containers run as PID 1 in their VM"), so the workspace process already
+    // runs under an init that reaps for it, and there is no parameter on
+    // `createContainer` to switch off. Answering a request for no init with a
+    // sandbox that has one is the silent divergence this file exists to avoid.
+    // gascan only ever asks for `true` (`translate.rs:229-231` refuses to build
+    // a create that does not), so this refuses nothing it sends.
+    guard request.init_p else {
+        return .failure(engineError(
+            .unsupportedCapability,
+            resource: name,
+            message: "this engine runs every workspace process under vminitd as PID 1 and "
+                + "cannot create a sandbox without an init"
+        ))
+    }
+
+    // Offline is the absence of an attachment, expressed as the networkMode
+    // `startContainer` skips auto-attachment for (`ContainerManager.swift:2356`)
+    // -- "none" and "host" are the two it skips, and "none" is the one that also
+    // means no vmnet interface.
+    let networkMode: String
+    switch request.network.mode {
+    case .offline:
+        networkMode = "none"
+    case .networkedName(let networkName):
+        guard !networkName.isEmpty else {
+            return .failure(engineError(
+                .invalidResourceIdentity,
+                resource: name,
+                message: "a networked sandbox must name its network and this one names none"
+            ))
+        }
+        networkMode = networkName
+    case nil:
+        return .failure(engineError(
+            .invalidState,
+            resource: name,
+            message: "create must state a network mode -- offline or a named network -- and "
+                + "this request states neither"
+        ))
+    }
+
+    return .success(SandboxContainerSpec(
+        image: image,
+        name: name,
+        env: env,
+        labels: labels,
+        networkMode: networkMode,
+        binds: binds,
+        portBindings: portBindings,
+        memory: memory,
+        nanoCpus: nanoCpus,
+        user: user
+    ))
+}
+
+/// The driver options one requested volume needs.
+///
+/// `capacity_bytes` is the contract's only sizing field and ContainerBridge has
+/// exactly one driver that can honour it: `block` formats an EXT4 image at
+/// `driverOpts["size"]` (`VolumeManager.swift:165-195`), while `local` is a
+/// VirtioFS directory share with no size at all (`:126-158`). So a capacity is
+/// a block volume and no capacity is a local one. This mirrors the sibling
+/// backend, which passes the same number as `container volume create -s`
+/// (`crates/gascan-apple/src/backend.rs:300`).
+///
+/// Zero is "no capacity was declared", which is the only reading available: the
+/// field is a bare `uint64` (engine.proto:200), so an unset one and a requested
+/// zero are the same bytes on the wire, and a zero-byte volume is not a thing to
+/// create in preference to an unsized one.
+package func volumeDriver(forCapacityBytes bytes: UInt64) -> (driver: String, options: [String: String]?) {
+    guard bytes > 0 else { return ("local", nil) }
+    // `parseSizeString` reads a bare number as bytes (`VolumeManager.swift:552-557`),
+    // which is the unit the contract carries, so no unit suffix is appended.
+    return ("block", ["size": "\(bytes)"])
+}

--- a/Sources/ArcaEngine/EngineCreate.swift
+++ b/Sources/ArcaEngine/EngineCreate.swift
@@ -243,6 +243,34 @@ package func sandboxContainerSpec(
     let networkMode: String
     switch request.network.mode {
     case .offline:
+        // **An offline sandbox cannot publish a port, so a request for both is
+        // refused rather than half-served.** Offline means no network
+        // attachment, so `getWireGuardClient` returns nil for the container
+        // (`NetworkManager.swift:819-833`) and the publish gate it feeds has no
+        // `else` (`ContainerManager.swift:2494-2541`). Accepting this request
+        // produces a sandbox that is created, started, and reported successful,
+        // whose `Inspect` names the binding -- because Task 7 reports what the
+        // store holds -- and which nothing on the host can connect to. Every
+        // check green over a port that does not exist.
+        //
+        // The combination is the contract's to permit: `Network` is a `oneof`
+        // and `ports` is a separate `repeated` field (engine.proto:238-246),
+        // with nothing saying which wins. That is a gap in the contract and is
+        // recorded as one; what this engine will not do is resolve it silently.
+        //
+        // `unsupported_capability` rather than a bad-request code: the request
+        // is well formed and this build cannot serve it, which is what that
+        // code says.
+        guard request.ports.isEmpty else {
+            return .failure(engineError(
+                .unsupportedCapability,
+                resource: name,
+                message: "this engine cannot publish ports for an offline sandbox: offline "
+                    + "means no network attachment, so there is nothing to publish through "
+                    + "and the \(request.ports.count) requested port mapping(s) would be "
+                    + "silently dropped"
+            ))
+        }
         networkMode = "none"
     case .networkedName(let networkName):
         guard !networkName.isEmpty else {

--- a/Sources/ArcaEngine/EngineImageLoad.swift
+++ b/Sources/ArcaEngine/EngineImageLoad.swift
@@ -1,0 +1,97 @@
+import ContainerBridge
+import Foundation
+import Logging
+
+/// What an `image load` put where.
+///
+/// `storeRoot` is read back from the `ImageManager` that performed the load,
+/// not re-derived from the state root beside it. The whole milestone rests on
+/// the engine's image store being its own -- ArcaDaemon shares Apple's and
+/// deletes `initfs.ext4` out of it on every start -- so a load that quietly
+/// wrote into the shared store would undo it silently, and a report that
+/// restated the expected path could not tell anyone that it had. The value here
+/// is the one the store actually used.
+///
+/// `references` is what distinguishes loading something from loading nothing.
+/// A load that reports only success is the shape this project has been bitten
+/// by repeatedly.
+package struct ImageLoadReport: Sendable, Equatable {
+    package let storeRoot: URL
+    package let references: [String]
+
+    package init(storeRoot: URL, references: [String]) {
+        self.storeRoot = storeRoot
+        self.references = references
+    }
+}
+
+/// The option `loadWorkspaceImages` refuses on behalf of, so a refusal names
+/// the thing the user would change.
+///
+/// Deliberately not `--vminit-layout`. That one is a *startup input* the engine
+/// must hold before it can construct a manager at all; this one is *content a
+/// consumer pushes* afterwards. Two concerns, two options, and keeping them
+/// apart is what avoids an install-time ordering step between them.
+private let ociLayoutOption = "--oci-layout"
+
+/// Loads an OCI image layout into the engine's OWN image store, and reports
+/// which references landed and where.
+///
+/// Lives in `ArcaEngine` and not in the `arca-engine` executable for the reason
+/// `EnginePaths` and `EngineManagers` do: a test target cannot import an
+/// executable, so a load only the executable can reach is a load no test can
+/// assert on. `ImageLoadTests` drives this function directly, and the
+/// subcommand over it by spawning the binary.
+///
+/// Nothing here calls `initialize()` on anything, and nothing here needs to.
+/// `ImageManager` opens its `ImageStore` in `init` and its own `initialize()`
+/// only logs (`ContainerBridge/ImageManager.swift:40-48`), while the
+/// `initialize()` that matters -- `ContainerManager`'s -- constructs a live
+/// `Containerization.VmnetNetwork` and needs an entitlement. An image load that
+/// demanded a VM and an entitlement is an image load that could not run in CI,
+/// so this deliberately touches neither, binds no socket, and serves nothing.
+///
+/// The load is wrapped rather than left to throw raw. `ImageStore.load` refuses
+/// a layout it can import nothing from -- it throws `failed to import image`
+/// when the imported set is empty
+/// (containerization/Sources/Containerization/Image/ImageStore/ImageStore+OCILayout.swift:101-103)
+/// -- and it refuses a truncated blob too, but neither message names an option
+/// or a path, which is the failure `validateOCILayoutDirectory`'s
+/// existence-only marker check leaves behind. Wrapping keeps the cause verbatim
+/// and adds the two things a user needs to act: which option, and which path.
+package func loadWorkspaceImages(
+    fromOCILayout layout: URL,
+    stateRoot: URL,
+    logger: Logger
+) async throws -> ImageLoadReport {
+    // Before the store is opened, so a bad layout leaves no state root behind:
+    // the same posture, and the same ordering, that `validateEngineInputs`
+    // holds ahead of `createSocketParentDirectory` at startup.
+    try validateOCILayoutDirectory(layout, option: ociLayoutOption)
+
+    let imageManager = try EngineManagers.makeImageManager(
+        paths: EnginePaths(stateRoot: stateRoot), logger: logger
+    )
+
+    // `[Containerization.Image]` is never named here, only mapped over, which is
+    // what keeps `ArcaEngine`'s declared dependencies as they are: `loadVminit`
+    // reads the same return value the same way, and neither needs the module
+    // imported to do it.
+    let references: [String]
+    do {
+        references = try await imageManager.loadFromOCILayout(directory: layout)
+            .map(\.reference)
+    } catch {
+        throw EngineStartupError.unreadableInput(
+            name: ociLayoutOption, path: layout.path, cause: "\(error)"
+        )
+    }
+
+    let report = ImageLoadReport(storeRoot: imageManager.storeRoot, references: references)
+    logger.info("loaded images into the engine's own store", metadata: [
+        "store": "\(report.storeRoot.path)",
+        "count": "\(report.references.count)",
+        "images": "\(report.references.joined(separator: ", "))",
+    ])
+    return report
+}

--- a/Sources/ArcaEngine/EngineLifecycle.swift
+++ b/Sources/ArcaEngine/EngineLifecycle.swift
@@ -1,0 +1,265 @@
+import SandboxEngineProto
+
+/// The decisions `Start`, `Stop` and `Remove` make before they touch anything,
+/// held here for the reason `EngineCreate.swift` holds `Create`'s: they are pure
+/// values, and the acts they gate are not reachable without a VM.
+///
+/// **These three are the first methods that WRITE.** Everything Landing 3 shipped
+/// reads: a wrong answer from `Inspect` is a wrong report, and the consumer's own
+/// checks stand behind it. A wrong answer here boots a VM, kills one, or deletes a
+/// volume, and there is nothing behind it. So each of the gates below is written
+/// as a refusal the engine makes for itself rather than a property it assumes of
+/// the caller.
+
+// MARK: - The resolver hazard, carried into every method that acts
+
+/// Whether the engine may resolve a container by the name in this request.
+///
+/// `SandboxIdentity.refusalReason(forSandboxId:)` is the whole rule and this is
+/// only the sentence that puts it in front of `Start`, `Stop` and `Remove` as
+/// well as `Create`. It is stated here because the reason it exists changed when
+/// these three landed.
+///
+/// `ContainerManager.resolveContainerID` (`:1999`) tries a hex prefix match
+/// *before* the name lookup at `:2026`: any input of 4 or more characters that is
+/// entirely hex is prefix-matched against Docker ids, and on more than one match
+/// it returns `matches.sorted().first` with a warning and no error.
+///
+/// **What that costs is measured, not argued.** Two tests hold the two call
+/// sites, and each is red when its own call to this function is deleted, run as
+/// `swift test --filter ArcaEngineTests`:
+///
+/// - deleted from `SandboxEngineService.lifecycleAck`, the only failure is
+///   `LifecycleTests.testStopRefusesAHexSandboxIdItWouldOtherwiseHaveAckedForAnUnrelatedContainer`
+///   -- the engine resolves `beef` to a container named `unrelated-container`
+///   and answers `Ack` for having stopped a sandbox it never touched.
+/// - deleted from `removableKind` below, the only failure is
+///   `LifecycleTests.testARemoveNamingAHexPrefixRefusesAndDeletesNothing`, which
+///   finds that same container **deleted**.
+///
+/// A Gas Can sandbox id always contains a hyphen
+/// (`crates/gascan-core/src/sandbox.rs`), so a well-behaved consumer cannot send
+/// such a name. That is exactly why the engine enforces it rather than assuming
+/// it: nothing on this side of the socket makes it true, and the property decides
+/// which container gets destroyed.
+///
+/// Volume and network names do not go through it -- `VolumeManager.volumes` and
+/// `NetworkManager.networkNames` are exact-key dictionary lookups
+/// (`VolumeManager.swift:297-303`, `NetworkManager.swift:696-702`) -- so this gate
+/// is applied to container names only, and applying it wider would refuse volume
+/// names the consumer is entitled to use.
+func containerNameRefusal(_ name: String) -> Arca_Engine_V1_EngineError? {
+    guard let reason = SandboxIdentity.refusalReason(forSandboxId: name) else { return nil }
+    return engineError(.invalidResourceIdentity, resource: name, message: reason)
+}
+
+// MARK: - Start and Stop
+
+/// Why this engine will not run a lifecycle verb against the container it holds
+/// under this name, or nil when it will.
+///
+/// `storedLabels` is nil when the engine holds no container under the name.
+///
+/// **Absent is `not_found` and unlabelled is `foreign_resource_refused`, and the
+/// two are not the same answer.** `not_found` is a final answer about a sandbox
+/// that is not there, which a reconciler responds to by creating it.
+/// `foreign_resource_refused` says something else is there under that name, which
+/// a reconciler must not respond to by creating a second one.
+///
+/// The unlabelled refusal is `Inspect`'s, one step harder. Task 7 refuses to
+/// *assert* that an unlabelled container is the sandbox that was asked for
+/// (`SandboxEngineService.sandboxResponse`); these methods would *boot* or *kill*
+/// it. Container names are a flat namespace this engine does not own, so a
+/// sandbox id can resolve to something the consumer never created, and starting
+/// it is a VM the consumer did not ask for running work it cannot see.
+///
+/// There is deliberately **no label comparison** here, unlike `Remove`'s.
+/// `StartRequest` and `StopRequest` carry a `sandbox_id` and nothing else
+/// (engine.proto:367-375) -- there are no caller labels on the wire to compare
+/// against, so an engine that decided a labelled container was or was not the
+/// caller's would be inventing the caller's identity. `Remove` compares because
+/// `RemoveRequest.owner` exists (`:383`). The asymmetry is the contract's.
+///
+/// **`containerNameRefusal` is deliberately NOT repeated here**, and the reason
+/// is a measured one. It ran in both this function and `lifecycleAck`, one
+/// belt-and-braces call apart, and the duplicate made the gate unfalsifiable:
+/// deleting the call in `lifecycleAck` -- the one that decides whether the
+/// resolver sees the name at all -- left `swift test --filter ArcaEngineTests`
+/// reporting `Executed 147 tests, with 0 failures`, because this copy caught it.
+/// A gate that two places enforce is a gate no test measures. It belongs in
+/// `lifecycleAck`, before the read, because a name this engine refuses to act
+/// under is one it should not resolve either.
+func lifecycleRefusal(
+    verb: String,
+    sandboxId: String,
+    storedLabels: [String: String]?
+) -> Arca_Engine_V1_EngineError? {
+    guard let labels = storedLabels else {
+        return engineError(
+            .notFound,
+            resource: sandboxId,
+            message: "this engine holds no container named \(sandboxId) to \(verb)"
+        )
+    }
+    guard SandboxIdentity.owner(from: labels) != nil else {
+        return engineError(
+            .foreignResourceRefused,
+            resource: sandboxId,
+            message: "container \(sandboxId) carries no gascan owner labels, so this engine "
+                + "cannot assert it is the sandbox that was asked for and will not \(verb) it"
+        )
+    }
+    return nil
+}
+
+// MARK: - Remove
+
+/// The three kinds `Remove` can delete, with `UNSPECIFIED` and any future value
+/// already excluded.
+///
+/// A parsed kind rather than a switch on the wire enum at each step, so that
+/// "this engine cannot delete that" is decided exactly once and no later switch
+/// needs an unreachable arm to satisfy exhaustiveness -- an arm no test could
+/// ever cover and which would quietly become reachable if the contract grew a
+/// fourth kind.
+enum RemovableKind {
+    case container
+    case volume
+    case network
+
+    /// The word an operator reading a refusal needs.
+    var noun: String {
+        switch self {
+        case .container: return "container"
+        case .volume: return "volume"
+        case .network: return "network"
+        }
+    }
+
+    /// The order `Remove` deletes in: containers, then volumes, then networks.
+    ///
+    /// **This is a dependency order and it is load-bearing, not tidiness.**
+    /// `VolumeManager.deleteVolume` refuses a volume any container still mounts
+    /// (`VolumeManager.swift:317-327`, `VolumeError.inUse`), and the
+    /// `volume_mounts` rows that make it "in use" are cleared by CASCADE when the
+    /// container row is deleted (`ContainerManager.swift:3173`). So a `Remove`
+    /// that deleted volumes first would fail on every sandbox that has one --
+    /// which is every sandbox Gas Can creates.
+    ///
+    /// MEASURED with the sort in `remove(request:)` deleted, so the request's own
+    /// order stands: `swift test --filter ArcaEngineTests`, the only failure is
+    /// `LifecycleTests.testRemoveDeletesAContainerTheVolumeItMountsAndItsNetworkInOneCall`,
+    /// which gets `invalid_state` naming the volume where it expected `Ack`.
+    ///
+    /// It is the reverse of `Create`'s volumes -> network -> container, which is
+    /// the same dependency read the other way, and it is the order the sibling
+    /// backend already uses (`crates/gascan-apple/src/backend.rs:487-491`) and the
+    /// one the consumer's own fake runtime sorts into
+    /// (`crates/gascan-core/src/fake_runtime.rs:935-940`). Three implementations
+    /// of one contract agreeing is worth more than any of them arguing.
+    var removalRank: Int {
+        switch self {
+        case .container: return 0
+        case .volume: return 1
+        case .network: return 2
+        }
+    }
+}
+
+/// The kind this identity names, or the refusal that says why the engine will
+/// not act on it.
+///
+/// `RESOURCE_KIND_UNSPECIFIED` is an unset field, which arrives as a request to
+/// delete "a resource" with no statement of which kind -- and the three kinds
+/// live in three separate namespaces, so guessing would pick a namespace. An
+/// empty name is refused for the same reason `containerResourceName` falls back
+/// to an id: a resource with no name is not one this engine can find.
+func removableKind(
+    _ identity: Arca_Engine_V1_ResourceIdentity
+) -> Result<RemovableKind, Arca_Engine_V1_EngineError> {
+    let kind: RemovableKind
+    switch identity.kind {
+    case .container: kind = .container
+    case .volume: kind = .volume
+    case .network: kind = .network
+    case .unspecified, .UNRECOGNIZED:
+        return .failure(engineError(
+            .invalidResourceIdentity,
+            resource: identity.name,
+            message: "a remove names each resource's kind, and this one names "
+                + "\(identity.kind) -- container, volume and network are three separate "
+                + "namespaces and this engine will not guess which one to delete from"
+        ))
+    }
+    guard !identity.name.isEmpty else {
+        return .failure(engineError(
+            .invalidResourceIdentity,
+            resource: "",
+            message: "a \(kind.noun) in this remove carries no name"
+        ))
+    }
+    if kind == .container, let refusal = containerNameRefusal(identity.name) { return .failure(refusal) }
+    return .success(kind)
+}
+
+/// Why this engine will not delete the resource it holds under this identity, or
+/// nil when it will.
+///
+/// `storedLabels` is nil when the engine holds no such resource.
+///
+/// **This is `Inspect`'s posture, not `ListResources`'.** `ListResources` reports
+/// an unlabelled resource with `owner` unset, because a consumer's leak detection
+/// depends on seeing it (engine.proto:389-391). That is a report. This is an
+/// authorisation, and the two answer different questions -- reporting a resource
+/// the consumer does not own is how it finds a leak; deleting one is how it
+/// causes an incident.
+///
+/// The three refusals are the three the consumer's own reference implementation
+/// raises, in the same order (`crates/gascan-core/src/fake_runtime.rs:916-934`):
+/// absent is `not_found`, unlabelled is `foreign_resource_refused`, and labels
+/// that differ from the caller's are `ownership_mismatch`.
+///
+/// **The comparison is on both labels and it is exact.** A resource carrying
+/// `managed_by=gascan` under a different `sandbox_id` is another sandbox's, and
+/// deleting it is precisely what `engine.proto:381-383` says this field exists to
+/// stop: "so one consumer cannot be induced to delete another's resource".
+/// Comparing only `sandbox_id` would let a different tool's resource through on a
+/// colliding id, and comparing only `managed_by` would let every gascan sandbox
+/// delete every other one.
+///
+/// This is not the engine interpreting labels, which `engine.proto:143-148`
+/// forbids. It is not deciding whether a labelled resource is the caller's on the
+/// caller's behalf -- the caller has *said* whose it is, in `RemoveRequest.owner`,
+/// and this refuses to act when the store disagrees with what the caller said.
+func removalRefusal(
+    kind: RemovableKind,
+    name: String,
+    storedLabels: [String: String]?,
+    owner: Arca_Engine_V1_OwnerLabels
+) -> Arca_Engine_V1_EngineError? {
+    guard let labels = storedLabels else {
+        return engineError(
+            .notFound,
+            resource: name,
+            message: "this engine holds no \(kind.noun) named \(name)"
+        )
+    }
+    guard let stored = SandboxIdentity.owner(from: labels) else {
+        return engineError(
+            .foreignResourceRefused,
+            resource: name,
+            message: "\(kind.noun) \(name) carries no gascan owner labels, so this engine "
+                + "cannot establish it is the caller's and will not delete it"
+        )
+    }
+    guard stored == owner else {
+        return engineError(
+            .ownershipMismatch,
+            resource: name,
+            message: "\(kind.noun) \(name) is labelled managed_by '\(stored.managedBy)' "
+                + "sandbox_id '\(stored.sandboxID)', and this remove is made under "
+                + "managed_by '\(owner.managedBy)' sandbox_id '\(owner.sandboxID)'"
+        )
+    }
+    return nil
+}

--- a/Sources/ArcaEngine/EngineManagers.swift
+++ b/Sources/ArcaEngine/EngineManagers.swift
@@ -86,6 +86,53 @@ public struct EngineManagers: Sendable {
         self.execManager = ExecManager(containerManager: containerManager, logger: logger)
     }
 
+    /// Hands `ContainerManager` the two collaborators it holds optionally.
+    ///
+    /// `ContainerManager` takes these by setter rather than by initializer
+    /// because `NetworkManager.init` already takes a `ContainerManager`: the two
+    /// refer to each other, so one edge has to be set after construction. That
+    /// makes the edge easy to omit, and omitting it is silent. `ArcaDaemon` sets
+    /// both (`ArcaDaemon.swift:236`, `:262`); until this existed the engine set
+    /// neither, and `ContainerBridge` had already written down what that costs:
+    ///
+    /// - `ContainerManager.swift:1743` throws `volumeManagerNotAvailable` for
+    ///   any container with anonymous volumes, so `Create` could not serve one.
+    /// - `ContainerManager.swift:4129` `cleanupVolumesForContainer` **returns
+    ///   silently** when `volumeManager` is nil, so `Remove` would delete the
+    ///   container, report success, and leave its anonymous volumes on disk with
+    ///   nothing in the store pointing at them. A leak the consumer cannot see
+    ///   is the failure `ListResources` exists to prevent.
+    /// - `ContainerManager.swift:826` builds a container's `NetworkSettings`
+    ///   only when `networkManager` is set, so `Inspect` would report a
+    ///   container on a network as attached to nothing.
+    ///
+    /// Called after all three `initialize()` calls, which is what `ArcaDaemon`
+    /// does and what the setters' own comments ask for. Nothing read during
+    /// `initialize()` consults either collaborator: the network restoration that
+    /// does (`ContainerManager.swift:2427`) is inside `startContainer`, not
+    /// inside `loadPersistedState`.
+    ///
+    /// Separate from the `initialize()` sequence, and VM-free, because that is
+    /// what lets it be proved at all. `ContainerManager.initialize()` constructs
+    /// a real `VmnetNetwork`, so no test may call a method containing it; this
+    /// one a test can call, and `EngineManagerWiringTests` drives each line
+    /// through behaviour rather than through the call. MEASURED, one line
+    /// removed at a time, `swift test --filter ArcaEngineTests`:
+    ///
+    /// - without `setVolumeManager`: `Executed 63 tests, with 1 failure` --
+    ///   `testRemovingAContainerDeletesItsAnonymousVolumeAndSparesTheNamedOne`,
+    ///   which found `["anon-vol", "named-vol"]` both still present after
+    ///   `Remove` had reported success.
+    /// - without `setNetworkManager`: `Executed 63 tests, with 3 failures`, all
+    ///   in `testAnAttachedContainerReportsTheNetworkItIsOn`, whose networks
+    ///   dictionary came back `[]`.
+    ///
+    /// Restored: `Executed 63 tests, with 0 failures`.
+    public func wireCollaborators() async {
+        await containerManager.setVolumeManager(volumeManager)
+        await containerManager.setNetworkManager(networkManager)
+    }
+
     /// The service over these managers.
     ///
     /// Here rather than at each call site for the reason the wiring above is:

--- a/Sources/ArcaEngine/EngineManagers.swift
+++ b/Sources/ArcaEngine/EngineManagers.swift
@@ -64,6 +64,7 @@ public struct EngineManagers: Sendable {
             kernelPath: kernelPath.path,
             imageStoreRoot: paths.imageStoreRoot,
             layerCachePath: paths.layerCache,
+            logRoot: paths.logsRoot,
             stateStore: stateStore,
             logger: logger
         )

--- a/Sources/ArcaEngine/EngineManagers.swift
+++ b/Sources/ArcaEngine/EngineManagers.swift
@@ -1,0 +1,104 @@
+import ContainerBridge
+import Foundation
+import Logging
+
+/// Every ContainerBridge manager the engine serves over, built once.
+///
+/// `EnginePaths` unified where the paths come *from*; this unifies which derived
+/// path reaches which constructor argument, which was the half still spelt out
+/// twice -- once in `ArcaEngineCommand.run()` and once in the tests' own
+/// `SandboxEngineService.forTesting`. Task 1's review measured that arrangement:
+/// swapping `imageStoreRoot: paths.layerCache` in the command alone left all 34
+/// tests of the day green, because the tests drove a parallel wiring over the
+/// shared derivation rather than the wiring itself.
+///
+/// There is one wiring now, and the tests drive it. MEASURED here, with the same
+/// swap applied to the `ContainerManager(...)` call below:
+/// `swift test --filter ArcaEngineTests` reported `Executed 60 tests, with 1
+/// failure`, that failure being
+/// `ContainerBridgePathsTests.testTheInitfsIsInsideTheImageStoreTheEngineHandsContainerization`.
+/// Restored, the same command reports `Executed 60 tests, with 0 failures`.
+///
+/// It lives in `ArcaEngine` rather than in the `arca-engine` executable for the
+/// reason `EnginePaths` does: a test target cannot import an executable, so a
+/// wiring only the executable can reach is a wiring no test can assert on.
+///
+/// Constructing this does not initialize anything. `initialize()` needs a live
+/// `Containerization.VmnetNetwork` and boots nothing until the engine asks --
+/// see the ordering note at `ArcaEngineCommand.run()`, which is the only caller
+/// that may ask.
+public struct EngineManagers: Sendable {
+    /// The derivation every path below came from, exposed so a caller can name
+    /// the same directories the managers were rooted in without re-deriving
+    /// them.
+    public let paths: EnginePaths
+
+    public let stateStore: StateStore
+    public let imageManager: ImageManager
+    public let containerManager: ContainerManager
+    public let volumeManager: VolumeManager
+    public let networkManager: NetworkManager
+    public let execManager: ExecManager
+
+    private let logger: Logger
+
+    /// Builds the managers for one state root.
+    ///
+    /// The kernel is a parameter rather than an `EnginePaths` member for the
+    /// same reason it is a separate CLI option: it is a read-only input the
+    /// engine is handed, not state the engine owns.
+    ///
+    /// `logLevel` reaches `ArcaConfig` only. It is a string here because that is
+    /// what `ArcaConfig` takes; the command has already parsed its own
+    /// `Logger.Level` from it.
+    public init(stateRoot: URL, kernelPath: URL, logLevel: String, logger: Logger) throws {
+        let paths = EnginePaths(stateRoot: stateRoot)
+        self.paths = paths
+        self.logger = logger
+
+        self.stateStore = try StateStore(path: paths.stateDatabase.path, logger: logger)
+        self.imageManager = try ImageManager(
+            logger: logger, imageStorePath: paths.imageStoreRoot
+        )
+        self.containerManager = ContainerManager(
+            imageManager: imageManager,
+            kernelPath: kernelPath.path,
+            imageStoreRoot: paths.imageStoreRoot,
+            layerCachePath: paths.layerCache,
+            stateStore: stateStore,
+            logger: logger
+        )
+        self.volumeManager = VolumeManager(
+            volumesBasePath: paths.volumesRoot.path,
+            stateStore: stateStore,
+            logger: logger
+        )
+        self.networkManager = NetworkManager(
+            config: ArcaConfig(
+                kernelPath: kernelPath.path,
+                socketPath: paths.socket.path,
+                logLevel: logLevel
+            ),
+            stateStore: stateStore,
+            containerManager: containerManager,
+            logger: logger
+        )
+        self.execManager = ExecManager(containerManager: containerManager, logger: logger)
+    }
+
+    /// The service over these managers.
+    ///
+    /// Here rather than at each call site for the reason the wiring above is:
+    /// six arguments spelt out twice is six chances for the command and the
+    /// tests to hand the service different managers.
+    public func makeService() -> SandboxEngineService {
+        SandboxEngineService(
+            containerManager: containerManager,
+            volumeManager: volumeManager,
+            networkManager: networkManager,
+            imageManager: imageManager,
+            execManager: execManager,
+            logger: logger
+        )
+    }
+}

--- a/Sources/ArcaEngine/EngineManagers.swift
+++ b/Sources/ArcaEngine/EngineManagers.swift
@@ -6,7 +6,7 @@ import Logging
 ///
 /// `EnginePaths` unified where the paths come *from*; this unifies which derived
 /// path reaches which constructor argument, which was the half still spelt out
-/// twice -- once in `ArcaEngineCommand.run()` and once in the tests' own
+/// twice -- once in `ServeCommand.run()` and once in the tests' own
 /// `SandboxEngineService.forTesting`. Task 1's review measured that arrangement:
 /// swapping `imageStoreRoot: paths.layerCache` in the command alone left all 34
 /// tests of the day green, because the tests drove a parallel wiring over the
@@ -25,7 +25,7 @@ import Logging
 ///
 /// Constructing this does not initialize anything. `initialize()` needs a live
 /// `Containerization.VmnetNetwork` and boots nothing until the engine asks --
-/// see the ordering note at `ArcaEngineCommand.run()`, which is the only caller
+/// see the ordering note at `ServeCommand.run()`, which is the only caller
 /// that may ask.
 public struct EngineManagers: Sendable {
     /// The derivation every path below came from, exposed so a caller can name
@@ -57,9 +57,7 @@ public struct EngineManagers: Sendable {
         self.logger = logger
 
         self.stateStore = try StateStore(path: paths.stateDatabase.path, logger: logger)
-        self.imageManager = try ImageManager(
-            logger: logger, imageStorePath: paths.imageStoreRoot
-        )
+        self.imageManager = try Self.makeImageManager(paths: paths, logger: logger)
         self.containerManager = ContainerManager(
             imageManager: imageManager,
             kernelPath: kernelPath.path,
@@ -84,6 +82,23 @@ public struct EngineManagers: Sendable {
             logger: logger
         )
         self.execManager = ExecManager(containerManager: containerManager, logger: logger)
+    }
+
+    /// The engine's own image store, rooted the one way.
+    ///
+    /// Static, and called by `init` above rather than duplicated by it, so that
+    /// a caller needing the image store and nothing else -- `arca-engine image
+    /// load`, which has no kernel, no state database and no VM -- reaches the
+    /// same `imageStorePath: paths.imageStoreRoot` mapping the served engine
+    /// does. `EnginePaths` already unified where the path comes from; this is
+    /// the other half, which derived path reaches which constructor argument,
+    /// and it is the half Task 1's review measured going wrong silently.
+    ///
+    /// This is not a second construction path for tests. Tests drive it because
+    /// `loadWorkspaceImages` does, exactly as they drive `init` through
+    /// `SandboxEngineService.forTesting`.
+    package static func makeImageManager(paths: EnginePaths, logger: Logger) throws -> ImageManager {
+        try ImageManager(logger: logger, imageStorePath: paths.imageStoreRoot)
     }
 
     /// Hands `ContainerManager` the two collaborators it holds optionally.

--- a/Sources/ArcaEngine/EngineManagers.swift
+++ b/Sources/ArcaEngine/EngineManagers.swift
@@ -166,16 +166,24 @@ public struct EngineManagers: Sendable {
     /// removed at a time, `swift test --filter ArcaEngineTests`, reported by
     /// which tests fail rather than by how many:
     ///
-    /// - without `setVolumeManager`, the only failure is
+    /// - without `setVolumeManager`, two tests fail and no others:
     ///   `EngineManagerWiringTests.testRemovingAContainerDeletesItsAnonymousVolumeAndSparesTheNamedOne`,
-    ///   which finds `["anon-vol", "named-vol"]` both still present after
-    ///   `Remove` has reported success.
+    ///   which drives `ContainerManager.removeContainer` directly, and
+    ///   `LifecycleTests.testRemovingAContainerThroughTheRPCDeletesItsAnonymousVolumeAndSparesTheNamedOne`,
+    ///   which drives the `Remove` RPC. Both find `["anon-vol", "named-vol"]`
+    ///   still present after the removal has reported success. The second joined
+    ///   the list when Task 12 landed `Remove`; the first is kept beside it
+    ///   because they fail for the same reason at two different altitudes, and
+    ///   the lower one keeps measuring if the RPC is ever rewritten.
     /// - without `setNetworkManager`, the only failing test is
     ///   `EngineManagerWiringTests.testAnAttachedContainerReportsTheNetworkItIsOn`,
     ///   on all three of its assertions, its networks dictionary having come
     ///   back `[]`.
     /// - without `setPortMapManager`, nothing fails, for the reason given above.
-    ///   That is the finding, not an omission.
+    ///   That is the finding, not an omission. Re-measured after Task 12: still
+    ///   nothing, because the one VM-free path that reaches the gate
+    ///   (`removeContainer`'s database-only branch) is reached here only by
+    ///   containers with no port bindings, and unpublishing none is a no-op.
     public func wireCollaborators() async {
         await containerManager.setVolumeManager(volumeManager)
         await containerManager.setNetworkManager(networkManager)

--- a/Sources/ArcaEngine/EngineManagers.swift
+++ b/Sources/ArcaEngine/EngineManagers.swift
@@ -39,6 +39,7 @@ public struct EngineManagers: Sendable {
     public let volumeManager: VolumeManager
     public let networkManager: NetworkManager
     public let execManager: ExecManager
+    public let portMapManager: PortMapManager
 
     private let logger: Logger
 
@@ -82,6 +83,14 @@ public struct EngineManagers: Sendable {
             logger: logger
         )
         self.execManager = ExecManager(containerManager: containerManager, logger: logger)
+        // `dumpNftablesOnPublish` follows the daemon's own rule
+        // (`ArcaDaemon.swift:276`): the dump is a debugging aid and is gated on
+        // the operator having asked for debug logging, not on a separate switch
+        // the engine would then have to grow a CLI option for.
+        self.portMapManager = PortMapManager(
+            logger: logger,
+            dumpNftablesOnPublish: logLevel.lowercased() == "debug"
+        )
     }
 
     /// The engine's own image store, rooted the one way.
@@ -101,7 +110,7 @@ public struct EngineManagers: Sendable {
         try ImageManager(logger: logger, imageStorePath: paths.imageStoreRoot)
     }
 
-    /// Hands `ContainerManager` the two collaborators it holds optionally.
+    /// Hands `ContainerManager` the three collaborators it holds optionally.
     ///
     /// `ContainerManager` takes these by setter rather than by initializer
     /// because `NetworkManager.init` already takes a `ContainerManager`: the two
@@ -120,6 +129,28 @@ public struct EngineManagers: Sendable {
     /// - `ContainerManager.swift:826` builds a container's `NetworkSettings`
     ///   only when `networkManager` is set, so `Inspect` would report a
     ///   container on a network as attached to nothing.
+    /// - `ContainerManager.swift:2494` publishes a container's ports only when
+    ///   `portMapManager` is set, and the gate has no `else`, so a `Create` that
+    ///   asked for ports would start a container that publishes none of them and
+    ///   report success. `Inspect` would then name the binding anyway, because
+    ///   Task 7 reports what the store holds -- see the note on
+    ///   `SandboxEngineService.inspect(request:)`. Every check green over a
+    ///   sandbox nothing can connect to.
+    ///
+    /// **The third line is not proved here the way the first two are, and that
+    /// is stated rather than papered over.** Both tests below assert on
+    /// behaviour a public method makes visible. `PortMapManager` exposes only
+    /// `publishPorts` and `unpublishPorts` (`PortMapManager.swift:61`, `:162`)
+    /// and no read at all, and `publishPorts` takes a non-optional
+    /// `WireGuardClient` whose `connect` needs a booted VM
+    /// (`NetworkManager.swift:836-838`). The one VM-free path that reaches the
+    /// gate -- `removeContainer`'s database-only branch, `:3052-3070` --
+    /// unpublishes a container that has no mappings, which is a no-op with no
+    /// observable result: a test written on it would pass with this line
+    /// deleted, which makes it worse than no test. Publication is provable only
+    /// from the live tier, and is routed to Task 13 with the shape that would
+    /// settle it: create with a `PortMapping`, `Start`, then connect to
+    /// `127.0.0.1:<host_port>` from the test process.
     ///
     /// Called after all three `initialize()` calls, which is what `ArcaDaemon`
     /// does and what the setters' own comments ask for. Nothing read during
@@ -130,22 +161,25 @@ public struct EngineManagers: Sendable {
     /// Separate from the `initialize()` sequence, and VM-free, because that is
     /// what lets it be proved at all. `ContainerManager.initialize()` constructs
     /// a real `VmnetNetwork`, so no test may call a method containing it; this
-    /// one a test can call, and `EngineManagerWiringTests` drives each line
-    /// through behaviour rather than through the call. MEASURED, one line
-    /// removed at a time, `swift test --filter ArcaEngineTests`:
+    /// one a test can call, and `EngineManagerWiringTests` drives the first two
+    /// lines through behaviour rather than through the call. MEASURED, one line
+    /// removed at a time, `swift test --filter ArcaEngineTests`, reported by
+    /// which tests fail rather than by how many:
     ///
-    /// - without `setVolumeManager`: `Executed 63 tests, with 1 failure` --
-    ///   `testRemovingAContainerDeletesItsAnonymousVolumeAndSparesTheNamedOne`,
-    ///   which found `["anon-vol", "named-vol"]` both still present after
-    ///   `Remove` had reported success.
-    /// - without `setNetworkManager`: `Executed 63 tests, with 3 failures`, all
-    ///   in `testAnAttachedContainerReportsTheNetworkItIsOn`, whose networks
-    ///   dictionary came back `[]`.
-    ///
-    /// Restored: `Executed 63 tests, with 0 failures`.
+    /// - without `setVolumeManager`, the only failure is
+    ///   `EngineManagerWiringTests.testRemovingAContainerDeletesItsAnonymousVolumeAndSparesTheNamedOne`,
+    ///   which finds `["anon-vol", "named-vol"]` both still present after
+    ///   `Remove` has reported success.
+    /// - without `setNetworkManager`, the only failing test is
+    ///   `EngineManagerWiringTests.testAnAttachedContainerReportsTheNetworkItIsOn`,
+    ///   on all three of its assertions, its networks dictionary having come
+    ///   back `[]`.
+    /// - without `setPortMapManager`, nothing fails, for the reason given above.
+    ///   That is the finding, not an omission.
     public func wireCollaborators() async {
         await containerManager.setVolumeManager(volumeManager)
         await containerManager.setNetworkManager(networkManager)
+        await containerManager.setPortMapManager(portMapManager)
     }
 
     /// The service over these managers.

--- a/Sources/ArcaEngine/EnginePaths.swift
+++ b/Sources/ArcaEngine/EnginePaths.swift
@@ -8,7 +8,7 @@ import Foundation
 /// a state root is not. See `EngineInputs`.
 ///
 /// One derivation, in the library, called by `arca-engine` and by the tests
-/// alike. Before this existed, `ArcaEngineCommand` and `TestSupport` each spelt
+/// alike. Before this existed, `ServeCommand` and `TestSupport` each spelt
 /// out `root.appendingPathComponent("images")` and its siblings, so the
 /// suite exercised a hand-copy of the wiring rather than the wiring: changing
 /// the engine's real image-store root left every test green.

--- a/Sources/ArcaEngine/EnginePaths.swift
+++ b/Sources/ArcaEngine/EnginePaths.swift
@@ -2,9 +2,14 @@ import Foundation
 
 /// Every path the engine derives from its `--state-root`.
 ///
+/// Only mutable state the engine owns is derived here. Read-only inputs are
+/// not: the kernel image arrives as `--kernel-path` and the vminit OCI layout
+/// as `--vminit-layout`, because a file two processes read is safe to share and
+/// a state root is not. See `EngineInputs`.
+///
 /// One derivation, in the library, called by `arca-engine` and by the tests
 /// alike. Before this existed, `ArcaEngineCommand` and `TestSupport` each spelt
-/// out `root.appendingPathComponent("images")` and its five siblings, so the
+/// out `root.appendingPathComponent("images")` and its siblings, so the
 /// suite exercised a hand-copy of the wiring rather than the wiring: changing
 /// the engine's real image-store root left every test green.
 ///
@@ -36,9 +41,6 @@ public struct EnginePaths: Sendable, Equatable {
     /// Base directory for named volumes.
     public let volumesRoot: URL
 
-    /// The Linux kernel image the engine boots containers with.
-    public let kernel: URL
-
     /// The socket recorded in `ArcaConfig`. Note that the socket the process
     /// actually serves on comes from `--socket-path`; this is the configured
     /// value the managers are handed.
@@ -50,7 +52,6 @@ public struct EnginePaths: Sendable, Equatable {
         self.layerCache = stateRoot.appendingPathComponent("layers")
         self.stateDatabase = stateRoot.appendingPathComponent("state.db")
         self.volumesRoot = stateRoot.appendingPathComponent("volumes")
-        self.kernel = stateRoot.appendingPathComponent("vmlinux")
         self.socket = stateRoot.appendingPathComponent("arca.sock")
     }
 }

--- a/Sources/ArcaEngine/EnginePaths.swift
+++ b/Sources/ArcaEngine/EnginePaths.swift
@@ -60,6 +60,23 @@ public struct EnginePaths: Sendable, Equatable {
     /// Base directory for named volumes.
     public let volumesRoot: URL
 
+    /// Base directory for container stdout/stderr logs, one subdirectory per
+    /// container.
+    ///
+    /// Under the state root rather than `~/Library/Application Support/
+    /// com.apple.arca/logs`, which is ArcaDaemon's tree and which every
+    /// `ContainerLogManager` derived for itself regardless of the root its
+    /// `ContainerManager` was given. That mattered in both directions: a
+    /// container's output landed in a directory the engine does not own, and
+    /// `removeContainer` deleted out of that same directory, so a throwaway
+    /// engine removing a sandbox deleted under the operator's real log store.
+    ///
+    /// A sibling of the other roots rather than a child of one: logs are
+    /// neither content-addressed store data nor volume data, and putting them
+    /// under `images/` would write engine-owned files into the directory
+    /// Containerization owns.
+    public let logsRoot: URL
+
     /// The socket recorded in `ArcaConfig`. Note that the socket the process
     /// actually serves on comes from `--socket-path`; this is the configured
     /// value the managers are handed.
@@ -73,6 +90,7 @@ public struct EnginePaths: Sendable, Equatable {
         self.layerCache = stateRoot.appendingPathComponent("layers")
         self.stateDatabase = stateRoot.appendingPathComponent("state.db")
         self.volumesRoot = stateRoot.appendingPathComponent("volumes")
+        self.logsRoot = stateRoot.appendingPathComponent("logs")
         self.socket = stateRoot.appendingPathComponent("arca.sock")
     }
 }

--- a/Sources/ArcaEngine/EnginePaths.swift
+++ b/Sources/ArcaEngine/EnginePaths.swift
@@ -31,9 +31,28 @@ public struct EnginePaths: Sendable, Equatable {
     /// image one loads is not the one the other resolves the initfs from.
     public let imageStoreRoot: URL
 
+    /// The init filesystem Containerization unpacks the vminit image into.
+    ///
+    /// Derived from `imageStoreRoot` and not spelt out from the state root,
+    /// because that is where Containerization puts it -- `ContainerManager`
+    /// appends `initfs.ext4` to the image store's own path
+    /// (containerization/Sources/Containerization/ContainerManager.swift:146).
+    /// Restating it from the state root would be a second derivation of the
+    /// image store root, free to drift from the first.
+    ///
+    /// It is the engine's because the store is: ArcaDaemon deletes the copy in
+    /// Apple's shared store on every start, and this one is not that file.
+    public let initfs: URL
+
     /// OverlayFS layer cache. Under the state root rather than `~/.arca/layers`,
     /// which is Arca's tree.
     public let layerCache: URL
+
+    /// Digest of the vminit image `initfs` was built from, so that a start can
+    /// tell an unchanged vminit from a new one. Beside the state root's other
+    /// records and never beside Apple's shared `initfs.ext4`, which belongs to
+    /// whichever ArcaDaemon is running.
+    public let vminitDigest: URL
 
     /// SQLite database holding container, network and volume state.
     public let stateDatabase: URL
@@ -49,6 +68,8 @@ public struct EnginePaths: Sendable, Equatable {
     public init(stateRoot: URL) {
         self.stateRoot = stateRoot
         self.imageStoreRoot = stateRoot.appendingPathComponent("images")
+        self.initfs = self.imageStoreRoot.appendingPathComponent("initfs.ext4")
+        self.vminitDigest = stateRoot.appendingPathComponent("vminit-digest")
         self.layerCache = stateRoot.appendingPathComponent("layers")
         self.stateDatabase = stateRoot.appendingPathComponent("state.db")
         self.volumesRoot = stateRoot.appendingPathComponent("volumes")

--- a/Sources/ArcaEngine/EnginePaths.swift
+++ b/Sources/ArcaEngine/EnginePaths.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Every path the engine derives from its `--state-root`.
+///
+/// One derivation, in the library, called by `arca-engine` and by the tests
+/// alike. Before this existed, `ArcaEngineCommand` and `TestSupport` each spelt
+/// out `root.appendingPathComponent("images")` and its five siblings, so the
+/// suite exercised a hand-copy of the wiring rather than the wiring: changing
+/// the engine's real image-store root left every test green.
+///
+/// It lives in `ArcaEngine` rather than in the `arca-engine` executable because
+/// a test target cannot import an executable, and a derivation only the
+/// executable can reach is a derivation no test can assert on.
+///
+/// A struct with a single initializer rather than a free `enginePaths(_:)`
+/// function: the members are one cohesive value, and the type is what later
+/// tasks add paths to.
+public struct EnginePaths: Sendable, Equatable {
+    /// The root the engine was told to own. Everything below is under it, and
+    /// that is the property tests assert -- not the individual spellings.
+    public let stateRoot: URL
+
+    /// Root of the Containerization ImageStore, and so the directory
+    /// `initfs.ext4` is built in. Shared by `ImageManager` and
+    /// `ContainerManager`: they must name the same directory or the vminit
+    /// image one loads is not the one the other resolves the initfs from.
+    public let imageStoreRoot: URL
+
+    /// OverlayFS layer cache. Under the state root rather than `~/.arca/layers`,
+    /// which is Arca's tree.
+    public let layerCache: URL
+
+    /// SQLite database holding container, network and volume state.
+    public let stateDatabase: URL
+
+    /// Base directory for named volumes.
+    public let volumesRoot: URL
+
+    /// The Linux kernel image the engine boots containers with.
+    public let kernel: URL
+
+    /// The socket recorded in `ArcaConfig`. Note that the socket the process
+    /// actually serves on comes from `--socket-path`; this is the configured
+    /// value the managers are handed.
+    public let socket: URL
+
+    public init(stateRoot: URL) {
+        self.stateRoot = stateRoot
+        self.imageStoreRoot = stateRoot.appendingPathComponent("images")
+        self.layerCache = stateRoot.appendingPathComponent("layers")
+        self.stateDatabase = stateRoot.appendingPathComponent("state.db")
+        self.volumesRoot = stateRoot.appendingPathComponent("volumes")
+        self.kernel = stateRoot.appendingPathComponent("vmlinux")
+        self.socket = stateRoot.appendingPathComponent("arca.sock")
+    }
+}

--- a/Sources/ArcaEngine/EngineServer.swift
+++ b/Sources/ArcaEngine/EngineServer.swift
@@ -127,6 +127,23 @@ public struct EngineServer: Sendable {
         // it is not the postcondition -- `onClose` is, and it is awaited next.
         server.close(promise: nil)
         try await onClose.get()
+        try releaseSocketPath()
+    }
+
+    /// Removes the socket and gives up the claim on its path, without waiting
+    /// for the server to finish closing.
+    ///
+    /// The cleanup half of `shutDown()` on its own, for the one caller that
+    /// cannot afford the other half: an operator signalling a second time is
+    /// escalating past a wait for accepted connections to close, so a teardown
+    /// that began by awaiting the very thing being escalated past would be no
+    /// escalation at all. `arca-engine`'s shutdown handler calls this and then
+    /// ends the process.
+    ///
+    /// The two steps live here rather than being repeated at that call site so
+    /// the ordinary and the escalated path cannot drift into releasing
+    /// different things.
+    public func releaseSocketPath() throws {
         try removeOwnSocket()
         try lock.release()
     }

--- a/Sources/ArcaEngine/EngineStartup.swift
+++ b/Sources/ArcaEngine/EngineStartup.swift
@@ -66,15 +66,37 @@ public func validateEngineInputs(_ inputs: EngineInputs) throws {
         )
     }
 
-    isDirectory = false
-    guard fileManager.fileExists(atPath: inputs.vminitLayout.path, isDirectory: &isDirectory) else {
-        throw EngineStartupError.missingInput(
-            name: "--vminit-layout", path: inputs.vminitLayout.path
-        )
+    try validateOCILayoutDirectory(inputs.vminitLayout, option: vminitLayoutOption)
+}
+
+/// Refuses a directory that is not an OCI image layout, naming the option the
+/// caller would change and the path it tried.
+///
+/// Parameterised by option name rather than fixed to `--vminit-layout` because
+/// two options now point at OCI layouts: `--vminit-layout`, the startup input,
+/// and `--oci-layout` on `arca-engine image load`, the workspace image a
+/// consumer pushes afterwards. They are separate options over separate
+/// mechanisms on purpose (a startup input is not pushed content), but "what
+/// makes a directory an OCI layout" is one question, and answering it twice is
+/// two answers free to drift -- the defect Task 1's duplicated wiring already
+/// cost this milestone in another form.
+///
+/// The marker check is EXISTENCE-ONLY, which is deliberate and bounded: it
+/// rejects an empty directory, a file, and a half-written layout, but a layout
+/// whose `oci-layout` and `index.json` are both zero bytes passes here and
+/// fails inside `ImageStore.load`. That residue is why `loadWorkspaceImages`
+/// wraps the load itself rather than trusting this check to be the only
+/// refusal.
+package func validateOCILayoutDirectory(_ directory: URL, option: String) throws {
+    let fileManager = FileManager.default
+
+    var isDirectory: ObjCBool = false
+    guard fileManager.fileExists(atPath: directory.path, isDirectory: &isDirectory) else {
+        throw EngineStartupError.missingInput(name: option, path: directory.path)
     }
     guard isDirectory.boolValue else {
         throw EngineStartupError.unreadableInput(
-            name: "--vminit-layout", path: inputs.vminitLayout.path,
+            name: option, path: directory.path,
             cause: "is a file, not an OCI layout directory"
         )
     }
@@ -83,18 +105,18 @@ public func validateEngineInputs(_ inputs: EngineInputs) throws {
     // directory exists would accept an empty directory and fail later, inside
     // ImageManager, with a message about the wrong thing.
     for marker in ["oci-layout", "index.json"] {
-        let path = inputs.vminitLayout.appendingPathComponent(marker).path
+        let path = directory.appendingPathComponent(marker).path
         guard fileManager.fileExists(atPath: path) else {
             throw EngineStartupError.unreadableInput(
-                name: "--vminit-layout", path: inputs.vminitLayout.path,
+                name: option, path: directory.path,
                 cause: "is not an OCI layout: no \(marker)"
             )
         }
     }
 }
 
-/// The option `loadVminit` refuses on behalf of, so a refusal names the thing
-/// the user would change.
+/// The option `validateEngineInputs` and `loadVminit` refuse on behalf of, so a
+/// refusal names the thing the user would change.
 private let vminitLayoutOption = "--vminit-layout"
 
 /// The reference the exported layout carries. VERIFIED against the real one:

--- a/Sources/ArcaEngine/EngineStartup.swift
+++ b/Sources/ArcaEngine/EngineStartup.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// The engine's inputs, split by mutability.
+///
+/// `stateRoot` is mutable and private to this engine: state.db, images/,
+/// volumes/, layers/. Sharing it with a live ArcaDaemon is the hazard the C1
+/// review finding named -- ContainerManager's restore loop marks persisted
+/// "running" containers exited 137 and writes that back.
+///
+/// `kernelPath` and `vminitLayout` are read-only inputs. A file two processes
+/// read is safe to share; a state root is not. They are separate options so
+/// that the CLI cannot express the confusion, and it is why the kernel is no
+/// longer one of `EnginePaths`' derivations: deriving it from the state root
+/// forced a read-only file to live inside the one directory the engine owns.
+public struct EngineInputs: Sendable {
+    public let stateRoot: URL
+    public let kernelPath: URL
+    public let vminitLayout: URL
+
+    public init(stateRoot: URL, kernelPath: URL, vminitLayout: URL) {
+        self.stateRoot = stateRoot
+        self.kernelPath = kernelPath
+        self.vminitLayout = vminitLayout
+    }
+}
+
+public enum EngineStartupError: Error, CustomStringConvertible {
+    case missingInput(name: String, path: String)
+    case unreadableInput(name: String, path: String, cause: String)
+    case unexpectedVminitReference(expected: String, actual: String)
+
+    public var description: String {
+        switch self {
+        case .missingInput(let name, let path):
+            return "\(name) names nothing that exists: \(path)"
+        case .unreadableInput(let name, let path, let cause):
+            return "\(name) is unusable at \(path): \(cause)"
+        case .unexpectedVminitReference(let expected, let actual):
+            return "the vminit layout holds \(actual), not \(expected)"
+        }
+    }
+}
+
+/// Refuses before any manager is constructed, so a bad input costs a clear
+/// error rather than a partially-initialised engine.
+public func validateEngineInputs(_ inputs: EngineInputs) throws {
+    let fileManager = FileManager.default
+
+    var isDirectory: ObjCBool = false
+    guard fileManager.fileExists(atPath: inputs.kernelPath.path, isDirectory: &isDirectory) else {
+        throw EngineStartupError.missingInput(
+            name: "--kernel-path", path: inputs.kernelPath.path
+        )
+    }
+    guard !isDirectory.boolValue else {
+        throw EngineStartupError.unreadableInput(
+            name: "--kernel-path", path: inputs.kernelPath.path,
+            cause: "is a directory, not a kernel image"
+        )
+    }
+
+    isDirectory = false
+    guard fileManager.fileExists(atPath: inputs.vminitLayout.path, isDirectory: &isDirectory) else {
+        throw EngineStartupError.missingInput(
+            name: "--vminit-layout", path: inputs.vminitLayout.path
+        )
+    }
+    guard isDirectory.boolValue else {
+        throw EngineStartupError.unreadableInput(
+            name: "--vminit-layout", path: inputs.vminitLayout.path,
+            cause: "is a file, not an OCI layout directory"
+        )
+    }
+
+    // An OCI layout is identified by these two files. Checking only that the
+    // directory exists would accept an empty directory and fail later, inside
+    // ImageManager, with a message about the wrong thing.
+    for marker in ["oci-layout", "index.json"] {
+        let path = inputs.vminitLayout.appendingPathComponent(marker).path
+        guard fileManager.fileExists(atPath: path) else {
+            throw EngineStartupError.unreadableInput(
+                name: "--vminit-layout", path: inputs.vminitLayout.path,
+                cause: "is not an OCI layout: no \(marker)"
+            )
+        }
+    }
+}

--- a/Sources/ArcaEngine/EngineStartup.swift
+++ b/Sources/ArcaEngine/EngineStartup.swift
@@ -1,4 +1,6 @@
+import ContainerBridge
 import Foundation
+import Logging
 
 /// The engine's inputs, split by mutability.
 ///
@@ -27,7 +29,12 @@ public struct EngineInputs: Sendable {
 public enum EngineStartupError: Error, CustomStringConvertible {
     case missingInput(name: String, path: String)
     case unreadableInput(name: String, path: String, cause: String)
-    case unexpectedVminitReference(expected: String, actual: String)
+    /// Carries the option and the path for the same reason the two cases above
+    /// do: this is the one refusal a user meets after the paths validated, and
+    /// "the vminit layout holds X, not Y" names neither the option to change
+    /// nor the layout that was read. A refusal that does not say what to fix is
+    /// a worse failure than a crash.
+    case unexpectedVminitReference(name: String, path: String, expected: String, actual: String)
 
     public var description: String {
         switch self {
@@ -35,8 +42,8 @@ public enum EngineStartupError: Error, CustomStringConvertible {
             return "\(name) names nothing that exists: \(path)"
         case .unreadableInput(let name, let path, let cause):
             return "\(name) is unusable at \(path): \(cause)"
-        case .unexpectedVminitReference(let expected, let actual):
-            return "the vminit layout holds \(actual), not \(expected)"
+        case .unexpectedVminitReference(let name, let path, let expected, let actual):
+            return "\(name) at \(path) holds \(actual), not \(expected)"
         }
     }
 }
@@ -84,4 +91,95 @@ public func validateEngineInputs(_ inputs: EngineInputs) throws {
             )
         }
     }
+}
+
+/// The option `loadVminit` refuses on behalf of, so a refusal names the thing
+/// the user would change.
+private let vminitLayoutOption = "--vminit-layout"
+
+/// The reference the exported layout carries. VERIFIED against the real one:
+/// `head -c 400 ~/.arca/vminit/index.json` shows its single manifest annotated
+/// `"org.opencontainers.image.ref.name": "arca-vminit:latest"`. It is also the
+/// reference `ContainerManager.initialize()` resolves the initfs from
+/// (ContainerBridge/ContainerManager.swift:275), so the two must agree.
+private let expectedVminitReference = "arca-vminit:latest"
+
+/// The digest of the vminit the initfs in this state root was built from, or
+/// nil if nothing has been recorded yet.
+///
+/// Absent reads as nil rather than as an error: the first start against a fresh
+/// state root has no record, and that is not a fault. An unreadable or corrupt
+/// record reads as nil too, and costs one regeneration rather than a refusal to
+/// start -- the right price for what is a cache key, not an input.
+public func recordedVminitDigest(stateRoot: URL) -> String? {
+    try? String(
+        contentsOf: EnginePaths(stateRoot: stateRoot).vminitDigest, encoding: .utf8
+    ).trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+/// Records the digest of the vminit the initfs was built from.
+public func recordVminitDigest(_ digest: String, stateRoot: URL) throws {
+    let paths = EnginePaths(stateRoot: stateRoot)
+    try FileManager.default.createDirectory(
+        at: paths.stateRoot, withIntermediateDirectories: true
+    )
+    try digest.write(to: paths.vminitDigest, atomically: true, encoding: .utf8)
+}
+
+/// Loads the vminit layout into the engine's OWN image store, regenerating the
+/// initfs if and only if the image changed, and returns the loaded digest.
+///
+/// The store is the engine's because `imageManager` is rooted at
+/// `EnginePaths.imageStoreRoot`, and `initfs.ext4` follows the store:
+/// Containerization builds it inside whichever image store it is handed. So
+/// this engine never touches the file ArcaDaemon deletes on every start, and
+/// the two need no coordination.
+///
+/// Regeneration is keyed on the digest rather than unconditional. Deleting the
+/// initfs on every start would rebuild a ~178MB image for no correctness gain,
+/// since Containerization reuses an existing file
+/// (containerization/Sources/Containerization/ContainerManager.swift:148-162).
+///
+/// An unexpected reference is a refusal. ArcaDaemon logs and continues in the
+/// same place (ArcaDaemon.swift:131-133); booting sandboxes on an unknown init
+/// image is not a warning-level condition.
+public func loadVminit(
+    from layout: URL,
+    into imageManager: ImageManager,
+    stateRoot: URL,
+    logger: Logger
+) async throws -> String {
+    let loaded = try await imageManager.loadFromOCILayout(directory: layout)
+    guard let image = loaded.first(where: { $0.reference == expectedVminitReference }) else {
+        throw EngineStartupError.unexpectedVminitReference(
+            name: vminitLayoutOption,
+            path: layout.path,
+            expected: expectedVminitReference,
+            actual: loaded.map(\.reference).joined(separator: ", ")
+        )
+    }
+
+    let digest = image.digest
+    guard recordedVminitDigest(stateRoot: stateRoot) != digest else {
+        logger.debug("vminit unchanged; keeping the existing initfs", metadata: [
+            "digest": "\(digest)"
+        ])
+        return digest
+    }
+
+    // Removed before the record is written and never after: a record written
+    // over a failed removal claims the initfs was built from an image it was
+    // not, and every later start believes it. Which is also why the removal is
+    // `try` and not `try?` -- a file that cannot be removed is a stale init
+    // image the engine would go on to boot.
+    let initfs = EnginePaths(stateRoot: stateRoot).initfs
+    if FileManager.default.fileExists(atPath: initfs.path) {
+        try FileManager.default.removeItem(at: initfs)
+    }
+    logger.info("vminit changed; initfs will be regenerated", metadata: [
+        "digest": "\(digest)",
+        "initfs": "\(initfs.path)",
+    ])
+    try recordVminitDigest(digest, stateRoot: stateRoot)
+    return digest
 }

--- a/Sources/ArcaEngine/EngineTranslation.swift
+++ b/Sources/ArcaEngine/EngineTranslation.swift
@@ -1,3 +1,4 @@
+import ContainerBridge
 import SandboxEngineProto
 
 /// Reads the leading `major.minor.patch` of a version string.
@@ -53,6 +54,102 @@ public func sandboxState(fromStatus status: String) -> Arca_Engine_V1_SandboxSta
     case "exited", "dead": return .stopped
     default: return .unspecified
     }
+}
+
+/// A stored port binding the contract has no field to carry.
+///
+/// Carried out rather than swallowed because there is no third answer available:
+/// `Sandbox.ports` is a plain `repeated PortMapping` (engine.proto:343) with no
+/// way to say "there is a binding here I cannot name", and `InspectResponse`'s
+/// three arms are sandbox, absent, and error (engine.proto:358-365). A sandbox
+/// arm carrying a port list that silently omits or invents a binding is the one
+/// outcome that cannot be detected downstream, so the refusal is the answer.
+///
+/// `reason` becomes the engine error's `message`: prose, never parsed
+/// (EngineErrors.swift:32-35), naming the binding so an operator knows which
+/// stored row to look at.
+public struct UnrepresentablePortBinding: Error, Equatable {
+    public let reason: String
+
+    public init(reason: String) {
+        self.reason = reason
+    }
+}
+
+/// A port number the wire can carry, or nil.
+///
+/// The field is `uint32` (engine.proto:214-215) but a TCP port is 1...65535, so
+/// three stored values have no representation: a negative, a number above
+/// 65535, and 0. The first two would wrap or trap on a bare `UInt32(_:)`
+/// conversion; 0 would convert cleanly and mean nothing -- the consumer reads it
+/// back as `port 0 is not a mapping`
+/// (crates/gascan-arca/src/translate.rs:370-375), blaming the engine's output
+/// for a number the store never held as a port.
+private func wirePort(_ value: Int) -> UInt32? {
+    guard (1...65535).contains(value) else { return nil }
+    return UInt32(value)
+}
+
+/// The binding as prose, for whichever refusal names it.
+private func describe(_ binding: PortMapping) -> String {
+    "\(binding.publicPort.map(String.init) ?? "<none>"):\(binding.privatePort)/\(binding.type)"
+}
+
+/// A sandbox's published ports, or the first binding that cannot be one.
+///
+/// The input is `ContainerManager.convertPortBindingsToMappings`' output, which
+/// is the parse of the stored `hostConfig.portBindings`. The output is the
+/// contract's `PortMapping`, and the two do not have the same shape: the stored
+/// side carries an optional host port, a protocol, and a bind address
+/// (`Types.swift:53-58`), and the wire side carries two numbers and nothing else
+/// (engine.proto:211-217). Every field the wire side lacks is a case where the
+/// only honest answers are "refuse" and "fabricate":
+///
+/// - **No host port.** An unset `publicPort` is a stored binding whose host side
+///   is not recorded. `hostPort = 0` fabricates the very class of value this
+///   mapping exists to stop, and dropping the entry asserts the sandbox
+///   publishes nothing on that guest port -- which is what drift detection then
+///   compares against.
+/// - **A protocol that is not tcp.** The wire has no protocol field, so a udp
+///   binding emitted here reads as a tcp publication that does not exist, and a
+///   tcp and a udp binding on the same two numbers collapse into a duplicate the
+///   consumer rejects outright (translate.rs:376-381).
+/// - **A number that is not a port.** See `wirePort` above.
+///
+/// Sorted, because `repeated` is ordered on the wire and the input comes from
+/// iterating a Dictionary (`ContainerManager.swift:959`), whose order is seeded
+/// per process. Unsorted, two Inspects of one unchanged sandbox can disagree
+/// about the order of its ports. Sorting reorders; it invents nothing.
+public func sandboxPorts(
+    fromBindings bindings: [PortMapping]
+) -> Result<[Arca_Engine_V1_PortMapping], UnrepresentablePortBinding> {
+    var ports: [Arca_Engine_V1_PortMapping] = []
+    for binding in bindings {
+        guard binding.type == "tcp" else {
+            return .failure(UnrepresentablePortBinding(
+                reason: "port binding \(describe(binding)) is not tcp, and the contract's "
+                    + "PortMapping carries no protocol field to say otherwise"
+            ))
+        }
+        guard let publicPort = binding.publicPort else {
+            return .failure(UnrepresentablePortBinding(
+                reason: "port binding \(describe(binding)) is stored with no host port, and "
+                    + "the contract has no way to report a binding that has none"
+            ))
+        }
+        guard let hostPort = wirePort(publicPort),
+              let guestPort = wirePort(binding.privatePort)
+        else {
+            return .failure(UnrepresentablePortBinding(
+                reason: "port binding \(describe(binding)) names a number that is not a port"
+            ))
+        }
+        ports.append(Arca_Engine_V1_PortMapping.with {
+            $0.hostPort = hostPort
+            $0.guestPort = guestPort
+        })
+    }
+    return .success(ports.sorted { ($0.guestPort, $0.hostPort) < ($1.guestPort, $1.hostPort) })
 }
 
 /// The container's resource name, as the contract requires it.

--- a/Sources/ArcaEngine/EngineTranslation.swift
+++ b/Sources/ArcaEngine/EngineTranslation.swift
@@ -103,12 +103,16 @@ public func imageStoreDigest(_ digest: Arca_Engine_V1_ImageDigest) -> String? {
 /// up, which keeps a tag inside the repository it reports. That asymmetry is
 /// real; it belongs to the Inspect path and is recorded rather than changed
 /// here.
+///
+/// **The rule moved into `ContainerBridge.ImageIdentity` and this forwards to
+/// it.** `ImageManager.resolveImage`'s exact-digest arm compares a requested
+/// repository against a stored one, and this compares the same two things for
+/// `PrepareImage`. Those answers have to agree -- an `Ack` here is a promise
+/// that the resolver there will find the content -- and two copies of a
+/// splitting rule agree only until one of them is edited. The name stays,
+/// because it is what the call sites already say; only the body moved.
 public func imageRepository(ofReference reference: String) -> String {
-    let name = reference.range(of: "@sha256:", options: .backwards)
-        .map { String(reference[reference.startIndex..<$0.lowerBound]) } ?? reference
-    guard let tagSeparator = name.lastIndex(of: ":") else { return name }
-    if let slash = name.lastIndex(of: "/"), tagSeparator < slash { return name }
-    return String(name[name.startIndex..<tagSeparator])
+    ImageIdentity.repository(of: reference)
 }
 
 /// Maps ContainerBridge's status string onto the contract's three states.

--- a/Sources/ArcaEngine/EngineTranslation.swift
+++ b/Sources/ArcaEngine/EngineTranslation.swift
@@ -20,22 +20,86 @@ public func engineVersion(from string: String) -> Arca_Engine_V1_Version? {
     return version
 }
 
+/// The hex half of a digest, as the contract spells it: bare, lowercase, and
+/// exactly 64 characters, with no "sha256:" prefix (engine.proto:179-185).
+///
+/// One predicate rather than one per direction. Both directions below decide
+/// the same question, and two copies of it are two chances for the engine to
+/// accept on the way in what it refuses on the way out.
+private func isSHA256Hex(_ hex: String) -> Bool {
+    hex.count == 64 && hex.allSatisfy { $0.isNumber || ("a"..."f").contains($0) }
+}
+
 /// Splits an exact digest reference into the two fields the contract carries.
 ///
 /// A tag is not representable on the wire, so a reference that is not an exact
-/// digest has nothing to map to and is refused. The hex is bare and lowercase,
-/// exactly 64 characters, with no "sha256:" prefix (engine.proto:179-185).
+/// digest has nothing to map to and is refused.
 public func imageDigest(fromReference reference: String) -> Arca_Engine_V1_ImageDigest? {
     guard let separator = reference.range(of: "@sha256:", options: .backwards) else { return nil }
     let repository = String(reference[reference.startIndex..<separator.lowerBound])
     let hex = String(reference[separator.upperBound...])
-    guard !repository.isEmpty, hex.count == 64,
-          hex.allSatisfy({ $0.isNumber || ("a"..."f").contains($0) })
-    else { return nil }
+    guard !repository.isEmpty, isSHA256Hex(hex) else { return nil }
     var digest = Arca_Engine_V1_ImageDigest()
     digest.repository = repository
     digest.sha256Hex = hex
     return digest
+}
+
+/// A wire digest as the reference an operator would go looking for.
+///
+/// The exact inverse of `imageDigest(fromReference:)` above, and here rather
+/// than spelt out at its call sites so the two cannot drift into disagreeing
+/// about what the canonical form is. Used for the `resource` field of a
+/// failure, which names "the resource the failure is about"
+/// (engine.proto:66-67) -- and for a request that names content, the thing the
+/// failure is about is the content, not the RPC.
+///
+/// Total, deliberately: this is what a refusal *echoes*, so it has to be able
+/// to echo a request that is itself malformed. Validity is
+/// `imageStoreDigest(_:)`'s question, one function down.
+public func imageReference(forDigest digest: Arca_Engine_V1_ImageDigest) -> String {
+    "\(digest.repository)@sha256:\(digest.sha256Hex)"
+}
+
+/// The image store's lookup key for a wire digest, or nil when the wire digest
+/// is not one.
+///
+/// Refusing rather than passing a malformed digest through to a lookup that
+/// would simply match nothing: the two answers are "you sent nonsense" and "the
+/// engine does not hold that", and a consumer acts differently on each --
+/// `not_found` is a final answer about content whose fix is to send the
+/// content. `ImageDigest` is a message, so an *unset* one arrives here with
+/// both fields empty and is refused by the same guard.
+///
+/// The `sha256:` prefix belongs to the store and not to the wire: the contract
+/// carries bare hex "with no sha256: prefix" (engine.proto:182-183), while
+/// Containerization records a descriptor digest prefixed. This is the one place
+/// that conversion happens.
+public func imageStoreDigest(_ digest: Arca_Engine_V1_ImageDigest) -> String? {
+    guard !digest.repository.isEmpty, isSHA256Hex(digest.sha256Hex) else { return nil }
+    return "sha256:\(digest.sha256Hex)"
+}
+
+/// The repository half of a stored image reference, split the way the consumer
+/// splits its own.
+///
+/// The rule is Gas Can's, mirrored: `immutable_image_identity`
+/// (crates/gascan-core/src/runtime.rs:704-715) drops anything from `@sha256:`
+/// onward, then drops a tag -- the last `:` that comes after the last `/`, so
+/// that the port in `registry.example:5000/repo` is not mistaken for one. The
+/// two sides have to split identically, or the comparison they meet in is
+/// decided by punctuation rather than by identity.
+///
+/// This is NOT the split `imageDigest(fromReference:)` performs one direction
+/// up, which keeps a tag inside the repository it reports. That asymmetry is
+/// real; it belongs to the Inspect path and is recorded rather than changed
+/// here.
+public func imageRepository(ofReference reference: String) -> String {
+    let name = reference.range(of: "@sha256:", options: .backwards)
+        .map { String(reference[reference.startIndex..<$0.lowerBound]) } ?? reference
+    guard let tagSeparator = name.lastIndex(of: ":") else { return name }
+    if let slash = name.lastIndex(of: "/"), tagSeparator < slash { return name }
+    return String(name[name.startIndex..<tagSeparator])
 }
 
 /// Maps ContainerBridge's status string onto the contract's three states.

--- a/Sources/ArcaEngine/EngineTranslation.swift
+++ b/Sources/ArcaEngine/EngineTranslation.swift
@@ -26,8 +26,17 @@ public func engineVersion(from string: String) -> Arca_Engine_V1_Version? {
 /// One predicate rather than one per direction. Both directions below decide
 /// the same question, and two copies of it are two chances for the engine to
 /// accept on the way in what it refuses on the way out.
+///
+/// `isASCII` first, and it is load-bearing rather than defensive: Swift's
+/// `Character.isNumber` is true for every Unicode number, so without it a run
+/// of 64 ARABIC-INDIC DIGIT THREEs (U+0663) passes a gate whose own
+/// documentation and whose refusal message both say "hex". No store can hold
+/// such a digest, so the only consequence was a `not_found` where an
+/// `invalid_resource_identity` belonged -- but a predicate that admits what its
+/// name forbids is one a later `Ack` could be built on, and it made two
+/// shipped sentences say more than the code enforced.
 private func isSHA256Hex(_ hex: String) -> Bool {
-    hex.count == 64 && hex.allSatisfy { $0.isNumber || ("a"..."f").contains($0) }
+    hex.count == 64 && hex.allSatisfy { $0.isASCII && ($0.isNumber || ("a"..."f").contains($0)) }
 }
 
 /// Splits an exact digest reference into the two fields the contract carries.

--- a/Sources/ArcaEngine/SandboxEngineService.swift
+++ b/Sources/ArcaEngine/SandboxEngineService.swift
@@ -10,32 +10,33 @@ import SandboxEngineProto
 /// in EngineTranslation, so that this file stays readable as a list of the
 /// contract's eleven methods.
 ///
-/// **In this build, two of the eleven are implemented: `Capabilities` and
-/// `Inspect`.** The other nine answer `unsupported_capability` inside their
-/// response `oneof`.
+/// **In this build, three of the eleven are implemented: `Capabilities`,
+/// `Inspect` and `ListResources`.** The other eight answer
+/// `unsupported_capability` inside their response `oneof`.
 ///
 /// `Inspect` and `ListResources` were both on that list because, when they were
 /// written, this process called `initialize()` on no manager, and an
 /// uninitialised manager does not report "I cannot tell", it reports "nothing
 /// exists". `ArcaEngineCommand.run()` now initializes all three before it binds
-/// the socket, so that reason has expired for both: `Inspect` answers from that
-/// loaded state below, and `ListResources` still answers
-/// `unsupported_capability` because it is unwritten -- Task 8's work -- not
-/// because the state behind it is empty.
+/// the socket, so that reason has expired for both, and both now answer from
+/// that loaded state below.
 public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvider {
     public let interceptors: Arca_Engine_V1_SandboxEngineServerInterceptorFactoryProtocol? = nil
 
-    // `containerManager` is read by `inspect(request:)` below. The other four
-    // are held and, in this build, unread. Deliberate on both counts.
+    // `containerManager` is read by `inspect(request:)` and, with
+    // `volumeManager` and `networkManager`, by `listResources(request:)` below.
+    // `imageManager` and `execManager` are held and, in this build, unread.
+    // Deliberate on both counts.
     //
-    // Unread because the methods that would consult them are the ones this
-    // build does not implement. Held because the dependency edge is itself a
-    // shipped property: gascan's tests/release/engine-targets-check.sh asserts
-    // that `arca-engine` and `ArcaEngine` reach neither `DockerAPI` nor
-    // `ArcaDaemon`, and that assertion measures something only while this
-    // target genuinely depends on ContainerBridge. Dropping the four to silence
-    // an unused-property reading would make the release gate pass for a reason
-    // that has nothing to do with what it exists to prove.
+    // Unread because the methods that would consult them -- `PrepareImage`,
+    // `Exec` -- are among the eight this build does not implement. Held because
+    // the dependency edge is itself a shipped property: gascan's
+    // tests/release/engine-targets-check.sh asserts that `arca-engine` and
+    // `ArcaEngine` reach neither `DockerAPI` nor `ArcaDaemon`, and that
+    // assertion measures something only while this target genuinely depends on
+    // ContainerBridge. Dropping the two to silence an unused-property reading
+    // would make the release gate pass for a reason that has nothing to do with
+    // what it exists to prove.
     let containerManager: ContainerManager
     let volumeManager: VolumeManager
     let networkManager: NetworkManager
@@ -337,31 +338,66 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
 
     /// See the note on the `create(request:)` overload above.
     ///
-    /// Unimplemented in this build, for the reason `inspect` used to give and
-    /// with a sharper edge.
-    ///
     /// `engine.proto`'s contract for this method is "Every resource the engine
-    /// holds, labelled or not", because a consumer's drift and leak detection
-    /// depends on seeing the unlabelled ones. An earlier revision walked
-    /// `ContainerManager`, `VolumeManager` and `NetworkManager`; with
-    /// `initialize()` called on none of them all three were permanently empty --
-    /// containers and volumes had no loaded rows, and
-    /// `NetworkManager.listNetworks()` read two backends that were both nil --
-    /// so it returned `[]` under every input. An
-    /// empty `ResourceList` is not an error arm: it is a confident report of a
-    /// clean host, which is precisely the report that hides a leak.
+    /// holds, labelled or not" (engine.proto:387-391), because a consumer's
+    /// drift and leak detection depends on seeing the unlabelled ones. Nothing
+    /// here filters: an unlabelled resource is reported with `owner` unset,
+    /// which is how the consumer sees one it does not own
+    /// (engine.proto:169-173). That is deliberately NOT what `inspect` does one
+    /// method up, where an unlabelled container is refused as
+    /// `foreign_resource_refused` -- these answer different questions. This one
+    /// reports what the engine holds; that one asserts a named container is the
+    /// sandbox that was asked for, and it cannot assert that without labels.
     ///
-    /// Two further defects sat behind that emptiness and would have surfaced
-    /// the moment state was loaded: `listContainers(all: true)` with no filters
+    /// **An empty `ResourceList` is not an error arm.** It is a confident report
+    /// of a clean host, which is precisely the report that hides a leak, so the
+    /// two must stay distinguishable at every source below. An earlier revision
+    /// of this method returned `[]` under every input: `initialize()` had been
+    /// called on no manager, so containers and volumes had no loaded rows and
+    /// `NetworkManager.listNetworks()` read two backends that were both nil.
+    /// `ArcaEngineCommand.run()` now initializes all three before it binds the
+    /// socket, so the state these three calls read is really there.
+    ///
+    /// Two further defects sat behind that emptiness and would have surfaced the
+    /// moment state was loaded: `listContainers(all: true)` with no filters
     /// dropped every container labelled `com.arca.internal=true`, and
-    /// `NetworkManager.listNetworks()` swallowed a WireGuard-backend failure
-    /// with `try?`, turning a real failure into a clean answer. Both are now
-    /// fixed in `ContainerBridge` -- `listContainers` takes an `includeInternal:`
-    /// argument and `listNetworks()` throws -- and this method must use both
-    /// when it is written, because a silently incomplete list is worse than no
-    /// list.
+    /// `listNetworks()` swallowed a WireGuard-backend failure with `try?`,
+    /// turning a real failure into a clean answer. Both are fixed in
+    /// `ContainerBridge`, and this method uses both: `includeInternal: true`, and
+    /// a `try` that carries a backend failure out as `command_io` rather than as
+    /// a short list. A silently incomplete list is worse than no list.
     func listResources(request: Arca_Engine_V1_ListResourcesRequest) async -> Arca_Engine_V1_ListResourcesResponse {
-        Arca_Engine_V1_ListResourcesResponse.with { $0.error = Self.notImplemented("ListResources") }
+        let collected = await engineErrorCatching(.commandIo) {
+            var resources: [Arca_Engine_V1_Resource] = []
+            for container in try await self.containerManager.listContainers(
+                all: true, includeInternal: true
+            ) {
+                resources.append(resourceMessage(
+                    kind: .container,
+                    name: containerResourceName(names: container.names, id: container.id),
+                    labels: container.labels
+                ))
+            }
+            for volume in try await self.volumeManager.listVolumes() {
+                resources.append(resourceMessage(
+                    kind: .volume, name: volume.name, labels: volume.labels
+                ))
+            }
+            for network in try await self.networkManager.listNetworks() {
+                resources.append(resourceMessage(
+                    kind: .network, name: network.name, labels: network.labels
+                ))
+            }
+            return resources
+        }
+        switch collected {
+        case .failure(let error):
+            return Arca_Engine_V1_ListResourcesResponse.with { $0.error = error }
+        case .success(let resources):
+            return Arca_Engine_V1_ListResourcesResponse.with { response in
+                response.resources = Arca_Engine_V1_ResourceList.with { $0.resources = resources }
+            }
+        }
     }
 
     public func listResources(

--- a/Sources/ArcaEngine/SandboxEngineService.swift
+++ b/Sources/ArcaEngine/SandboxEngineService.swift
@@ -10,9 +10,10 @@ import SandboxEngineProto
 /// in EngineTranslation, so that this file stays readable as a list of the
 /// contract's eleven methods.
 ///
-/// **In this build, five of the eleven are implemented: `Capabilities`,
-/// `Inspect`, `ListResources`, `PrepareImage` and `Create`.** The other six
-/// answer `unsupported_capability` inside their response `oneof`.
+/// **In this build, eight of the eleven are implemented: `Capabilities`,
+/// `Inspect`, `ListResources`, `PrepareImage`, `Create`, `Start`, `Stop` and
+/// `Remove`.** The other three -- `CreateContainer`, `Exec` and `Logs` -- answer
+/// `unsupported_capability` inside their response `oneof`.
 ///
 /// `Inspect` and `ListResources` were both on that list because, when they were
 /// written, this process called `initialize()` on no manager, and an
@@ -645,8 +646,29 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
     }
 
     /// See the note on the `create(request:)` overload above.
+    ///
+    /// **What this deliberately does NOT do, and it is the whole reason `Start`
+    /// is dangerous to write by looking at the daemon.** The daemon's other
+    /// caller of `startContainer` is `applyRestartPolicies()`
+    /// (`ContainerManager.swift:495`), which asks the store for every container
+    /// whose policy says restart and starts each one (`:513`);
+    /// `ArcaDaemon.swift:286` calls it, and `server.start()` is not until `:314`.
+    /// Imported here, that would boot VMs for sandboxes the consumer believes
+    /// stopped, at a moment before the socket exists, so the consumer could not
+    /// even observe it happening. This method starts exactly the one container the
+    /// request names and the engine runs no policy pass at all; `Create` leaves
+    /// the default `no` policy in place (`ContainerManager.swift:1916`) so there
+    /// is nothing for one to find.
+    ///
+    /// **The refusals run before `startContainer`, and the order is the point.**
+    /// `startContainer` resolves the name at `:2071`, *then* guards on
+    /// `nativeManager` at `:2080`. So the resolver's hex prefix match happens
+    /// first, and by the time anything would refuse, the container this method is
+    /// about is already the wrong one. See `containerNameRefusal`.
     func start(request: Arca_Engine_V1_StartRequest) async -> Arca_Engine_V1_AckResponse {
-        Arca_Engine_V1_AckResponse.with { $0.error = Self.notImplemented("Start") }
+        await lifecycleAck(verb: "start", sandboxId: request.sandboxID) { name in
+            try await self.containerManager.startContainer(id: name)
+        }
     }
 
     public func start(
@@ -657,8 +679,29 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
     }
 
     /// See the note on the `create(request:)` overload above.
+    ///
+    /// No timeout is passed because the contract carries none: `StopRequest` is a
+    /// `sandbox_id` and nothing else (engine.proto:372-375), so
+    /// `stopContainer(id:timeout:)` takes its own default rather than a number
+    /// this engine would have invented.
+    ///
+    /// **`Stop` is idempotent below this seam and that is ContainerBridge's
+    /// behaviour, not this method's.** `stopContainer` returns without acting for
+    /// a container already `created`, `exited` or `dead`
+    /// (`ContainerManager.swift:2701-2707`), so a second `Stop` answers `Ack`.
+    /// That is the right answer for a reconciler -- "it is stopped" is what it
+    /// asked for -- but note what it does *not* change: the early return at
+    /// `:2706` never touches `info.state`, so a container that was created and
+    /// never started stays `created`, and `sandboxState(fromStatus:)` maps that
+    /// to `.creating` (`EngineTranslation.swift:129`). `Inspect` therefore
+    /// reports `SANDBOX_STATE_CREATING` after a successful `Stop`. Recorded here
+    /// because it is visible on the wire, and left alone because inventing an
+    /// `exited` state for a container that never ran would be a report of a
+    /// transition that did not happen.
     func stop(request: Arca_Engine_V1_StopRequest) async -> Arca_Engine_V1_AckResponse {
-        Arca_Engine_V1_AckResponse.with { $0.error = Self.notImplemented("Stop") }
+        await lifecycleAck(verb: "stop", sandboxId: request.sandboxID) { name in
+            try await self.containerManager.stopContainer(id: name)
+        }
     }
 
     public func stop(
@@ -668,9 +711,265 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
         await stop(request: request)
     }
 
+    /// `Start` and `Stop`, which differ only in the verb and the call.
+    ///
+    /// One function rather than two, because the three gates in front of the call
+    /// are the same three and the failure this shape prevents is one of them being
+    /// added to `Start` and forgotten on `Stop`. See `lifecycleRefusal` for what
+    /// each gate refuses and why `Start` and `Stop` cannot compare owner labels
+    /// the way `Remove` does.
+    ///
+    /// The container is read through `getContainer` first, which resolves through
+    /// the same `resolveContainerID` the call below will -- so this is a
+    /// check-then-act and the two reads can in principle disagree. There is no
+    /// engine-side lock that would make it otherwise, and the narrower race is
+    /// much better than no gate: the same reasoning `create(request:)` records
+    /// for its network-name check.
+    private func lifecycleAck(
+        verb: String,
+        sandboxId: String,
+        _ act: (String) async throws -> Void
+    ) async -> Arca_Engine_V1_AckResponse {
+        let name = SandboxIdentity.containerName(forSandboxId: sandboxId)
+        if let refusal = containerNameRefusal(name) { return Self.ackFailed(refusal) }
+
+        let found = await engineErrorCatching(.commandIo, resource: name) {
+            try await self.containerManager.getContainer(id: name)
+        }
+        let container: Container?
+        switch found {
+        case .failure(let error): return Self.ackFailed(error)
+        case .success(let read): container = read
+        }
+        if let refusal = lifecycleRefusal(
+            verb: verb, sandboxId: name, storedLabels: container?.config.labels
+        ) {
+            return Self.ackFailed(refusal)
+        }
+
+        if case .failure(let error) = await Self.actCatching(resource: name, { try await act(name) }) {
+            return Self.ackFailed(error)
+        }
+        return Arca_Engine_V1_AckResponse.with { $0.ok = Arca_Engine_V1_Ack() }
+    }
+
     /// See the note on the `create(request:)` overload above.
+    ///
+    /// **Every named resource is authorised before any of them is deleted, and
+    /// the two passes cannot be merged.** `AckResponse` is `ok` or `error`
+    /// (engine.proto:76-82) -- there is no `CreateFailed.created` here, no field
+    /// in which a partial teardown can report what it already destroyed. So a
+    /// single pass that deleted a container and then refused its volume would
+    /// leave the consumer with an error, a sandbox that is gone, and no way to
+    /// learn which of the two happened. Refusing the whole call before touching
+    /// anything is the only arrangement in which an error means "nothing
+    /// changed".
+    ///
+    /// A delete that *fails* mid-pass still has that problem and it is not
+    /// solvable here: the resources before it are already gone and the error
+    /// names only the one that failed. That is the contract's shape rather than
+    /// this method's choice, and `ListResources` is what the consumer has to
+    /// reconcile with afterwards.
+    ///
+    /// **No `force`.** `removeContainer` refuses a running container without it
+    /// (`ContainerManager.swift:3011-3013`) and that refusal is the useful one: a
+    /// consumer removing a sandbox it believes stopped, over a sandbox that is
+    /// running, has a disagreement worth hearing about rather than a VM worth
+    /// killing. The sibling backend takes the same position -- `container delete
+    /// <name>` with no `--force` (`crates/gascan-apple/src/backend.rs:513-515`).
+    /// `Stop` is how a consumer means to stop something.
+    ///
+    /// **`removeVolumes` is not passed, and the reason is that it does nothing.**
+    /// `removeContainer(id:force:removeVolumes:)` spans
+    /// `ContainerManager.swift:2995-3202` and the identifier `removeVolumes`
+    /// occurs exactly once inside it: on the signature line. The body never reads
+    /// it, so passing `true` would name a control the code does not have -- the
+    /// shape of claim this milestone has shipped eight defects of. What the body
+    /// does unconditionally is call `cleanupVolumesForContainer` (`:3170`), which
+    /// deletes the container's *anonymous* volume mounts and spares its named
+    /// ones. That is the right behaviour for this contract either way: `Remove`
+    /// names exact resources (engine.proto:377-379), so every volume Gas Can
+    /// wants gone arrives as its own `ResourceIdentity` and is deleted by the
+    /// volume pass below, while an anonymous volume is one no `ResourceIdentity`
+    /// can ever name and would otherwise leak.
     func remove(request: Arca_Engine_V1_RemoveRequest) async -> Arca_Engine_V1_AckResponse {
-        Arca_Engine_V1_AckResponse.with { $0.error = Self.notImplemented("Remove") }
+        // An empty remove has an `Ack` that is true and useless -- "I deleted
+        // everything you named" over nothing. It is refused because the way one
+        // arrives is a caller that dropped its list, and that caller reads the
+        // `Ack` as a teardown that happened. The consumer refuses to build one
+        // itself (`crates/gascan-arca/src/translate.rs:255-256`), so this refuses
+        // nothing it sends.
+        guard !request.resources.isEmpty else {
+            return Self.ackFailed(engineError(
+                .invalidState,
+                message: "a remove names the resources to delete and this one names none"
+            ))
+        }
+        // The labels every resource below is checked against. A half-set owner
+        // cannot be compared -- it would match only resources labelled equally
+        // half-set -- so it is refused here rather than turned into an
+        // `ownership_mismatch` for every resource in the call, which would read
+        // as "these are not yours" when the truth is "you did not say who you
+        // are".
+        guard !request.owner.managedBy.isEmpty, !request.owner.sandboxID.isEmpty else {
+            return Self.ackFailed(engineError(
+                .invalidResourceIdentity,
+                message: "remove requires both owner labels to compare against; this request "
+                    + "carries managed_by '\(request.owner.managedBy)' and sandbox_id "
+                    + "'\(request.owner.sandboxID)'"
+            ))
+        }
+
+        var ordered: [(kind: RemovableKind, name: String)] = []
+        for identity in request.resources {
+            switch removableKind(identity) {
+            case .failure(let error): return Self.ackFailed(error)
+            case .success(let kind): ordered.append((kind: kind, name: identity.name))
+            }
+        }
+        // `enumerated` as the tiebreaker because `sorted(by:)` is not documented
+        // stable: without it, two volumes in one request could be deleted in
+        // either order, and a failure on the second would report a different
+        // resource run to run.
+        ordered = ordered.enumerated()
+            .sorted { ($0.element.kind.removalRank, $0.offset) < ($1.element.kind.removalRank, $1.offset) }
+            .map(\.element)
+
+        for resource in ordered {
+            let held: [String: String]?
+            switch await storedLabels(kind: resource.kind, name: resource.name) {
+            case .failure(let error): return Self.ackFailed(error)
+            case .success(let labels): held = labels
+            }
+            if let refusal = removalRefusal(
+                kind: resource.kind, name: resource.name, storedLabels: held, owner: request.owner
+            ) {
+                return Self.ackFailed(refusal)
+            }
+        }
+
+        for resource in ordered {
+            if let error = await delete(kind: resource.kind, name: resource.name) {
+                return Self.ackFailed(error)
+            }
+        }
+        return Arca_Engine_V1_AckResponse.with { $0.ok = Arca_Engine_V1_Ack() }
+    }
+
+    /// The labels the engine stores for one named resource, or nil when it holds
+    /// no such resource.
+    ///
+    /// Each kind's "absent" is expressed differently by its manager -- a nil
+    /// `Container`, a thrown `VolumeError.notFound`, a nil `NetworkMetadata` --
+    /// and collapsing the three into one optional here is what lets
+    /// `removalRefusal` be a pure function with one absent case. A manager
+    /// failure that is *not* absence stays a failure: a `command_io` that says
+    /// "I could not tell" rather than a `not_found` that says "it is not there",
+    /// because the consumer creates on the second and retries on the first.
+    private func storedLabels(
+        kind: RemovableKind,
+        name: String
+    ) async -> Result<[String: String]?, Arca_Engine_V1_EngineError> {
+        switch kind {
+        case .container:
+            return await engineErrorCatching(.commandIo, resource: name) {
+                try await self.containerManager.getContainer(id: name)?.config.labels
+            }
+        case .volume:
+            do {
+                return .success(try await volumeManager.inspectVolume(name: name).labels)
+            } catch VolumeError.notFound {
+                return .success(nil)
+            } catch {
+                return .failure(engineError(.commandIo, resource: name, message: "\(error)"))
+            }
+        case .network:
+            return .success(await networkManager.getNetworkByName(name: name)?.labels)
+        }
+    }
+
+    /// One authorised resource, deleted, or the failure that says why it was not.
+    ///
+    /// The network is looked up again rather than carried from the authorisation
+    /// pass because `deleteNetwork` takes an id and the contract names a network
+    /// by name (engine.proto:162-166). A network that vanished between the two
+    /// passes is `not_found` here rather than a crash on a stale id.
+    private func delete(kind: RemovableKind, name: String) async -> Arca_Engine_V1_EngineError? {
+        switch kind {
+        case .container:
+            let done = await Self.actCatching(resource: name) {
+                try await self.containerManager.removeContainer(id: name)
+            }
+            if case .failure(let error) = done { return error }
+        case .volume:
+            let done = await Self.actCatching(resource: name) {
+                try await self.volumeManager.deleteVolume(name: name)
+            }
+            if case .failure(let error) = done { return error }
+        case .network:
+            guard let network = await networkManager.getNetworkByName(name: name) else {
+                return engineError(
+                    .notFound,
+                    resource: name,
+                    message: "this engine holds no network named \(name)"
+                )
+            }
+            let done = await Self.actCatching(resource: name) {
+                try await self.networkManager.deleteNetwork(id: network.id)
+            }
+            if case .failure(let error) = done { return error }
+        }
+        return nil
+    }
+
+    /// `engineErrorCatching` with the distinctions the acting methods have to
+    /// preserve, the way `createCatching` carries `Create`'s.
+    ///
+    /// Three codes rather than one `command_failed`, because each tells a
+    /// reconciler to do something different:
+    ///
+    /// - **`not_found`.** Every method here checks the store before it acts, so a
+    ///   `containerNotFound` from the act itself means the container went away in
+    ///   between. `command_failed` would have the consumer retry against a
+    ///   sandbox that is gone; `not_found` has it create one.
+    /// - **`invalid_state`.** `containerRunning` is `removeContainer` refusing to
+    ///   destroy a running sandbox without `force`. Retrying is futile until
+    ///   something stops it, which is what `invalid_state` says and what
+    ///   `command_failed` does not.
+    /// - **`command_failed`** for everything else, including the
+    ///   `notInitialized` an unstarted engine raises: the engine tried and
+    ///   something broke.
+    private static func actCatching(
+        resource: String,
+        _ body: () async throws -> Void
+    ) async -> Result<Void, Arca_Engine_V1_EngineError> {
+        do {
+            return .success(try await body())
+        } catch {
+            let code: EngineErrorCode
+            switch error {
+            case ContainerManagerError.containerNotFound, VolumeError.notFound,
+                 NetworkManagerError.networkNotFound:
+                code = .notFound
+            case ContainerManagerError.containerRunning, VolumeError.inUse:
+                code = .invalidState
+            default:
+                code = .commandFailed
+            }
+            return .failure(engineError(code, resource: resource, message: "\(error)"))
+        }
+    }
+
+    /// The failure arm of an `AckResponse`, in one place.
+    ///
+    /// Every refusal in `Start`, `Stop` and `Remove` goes through it, for the
+    /// reason `createFailed` exists: spelling the wrapper out at a dozen early
+    /// returns is a dozen chances for one of them to leave the `oneof` unset, and
+    /// an `AckResponse` with no outcome reads as neither success nor failure.
+    private static func ackFailed(
+        _ error: Arca_Engine_V1_EngineError
+    ) -> Arca_Engine_V1_AckResponse {
+        Arca_Engine_V1_AckResponse.with { $0.error = error }
     }
 
     public func remove(

--- a/Sources/ArcaEngine/SandboxEngineService.swift
+++ b/Sources/ArcaEngine/SandboxEngineService.swift
@@ -10,8 +10,8 @@ import SandboxEngineProto
 /// in EngineTranslation, so that this file stays readable as a list of the
 /// contract's eleven methods.
 ///
-/// **In this build, three of the eleven are implemented: `Capabilities`,
-/// `Inspect` and `ListResources`.** The other eight answer
+/// **In this build, four of the eleven are implemented: `Capabilities`,
+/// `Inspect`, `ListResources` and `PrepareImage`.** The other seven answer
 /// `unsupported_capability` inside their response `oneof`.
 ///
 /// `Inspect` and `ListResources` were both on that list because, when they were
@@ -25,11 +25,11 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
 
     // `containerManager` is read by `inspect(request:)` and, with
     // `volumeManager` and `networkManager`, by `listResources(request:)` below.
-    // `imageManager` and `execManager` are held and, in this build, unread.
-    // Deliberate on both counts.
+    // `imageManager` is read by `prepareImage(request:)`. `execManager` is held
+    // and, in this build, unread. Deliberate on both counts.
     //
-    // Unread because the methods that would consult them -- `PrepareImage`,
-    // `Exec` -- are among the eight this build does not implement. Held because
+    // Unread because the method that would consult it -- `Exec` -- is among the
+    // seven this build does not implement. Held because
     // the dependency edge is itself a shipped property: gascan's
     // tests/release/engine-targets-check.sh asserts that `arca-engine` and
     // `ArcaEngine` reach neither `DockerAPI` nor `ArcaDaemon`, and that
@@ -253,8 +253,123 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
     }
 
     /// See the note on the `create(request:)` overload above.
+    ///
+    /// **Absent content is `not_found`, and that is a correct, final answer.**
+    /// It is not `unsupported_capability`, which means "this build cannot do
+    /// that", and it is not an invitation to fetch. `engine.proto:308-313` says
+    /// the same thing above the request message: "Materialise a rootfs for
+    /// content THE ENGINE ALREADY HOLDS ... Absent content is a failure; it is
+    /// never a fetch", and "How the engine comes to hold the content is
+    /// deliberately unanswered by this contract." Content arrives by
+    /// `arca-engine image load --oci-layout <dir>`, out of band, before any of
+    /// this.
+    ///
+    /// **There is no fallback to `ImageManager.pullImage`, and adding one would
+    /// undo the milestone.** It is the obvious-looking improvement here -- the
+    /// manager is right there, it has the method, and the failing request names
+    /// exactly what it would fetch. The design rejected it because it "would put
+    /// registry credentials and Keychain access back inside the component the
+    /// policy boundary exists to constrain"
+    /// (docs/superpowers/specs/2026-08-10-p5-1-engine-service-and-wiring-design.md
+    /// §2.2). A compromised guest must have no frame it can send that reaches a
+    /// registry, and this is the method the proto itself calls "the one method
+    /// that would grow a registry client if nobody were watching it".
+    ///
+    /// **What this verifies, and what it does not.** It asks the image store
+    /// whether it holds the content in full: an image under exactly this digest,
+    /// and every blob that image names present in the content store. That last
+    /// part is the substance -- an image row can outlive its layer blobs, and
+    /// the cheap answer, `imageExists(nameOrId:)`
+    /// (`ContainerBridge/ImageManager.swift:616-624`), says `true` for one that
+    /// has: it is built on `inspectImage`, which reads the index, the manifest
+    /// and the config and never a layer. `Ack` carries no payload, so an `Ack`
+    /// granted on that answer is a report the consumer has no way to check.
+    ///
+    /// It does **not** unpack the layers into the OverlayFS layer cache, which
+    /// is the only thing in this codebase that materialises a rootfs. That is
+    /// not a shortcut taken for convenience; the unpacker is not reachable here
+    /// in a way that would be correct. `ContainerManager` builds its
+    /// `OverlayFSUnpacker` inside `initialize()`
+    /// (`ContainerBridge/ContainerManager.swift:280-285`) and keeps it private,
+    /// and `Containerization.OverlayFSUnpacker.unpack` is per-*container*, not
+    /// per-image: it creates `upper` and `work` directories at a container path
+    /// and increments a reference count for each layer
+    /// (`containerization/Sources/Containerization/Image/Unpacker/OverlayFSUnpacker.swift:123-144`).
+    /// Running it for an image with no container would leak reference counts
+    /// nothing will ever release, and its per-image half, `unpackLayerToCache`,
+    /// is private upstream. `Create` unpacks, scoped to the container that owns
+    /// the result; the promise this method can keep is that `Create` will find
+    /// the content here and will not need to reach a registry for it.
+    ///
+    /// **The repository is checked as well as the digest.** Answering `Ack` for
+    /// content held under a different repository would be a success followed by
+    /// a `Create` failure, since `ContainerManager.createContainer` resolves the
+    /// image by the reference it is given
+    /// (`ContainerBridge/ContainerManager.swift:1696-1698`). The comparison
+    /// splits both sides by Gas Can's own rule -- see
+    /// `imageRepository(ofReference:)` -- and is exact. It normalizes no
+    /// registry prefix, so content stored as `docker.io/library/alpine:3.19` is
+    /// not found under a requested repository of `alpine`. That is the safe
+    /// direction and it is chosen deliberately: a false `not_found` is visible
+    /// and recoverable, a false `Ack` is neither.
     func prepareImage(request: Arca_Engine_V1_PrepareImageRequest) async -> Arca_Engine_V1_PrepareImageResponse {
-        Arca_Engine_V1_PrepareImageResponse.with { $0.error = Self.notImplemented("PrepareImage") }
+        let resource = imageReference(forDigest: request.image)
+        guard let key = imageStoreDigest(request.image) else {
+            return Self.prepareImageFailure(engineError(
+                .invalidResourceIdentity,
+                resource: resource,
+                message: "an image digest is a non-empty repository and a 64-character lowercase "
+                    + "hex sha256 carrying no prefix"
+            ))
+        }
+
+        let held = await engineErrorCatching(.commandIo, resource: resource) {
+            try await self.imageManager.heldImageContent(digest: key)
+        }
+        switch held {
+        case .failure(let error):
+            return Self.prepareImageFailure(error)
+        case .success(.noImageForDigest):
+            return Self.prepareImageFailure(engineError(
+                .notFound,
+                resource: resource,
+                message: "this engine holds no image with that content digest and will not fetch "
+                    + "one; load it with 'arca-engine image load --oci-layout <dir>'"
+            ))
+        case .success(.blobsMissing(let reference, let digests)):
+            return Self.prepareImageFailure(engineError(
+                .notFound,
+                resource: resource,
+                message: "the image stored as \(reference) carries that content digest, but this "
+                    + "engine does not hold \(digests.count) of the blobs it names: "
+                    + digests.joined(separator: ", ")
+            ))
+        case .success(.held(let reference)):
+            let stored = imageRepository(ofReference: reference)
+            guard stored == request.image.repository else {
+                return Self.prepareImageFailure(engineError(
+                    .notFound,
+                    resource: resource,
+                    message: "this engine holds that content digest under repository "
+                        + "\(stored), not \(request.image.repository)"
+                ))
+            }
+            logger.info("image content is held in full", metadata: [
+                "reference": "\(reference)",
+                "digest": "\(key)",
+            ])
+            return Arca_Engine_V1_PrepareImageResponse.with { $0.ok = Arca_Engine_V1_Ack() }
+        }
+    }
+
+    /// The failure arm, in one place.
+    ///
+    /// Five refusals reach it, and spelling the wrapper out five times is five
+    /// chances for a later edit to build one of them differently.
+    private static func prepareImageFailure(
+        _ error: Arca_Engine_V1_EngineError
+    ) -> Arca_Engine_V1_PrepareImageResponse {
+        Arca_Engine_V1_PrepareImageResponse.with { $0.error = error }
     }
 
     public func prepareImage(

--- a/Sources/ArcaEngine/SandboxEngineService.swift
+++ b/Sources/ArcaEngine/SandboxEngineService.swift
@@ -10,28 +10,32 @@ import SandboxEngineProto
 /// in EngineTranslation, so that this file stays readable as a list of the
 /// contract's eleven methods.
 ///
-/// **In this build, one of the eleven is implemented: `Capabilities`.** The
-/// other ten answer `unsupported_capability` inside their response `oneof`.
-/// `Inspect` and `ListResources` joined that list because, when they were
+/// **In this build, two of the eleven are implemented: `Capabilities` and
+/// `Inspect`.** The other nine answer `unsupported_capability` inside their
+/// response `oneof`.
+///
+/// `Inspect` and `ListResources` were both on that list because, when they were
 /// written, this process called `initialize()` on no manager, and an
 /// uninitialised manager does not report "I cannot tell", it reports "nothing
 /// exists". `ArcaEngineCommand.run()` now initializes all three before it binds
-/// the socket, so that reason has expired: implementing the two is Tasks 7 and
-/// 8's work, and until then they answer `unsupported_capability` because they
-/// are unwritten, not because the state behind them is empty.
+/// the socket, so that reason has expired for both: `Inspect` answers from that
+/// loaded state below, and `ListResources` still answers
+/// `unsupported_capability` because it is unwritten -- Task 8's work -- not
+/// because the state behind it is empty.
 public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvider {
     public let interceptors: Arca_Engine_V1_SandboxEngineServerInterceptorFactoryProtocol? = nil
 
-    // Held and, in this build, unread. Deliberate on both counts.
+    // `containerManager` is read by `inspect(request:)` below. The other four
+    // are held and, in this build, unread. Deliberate on both counts.
     //
-    // Unread because the only two methods that consulted them could not report
-    // anything true without loaded state. Held because the dependency edge is
-    // itself a shipped property: gascan's tests/release/engine-targets-check.sh
-    // asserts that `arca-engine` and `ArcaEngine` reach neither `DockerAPI` nor
+    // Unread because the methods that would consult them are the ones this
+    // build does not implement. Held because the dependency edge is itself a
+    // shipped property: gascan's tests/release/engine-targets-check.sh asserts
+    // that `arca-engine` and `ArcaEngine` reach neither `DockerAPI` nor
     // `ArcaDaemon`, and that assertion measures something only while this
-    // target genuinely depends on ContainerBridge. Dropping these five to
-    // silence an unused-property reading would make the release gate pass for a
-    // reason that has nothing to do with what it exists to prove.
+    // target genuinely depends on ContainerBridge. Dropping the four to silence
+    // an unused-property reading would make the release gate pass for a reason
+    // that has nothing to do with what it exists to prove.
     let containerManager: ContainerManager
     let volumeManager: VolumeManager
     let networkManager: NetworkManager
@@ -107,28 +111,117 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
 
     /// See the note on the `create(request:)` overload above.
     ///
-    /// Unimplemented in this build, and that is a deliberate reversal.
+    /// Three arms, kept distinct. `engine.proto`'s `InspectResponse`
+    /// (`:354-365`) separates "it is not there" from "I could not tell" because
+    /// they "demand opposite behaviour from a reconciler": on `absent` a
+    /// consumer creates the sandbox, so answering `absent` for a sandbox that is
+    /// running induces a duplicate, and answering an error for one that is
+    /// genuinely gone stalls the reconciler instead. A read that throws is the
+    /// error arm; a read that resolves nothing is the absent arm; they are never
+    /// merged.
     ///
-    /// An earlier revision answered from `ContainerManager`. Because the process
-    /// then called `ContainerManager.initialize()` on no manager, the only two
-    /// writers of `ContainerManager.containers` never ran, so that
-    /// implementation could return exactly one answer: `absent`.
-    /// `engine.proto`'s `InspectResponse`
-    /// has three arms specifically so that "it is not there" stays
-    /// distinguishable from "I could not tell", and those "demand opposite
-    /// behaviour from a reconciler": on `absent` a consumer creates the
-    /// sandbox. An engine that answers `absent` for a sandbox that is running
-    /// induces a duplicate.
+    /// **The owner labels are read before the image digest, and the order is the
+    /// point.** Container names are a flat namespace this engine does not own,
+    /// so the name a sandbox id resolves to can belong to something else
+    /// entirely -- and something else was very likely created from a tag, which
+    /// `imageDigest(fromReference:)` refuses. Checking the digest first answers
+    /// `invalid_output` for that container, and `invalid_output` is the code
+    /// gascan reserves for "the engine sent me something I cannot interpret"
+    /// (`crates/gascan-arca/src/error.rs`), which tells the consumer the engine
+    /// is broken when the truth is a foreign resource.
+    /// `foreign_resource_refused` exists for exactly that, so the label read
+    /// goes first and the digest refusal is left to describe only containers
+    /// this engine has already established are gascan's.
     ///
-    /// `unsupported_capability` is the honest answer for a build that holds no
-    /// loaded state. It costs the consumer nothing it was getting -- the
-    /// previous answer carried no information -- and it cannot be mistaken for
-    /// an observation. `ArcaEngineCommand.run()` now calls `initialize()` on all
-    /// three managers before it binds the socket, so the state is there; Task 7
-    /// restores this method along with the `Sandbox` translation in
-    /// `EngineTranslation`, which stays in the target, tested, for that purpose.
+    /// Refusing an unlabelled container rather than returning a `Sandbox`
+    /// without an owner is the same finding one hop later: gascan turns an
+    /// ownerless `Sandbox` into `invalid_output("sandbox {id} carries no owner
+    /// labels")` itself (`translate.rs:412-414`), so the ownerless sandbox arm
+    /// reaches the consumer as the same wrong code.
+    ///
+    /// This is not the engine interpreting labels, which `engine.proto:143-148`
+    /// forbids. The engine is not deciding whether a labelled resource is the
+    /// caller's; it is declining to assert that an unlabelled one **is** the
+    /// sandbox that was asked for. The consumer's judgment is untouched: a
+    /// container labelled for a different sandbox is returned with its labels,
+    /// and `translate.rs:421-425` raises `OwnershipMismatch` on its own. No
+    /// `sandbox_id` comparison happens here.
+    ///
+    /// **The ports are what the store holds, and that is deliberate.**
+    /// `setPortMapManager` is unwired until Task 11, so a container's stored
+    /// `hostConfig.portBindings` can name a binding that was never actually
+    /// published on the host. Reporting the store is still correct: drift
+    /// detection compares the engine's report against the desired spec, and a
+    /// report synthesised from anything else would compare the wrong thing. What
+    /// this method must never do is emit a port value the store did not hold --
+    /// see `sandboxPorts(fromBindings:)` for the three stored shapes the
+    /// contract cannot carry and why each is refused rather than invented.
     func inspect(request: Arca_Engine_V1_InspectRequest) async -> Arca_Engine_V1_InspectResponse {
-        Arca_Engine_V1_InspectResponse.with { $0.error = Self.notImplemented("Inspect") }
+        let name = SandboxIdentity.containerName(forSandboxId: request.sandboxID)
+        let found = await engineErrorCatching(.commandIo, resource: name) {
+            try await self.containerManager.getContainer(id: name)
+        }
+        switch found {
+        case .failure(let error):
+            return Arca_Engine_V1_InspectResponse.with { $0.error = error }
+        case .success(nil):
+            return Arca_Engine_V1_InspectResponse.with { $0.absent = Arca_Engine_V1_Absent() }
+        case .success(.some(let container)):
+            return await sandboxResponse(
+                for: container, name: name, sandboxId: request.sandboxID
+            )
+        }
+    }
+
+    /// The sandbox arm, and the two refusals that stand in front of it.
+    ///
+    /// Separate from `inspect(request:)` so that the order the doc comment above
+    /// argues for is the order this reads in: labels, then digest, then ports.
+    private func sandboxResponse(
+        for container: Container,
+        name: String,
+        sandboxId: String
+    ) async -> Arca_Engine_V1_InspectResponse {
+        guard let owner = SandboxIdentity.owner(from: container.config.labels) else {
+            return Arca_Engine_V1_InspectResponse.with {
+                $0.error = engineError(
+                    .foreignResourceRefused,
+                    resource: name,
+                    message: "container \(name) carries no gascan owner labels, so this engine "
+                        + "cannot assert it is the sandbox that was asked for"
+                )
+            }
+        }
+        guard let digest = imageDigest(fromReference: container.image) else {
+            return Arca_Engine_V1_InspectResponse.with {
+                $0.error = engineError(
+                    .invalidOutput,
+                    resource: name,
+                    message: "container image \(container.image) is not an exact digest reference"
+                )
+            }
+        }
+        let bindings = await containerManager.convertPortBindingsToMappings(
+            container.hostConfig.portBindings
+        )
+        switch sandboxPorts(fromBindings: bindings) {
+        case .failure(let unrepresentable):
+            return Arca_Engine_V1_InspectResponse.with {
+                $0.error = engineError(
+                    .invalidOutput, resource: name, message: unrepresentable.reason
+                )
+            }
+        case .success(let ports):
+            return Arca_Engine_V1_InspectResponse.with { response in
+                response.sandbox = Arca_Engine_V1_Sandbox.with { sandbox in
+                    sandbox.sandboxID = sandboxId
+                    sandbox.image = digest
+                    sandbox.state = sandboxState(fromStatus: container.state.status)
+                    sandbox.owner = owner
+                    sandbox.ports = ports
+                }
+            }
+        }
     }
 
     public func inspect(
@@ -244,8 +337,8 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
 
     /// See the note on the `create(request:)` overload above.
     ///
-    /// Unimplemented in this build, for the same reason as `inspect` and with a
-    /// sharper edge.
+    /// Unimplemented in this build, for the reason `inspect` used to give and
+    /// with a sharper edge.
     ///
     /// `engine.proto`'s contract for this method is "Every resource the engine
     /// holds, labelled or not", because a consumer's drift and leak detection
@@ -260,11 +353,13 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
     ///
     /// Two further defects sat behind that emptiness and would have surfaced
     /// the moment state was loaded: `listContainers(all: true)` with no filters
-    /// drops every container labelled `com.arca.internal=true`, and
-    /// `NetworkManager.listNetworks()` swallows a WireGuard-backend failure
-    /// with `try?`, turning a real failure into a clean answer. Both must be
-    /// fixed in `ContainerBridge` before this method reports anything; a
-    /// silently incomplete list is worse than no list.
+    /// dropped every container labelled `com.arca.internal=true`, and
+    /// `NetworkManager.listNetworks()` swallowed a WireGuard-backend failure
+    /// with `try?`, turning a real failure into a clean answer. Both are now
+    /// fixed in `ContainerBridge` -- `listContainers` takes an `includeInternal:`
+    /// argument and `listNetworks()` throws -- and this method must use both
+    /// when it is written, because a silently incomplete list is worse than no
+    /// list.
     func listResources(request: Arca_Engine_V1_ListResourcesRequest) async -> Arca_Engine_V1_ListResourcesResponse {
         Arca_Engine_V1_ListResourcesResponse.with { $0.error = Self.notImplemented("ListResources") }
     }

--- a/Sources/ArcaEngine/SandboxEngineService.swift
+++ b/Sources/ArcaEngine/SandboxEngineService.swift
@@ -10,9 +10,9 @@ import SandboxEngineProto
 /// in EngineTranslation, so that this file stays readable as a list of the
 /// contract's eleven methods.
 ///
-/// **In this build, four of the eleven are implemented: `Capabilities`,
-/// `Inspect`, `ListResources` and `PrepareImage`.** The other seven answer
-/// `unsupported_capability` inside their response `oneof`.
+/// **In this build, five of the eleven are implemented: `Capabilities`,
+/// `Inspect`, `ListResources`, `PrepareImage` and `Create`.** The other six
+/// answer `unsupported_capability` inside their response `oneof`.
 ///
 /// `Inspect` and `ListResources` were both on that list because, when they were
 /// written, this process called `initialize()` on no manager, and an
@@ -74,11 +74,18 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
 
     /// See the note on the `create(request:)` overload above.
     ///
-    /// Every capability flag reports what this build implements. Milestone 1
-    /// implements no create and no exec, so every feature flag is false and
-    /// offline is unverified; later milestones flip each flag as they earn
-    /// it. A flag that is true before its code exists induces a consumer to
-    /// send a request the engine cannot honour.
+    /// Every capability flag reports what this build implements, and a flag that
+    /// is true before its code exists induces a consumer to send a request the
+    /// engine cannot honour.
+    ///
+    /// **Every flag is still false, and `Create` landing does not change that.**
+    /// `Create` now honours a project mount, named volumes, loopback publishing
+    /// and resource limits, so three of these flags look ready to flip -- but
+    /// `loopback_publish` in particular is exactly the claim this build cannot
+    /// support: `setPortMapManager` is wired, and gates 2 and 3 between "a
+    /// container with bindings starts" and "a port is published" are provable
+    /// only from the live tier. Flipping the flags is its own task, done against
+    /// the evidence for each, and no flag moves here as a side effect.
     func capabilities(request: Arca_Engine_V1_CapabilitiesRequest) async -> Arca_Engine_V1_CapabilitiesResponse {
         guard let version = engineVersion(from: ArcaVersion.version) else {
             return Arca_Engine_V1_CapabilitiesResponse.with {
@@ -239,9 +246,186 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
     /// This overload carries the actual logic; the protocol-conforming
     /// method below just forwards to it, which is safe because none of the
     /// not-implemented bodies read the context.
+    /// Volumes, then the network, then the container -- and whatever succeeded
+    /// before a failure is reported.
+    ///
+    /// **The order is the contract's, and the report is the reason it matters.**
+    /// `CreateFailed.created` exists because "losing this evidence leaks
+    /// resources that nothing afterwards knows to look for"
+    /// (engine.proto:279-283): the consumer removes exactly what it is told was
+    /// made, so a resource created and not reported is a resource on the host
+    /// that no `Remove` will ever name and only `ListResources` can find. Every
+    /// step below appends to `created` immediately after the call that made the
+    /// resource returns, never in a batch at the end, because a batch is one
+    /// early return away from being skipped.
+    ///
+    /// **Nothing is created before both refusal gates.** The image is checked
+    /// first and the request is translated second; both report an empty
+    /// `created`, so their order decides only which refusal a malformed request
+    /// hears first. The image goes first because it is the failure `PrepareImage`
+    /// exists to pre-empt, and hearing it here means the `Ack` that preceded it
+    /// was wrong -- which is worth surfacing ahead of a field-level complaint.
+    ///
+    /// **What this deliberately does NOT do**, both of which the daemon does and
+    /// both of which would arrive together if this method were written by
+    /// mirroring `ArcaDaemon`:
+    ///
+    /// - It runs no restart policy. `applyRestartPolicies()` calls
+    ///   `startContainer` and boots VMs, which would resurrect sandboxes the
+    ///   consumer believes stopped -- and the daemon does it before the socket
+    ///   binds, so the consumer could not even observe it happening. The
+    ///   container is created with the default `no` policy
+    ///   (`ContainerManager.swift:1916`) and nothing here changes that.
+    /// - It deletes no shared `initfs.ext4`. The private image-store root exists
+    ///   precisely so that this engine never touches the file Apple's tooling
+    ///   shares.
     func create(request: Arca_Engine_V1_CreateRequest) async -> Arca_Engine_V1_CreateResponse {
-        Arca_Engine_V1_CreateResponse.with {
-            $0.failed = Arca_Engine_V1_CreateFailed.with { $0.error = Self.notImplemented("Create") }
+        let image: String
+        switch await heldImageReferences(for: request.image) {
+        case .failure(let error):
+            return Self.createFailed([], error)
+        case .success:
+            // Problem 1's decision, in one expression. See
+            // `heldImageReferences(for:)` above for why the store is consulted
+            // at all, and `SandboxContainerSpec.image` for why the reference
+            // handed on is the digest form rather than a stored tag.
+            image = imageReference(forDigest: request.image)
+        }
+
+        let spec: SandboxContainerSpec
+        switch sandboxContainerSpec(for: request, image: image) {
+        case .failure(let error):
+            return Self.createFailed([], error)
+        case .success(let translated):
+            spec = translated
+        }
+
+        var created: [Arca_Engine_V1_Resource] = []
+
+        for volume in request.volumes {
+            let driver = volumeDriver(forCapacityBytes: volume.capacityBytes)
+            let made = await Self.createCatching(resource: volume.name) {
+                try await self.volumeManager.createVolume(
+                    name: volume.name,
+                    driver: driver.driver,
+                    driverOpts: driver.options,
+                    labels: spec.labels
+                )
+            }
+            if case .failure(let error) = made {
+                return Self.createFailed(created, error)
+            }
+            created.append(resourceMessage(kind: .volume, name: volume.name, labels: spec.labels))
+        }
+
+        if case .networkedName(let networkName) = request.network.mode {
+            // Asked before creating, because `NetworkManager.createNetwork` does
+            // not refuse a name it already holds: it generates a fresh id and
+            // overwrites `networkNames[name]` (`NetworkManager.swift:467`), so a
+            // repeated create would leave the first network on the host with
+            // nothing pointing at it. `createDefaultNetworks` guards itself the
+            // same way (`:297-330`); this is that guard at the one call site
+            // that takes a name from the wire. It is a check-then-act and there
+            // is no engine-side lock to make it otherwise -- the narrower race
+            // is still much better than the silent overwrite.
+            if await networkManager.getNetworkByName(name: networkName) != nil {
+                return Self.createFailed(created, engineError(
+                    .resourceConflict,
+                    resource: networkName,
+                    message: "this engine already holds a network named \(networkName)"
+                ))
+            }
+            let made = await Self.createCatching(resource: networkName) {
+                // `bridge` rather than `vmnet`, and it is the choice that decides
+                // whether ports can ever publish: bridge networks are
+                // WireGuard-backed (`NetworkManager.swift:393-395`), and
+                // `getWireGuardClient` returns nil -- silently publishing
+                // nothing -- for a container that is on no WireGuard network
+                // (`:819-833`).
+                try await self.networkManager.createNetwork(
+                    name: networkName,
+                    driver: "bridge",
+                    subnet: nil,
+                    gateway: nil,
+                    ipRange: nil,
+                    options: [:],
+                    labels: spec.labels
+                )
+            }
+            if case .failure(let error) = made {
+                return Self.createFailed(created, error)
+            }
+            created.append(
+                resourceMessage(kind: .network, name: networkName, labels: spec.labels)
+            )
+        }
+
+        let container = await Self.createCatching(resource: spec.name) {
+            try await self.containerManager.createContainer(
+                image: spec.image,
+                name: spec.name,
+                entrypoint: nil,
+                command: nil,
+                env: spec.env,
+                workingDir: nil,
+                labels: spec.labels,
+                networkMode: spec.networkMode,
+                binds: spec.binds,
+                portBindings: spec.portBindings,
+                memory: spec.memory,
+                nanoCpus: spec.nanoCpus,
+                user: spec.user
+            )
+        }
+        if case .failure(let error) = container {
+            return Self.createFailed(created, error)
+        }
+        created.append(resourceMessage(kind: .container, name: spec.name, labels: spec.labels))
+
+        return Arca_Engine_V1_CreateResponse.with { response in
+            response.created = Arca_Engine_V1_Created.with { $0.created = created }
+        }
+    }
+
+    /// A create failure with the evidence attached.
+    ///
+    /// Every early return in `create(request:)` goes through this, so that
+    /// "report what was made" cannot be forgotten at one of them.
+    private static func createFailed(
+        _ created: [Arca_Engine_V1_Resource],
+        _ error: Arca_Engine_V1_EngineError
+    ) -> Arca_Engine_V1_CreateResponse {
+        Arca_Engine_V1_CreateResponse.with { response in
+            response.failed = Arca_Engine_V1_CreateFailed.with {
+                $0.created = created
+                $0.error = error
+            }
+        }
+    }
+
+    /// `engineErrorCatching` with the one distinction `Create` has to preserve.
+    ///
+    /// A name that is already taken is `resource_conflict`, not
+    /// `command_failed`. The two are opposite instructions to a reconciler:
+    /// `command_failed` says the engine tried and something broke, so retrying
+    /// is reasonable, while `resource_conflict` says the name is occupied and
+    /// retrying will fail identically until something is removed. Collapsing
+    /// them puts a reconciler into a loop against a sandbox that already exists.
+    private static func createCatching<T>(
+        resource: String,
+        _ body: () async throws -> T
+    ) async -> Result<T, Arca_Engine_V1_EngineError> {
+        do {
+            return .success(try await body())
+        } catch {
+            let code: EngineErrorCode
+            switch error {
+            case ContainerManagerError.nameConflict, VolumeError.alreadyExists:
+                code = .resourceConflict
+            default:
+                code = .commandFailed
+            }
+            return .failure(engineError(code, resource: resource, message: "\(error)"))
         }
     }
 
@@ -322,9 +506,35 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
     /// `not_found` for content the engine held, naming a repository the caller
     /// had not asked about.
     func prepareImage(request: Arca_Engine_V1_PrepareImageRequest) async -> Arca_Engine_V1_PrepareImageResponse {
-        let resource = imageReference(forDigest: request.image)
-        guard let key = imageStoreDigest(request.image) else {
-            return Self.prepareImageFailure(engineError(
+        switch await heldImageReferences(for: request.image) {
+        case .failure(let error):
+            return Self.prepareImageFailure(error)
+        case .success:
+            return Arca_Engine_V1_PrepareImageResponse.with { $0.ok = Arca_Engine_V1_Ack() }
+        }
+    }
+
+    /// The references this engine holds a wire digest's content under, or the
+    /// refusal that says why it holds none.
+    ///
+    /// **Shared by `PrepareImage` and `Create`, and sharing it is the point
+    /// rather than a tidiness.** The two methods are a promise and the act that
+    /// depends on it: an `Ack` means "`Create` will find this content and will
+    /// not need a registry for it", and a `Create` that then decided held-ness
+    /// by a second rule could refuse content its own engine had just promised.
+    /// One function decides, so the two cannot disagree about one digest.
+    ///
+    /// The five refusals above it are the same five in either caller, and their
+    /// prose is unchanged from when `prepareImage` spelt them out inline. See
+    /// that method's doc comment for why the store is asked in full rather than
+    /// through `imageExists`, why the repository is compared as well as the
+    /// digest, and why the comparison is exact and normalizes nothing.
+    func heldImageReferences(
+        for image: Arca_Engine_V1_ImageDigest
+    ) async -> Result<[String], Arca_Engine_V1_EngineError> {
+        let resource = imageReference(forDigest: image)
+        guard let key = imageStoreDigest(image) else {
+            return .failure(engineError(
                 .invalidResourceIdentity,
                 resource: resource,
                 message: "an image digest is a non-empty repository and a 64-character lowercase "
@@ -337,16 +547,16 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
         }
         switch held {
         case .failure(let error):
-            return Self.prepareImageFailure(error)
+            return .failure(error)
         case .success(.noImageForDigest):
-            return Self.prepareImageFailure(engineError(
+            return .failure(engineError(
                 .notFound,
                 resource: resource,
                 message: "this engine holds no image with that content digest and will not fetch "
                     + "one; load it with 'arca-engine image load --oci-layout <dir>'"
             ))
         case .success(.blobsMissing(let references, let digests)):
-            return Self.prepareImageFailure(engineError(
+            return .failure(engineError(
                 .notFound,
                 resource: resource,
                 message: "this engine has that content digest in its store under "
@@ -359,12 +569,12 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
             // them. Testing a single row would refuse content the engine holds,
             // by whichever row the store listed first.
             let stored = Set(references.map(imageRepository(ofReference:))).sorted()
-            guard stored.contains(request.image.repository) else {
-                return Self.prepareImageFailure(engineError(
+            guard stored.contains(image.repository) else {
+                return .failure(engineError(
                     .notFound,
                     resource: resource,
                     message: "this engine does not hold that content digest under repository "
-                        + "\(request.image.repository); it holds it under "
+                        + "\(image.repository); it holds it under "
                         + stored.joined(separator: ", ")
                 ))
             }
@@ -372,7 +582,7 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
                 "references": "\(references.joined(separator: ", "))",
                 "digest": "\(key)",
             ])
-            return Arca_Engine_V1_PrepareImageResponse.with { $0.ok = Arca_Engine_V1_Ack() }
+            return .success(references)
         }
     }
 

--- a/Sources/ArcaEngine/SandboxEngineService.swift
+++ b/Sources/ArcaEngine/SandboxEngineService.swift
@@ -79,14 +79,51 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
     /// is true before its code exists induces a consumer to send a request the
     /// engine cannot honour.
     ///
-    /// **Every flag is still false, and `Create` landing does not change that.**
-    /// `Create` now honours a project mount, named volumes, loopback publishing
-    /// and resource limits, so three of these flags look ready to flip -- but
-    /// `loopback_publish` in particular is exactly the claim this build cannot
-    /// support: `setPortMapManager` is wired, and gates 2 and 3 between "a
-    /// container with bindings starts" and "a port is published" are provable
-    /// only from the live tier. Flipping the flags is its own task, done against
-    /// the evidence for each, and no flag moves here as a side effect.
+    /// **Three flags are true, and each one names a live test that drove the
+    /// capability from outside this engine's own store.** `Inspect` reports what
+    /// the store holds, deliberately, so it can corroborate none of them; every
+    /// flag below that is true was earned by an observation of the guest or of
+    /// the host, and every flag that is false is false because no such
+    /// observation exists or because one was made and failed.
+    ///
+    /// - `projectMount`: the host writes a file into the project root, the
+    ///   guest's own `Cmd` serves it back over a published port, and the host
+    ///   then reads a file the guest wrote into the same directory. Earned by
+    ///   `mounts::the_project_root_is_readable_in_the_guest_and_writable_back_to_the_host`
+    ///   in gascan's `gascan-arca` live tier. SEEN TO FAIL, and isolated: with
+    ///   `binds` here started empty instead of carrying the project mount, it
+    ///   was the **only** live test that failed, after 180s with
+    ///   `connected and read nothing`. `CreateTranslationTests
+    ///   .testTheProjectMountAndTheVolumesBecomeBinds` also caught that
+    ///   mutation, which is the difference between the two: the unit test sees
+    ///   the argument, the live test sees the filesystem.
+    /// - `loopbackPublish`: a TCP connection from the test process reads bytes
+    ///   the guest produced. Earned by
+    ///   `ports::a_published_port_is_reachable_from_the_test_process`.
+    /// - `resourceLimits`: the guest's own `/sys/fs/cgroup/cpu.max` and
+    ///   `memory.max` are exactly what the request asked for. Earned by
+    ///   `limits::the_requested_cpu_and_memory_limits_are_the_guests_own_cgroup_limits`.
+    ///   SEEN TO FAIL, and isolated: with `nanoCpus` and `memory` in
+    ///   `sandboxContainerSpec` forced to nil, it was the **only** live test
+    ///   that failed, and the guest reported `400000 100000` and `4294967296`
+    ///   -- four CPUs and ContainerBridge's 4GiB default, in place of the one
+    ///   CPU and 1GiB that were asked for.
+    ///
+    /// **`namedVolumes` stays false, and it is not an oversight.** `Create`
+    /// makes the volumes, `volumeDriver` formats each as an EXT4 image at its
+    /// requested capacity, and `parseVolumeMounts` resolves each one and builds
+    /// a `Mount.block` for it -- and the guest mounts none of them. MEASURED
+    /// from the live tier: three volumes of 256MiB, 512MiB and 1GiB arrive in
+    /// the guest as three block devices of exactly 262144, 524288 and 1048576
+    /// 1K-blocks, while `/proc/mounts` names none of the three targets, with no
+    /// warning and no error anywhere in the log. The mount points were ruled out
+    /// as the cause: the same run with an image carrying all three directories
+    /// behaves identically. `the_managed_volumes_are_attached_to_the_guest_but_this_engine_mounts_none_of_them`
+    /// is the instrument that holds this flag down, and it fails the day the
+    /// mount starts working.
+    ///
+    /// `tty` and `signals` are milestone 3's, with `Exec`. `offline` stays
+    /// `.unverified` until milestone 4 proves it.
     func capabilities(request: Arca_Engine_V1_CapabilitiesRequest) async -> Arca_Engine_V1_CapabilitiesResponse {
         guard let version = engineVersion(from: ArcaVersion.version) else {
             return Arca_Engine_V1_CapabilitiesResponse.with {
@@ -100,12 +137,12 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
             response.capabilities = Arca_Engine_V1_Capabilities.with { capabilities in
                 capabilities.engineVersion = version
                 capabilities.contractMinor = 0
-                capabilities.projectMount = false
+                capabilities.projectMount = true
                 capabilities.namedVolumes = false
                 capabilities.tty = false
                 capabilities.signals = false
-                capabilities.loopbackPublish = false
-                capabilities.resourceLimits = false
+                capabilities.loopbackPublish = true
+                capabilities.resourceLimits = true
                 capabilities.offline = .unverified
             }
         }

--- a/Sources/ArcaEngine/SandboxEngineService.swift
+++ b/Sources/ArcaEngine/SandboxEngineService.swift
@@ -17,7 +17,7 @@ import SandboxEngineProto
 /// `Inspect` and `ListResources` were both on that list because, when they were
 /// written, this process called `initialize()` on no manager, and an
 /// uninitialised manager does not report "I cannot tell", it reports "nothing
-/// exists". `ArcaEngineCommand.run()` now initializes all three before it binds
+/// exists". `ServeCommand.run()` now initializes all three before it binds
 /// the socket, so that reason has expired for both, and both now answer from
 /// that loaded state below.
 public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvider {
@@ -355,7 +355,7 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
     /// of this method returned `[]` under every input: `initialize()` had been
     /// called on no manager, so containers and volumes had no loaded rows and
     /// `NetworkManager.listNetworks()` read two backends that were both nil.
-    /// `ArcaEngineCommand.run()` now initializes all three before it binds the
+    /// `ServeCommand.run()` now initializes all three before it binds the
     /// socket, so the state these three calls read is really there.
     ///
     /// Two further defects sat behind that emptiness and would have surfaced the

--- a/Sources/ArcaEngine/SandboxEngineService.swift
+++ b/Sources/ArcaEngine/SandboxEngineService.swift
@@ -312,6 +312,15 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
     /// not found under a requested repository of `alpine`. That is the safe
     /// direction and it is chosen deliberately: a false `not_found` is visible
     /// and recoverable, a false `Ack` is neither.
+    ///
+    /// It is compared against **every** reference the digest is held under, and
+    /// that is a correction rather than a nicety: a store holds one row per
+    /// reference, `ImageManager.tagImage(source:target:)` adds a row to content
+    /// that is already there, and the first revision of this method tested the
+    /// request against whichever row `imageStore.list()` returned first. Two
+    /// rows on one digest then made the answer depend on store ordering --
+    /// `not_found` for content the engine held, naming a repository the caller
+    /// had not asked about.
     func prepareImage(request: Arca_Engine_V1_PrepareImageRequest) async -> Arca_Engine_V1_PrepareImageResponse {
         let resource = imageReference(forDigest: request.image)
         guard let key = imageStoreDigest(request.image) else {
@@ -336,26 +345,31 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
                 message: "this engine holds no image with that content digest and will not fetch "
                     + "one; load it with 'arca-engine image load --oci-layout <dir>'"
             ))
-        case .success(.blobsMissing(let reference, let digests)):
+        case .success(.blobsMissing(let references, let digests)):
             return Self.prepareImageFailure(engineError(
                 .notFound,
                 resource: resource,
-                message: "the image stored as \(reference) carries that content digest, but this "
-                    + "engine does not hold \(digests.count) of the blobs it names: "
-                    + digests.joined(separator: ", ")
+                message: "this engine has that content digest in its store under "
+                    + "\(references.joined(separator: ", ")), but does not hold \(digests.count) "
+                    + "of the blobs it names: " + digests.joined(separator: ", ")
             ))
-        case .success(.held(let reference)):
-            let stored = imageRepository(ofReference: reference)
-            guard stored == request.image.repository else {
+        case .success(.held(let references)):
+            // Every reference the digest is held under, because a tag puts a
+            // second row on one piece of content and the request names one of
+            // them. Testing a single row would refuse content the engine holds,
+            // by whichever row the store listed first.
+            let stored = Set(references.map(imageRepository(ofReference:))).sorted()
+            guard stored.contains(request.image.repository) else {
                 return Self.prepareImageFailure(engineError(
                     .notFound,
                     resource: resource,
-                    message: "this engine holds that content digest under repository "
-                        + "\(stored), not \(request.image.repository)"
+                    message: "this engine does not hold that content digest under repository "
+                        + "\(request.image.repository); it holds it under "
+                        + stored.joined(separator: ", ")
                 ))
             }
             logger.info("image content is held in full", metadata: [
-                "reference": "\(reference)",
+                "references": "\(references.joined(separator: ", "))",
                 "digest": "\(key)",
             ])
             return Arca_Engine_V1_PrepareImageResponse.with { $0.ok = Arca_Engine_V1_Ack() }

--- a/Sources/ArcaEngine/SandboxEngineService.swift
+++ b/Sources/ArcaEngine/SandboxEngineService.swift
@@ -280,20 +280,8 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
     ///   precisely so that this engine never touches the file Apple's tooling
     ///   shares.
     func create(request: Arca_Engine_V1_CreateRequest) async -> Arca_Engine_V1_CreateResponse {
-        let image: String
-        switch await heldImageReferences(for: request.image) {
-        case .failure(let error):
-            return Self.createFailed([], error)
-        case .success:
-            // Problem 1's decision, in one expression. See
-            // `heldImageReferences(for:)` above for why the store is consulted
-            // at all, and `SandboxContainerSpec.image` for why the reference
-            // handed on is the digest form rather than a stored tag.
-            image = imageReference(forDigest: request.image)
-        }
-
         let spec: SandboxContainerSpec
-        switch sandboxContainerSpec(for: request, image: image) {
+        switch await createSpec(for: request) {
         case .failure(let error):
             return Self.createFailed([], error)
         case .success(let translated):
@@ -385,6 +373,43 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
         return Arca_Engine_V1_CreateResponse.with { response in
             response.created = Arca_Engine_V1_Created.with { $0.created = created }
         }
+    }
+
+    /// Both gates a create passes before anything is made: the engine really
+    /// holds the content, and the request really translates.
+    ///
+    /// **This is a seam and not a convenience, and the reason is a mutation that
+    /// survived.** The whole of Problem 1 -- the justification for widening a
+    /// resolver shared with Arca's Docker surface -- rests on `create` handing
+    /// `createContainer` the exact digest reference rather than a stored tag,
+    /// because that same string is what `Inspect` re-parses
+    /// (`imageDigest(fromReference:)`, `:196`) and what `startContainer:2218`
+    /// re-resolves after a restart. Task 11's review replaced the one line that
+    /// decides it with `references.first ?? …` -- the arrangement Problem 1
+    /// explicitly rejected -- and the whole suite stayed green. Every sandbox
+    /// would have recorded `workspace:latest` and every `Inspect` would have
+    /// answered `invalid_output`, with 123 tests passing.
+    ///
+    /// `ImageResolutionTests` proves the *resolver* accepts the digest form.
+    /// Nothing proved the *caller* produced it. The resolution itself is
+    /// genuinely unreachable without a VM -- `createContainer`'s `nativeManager`
+    /// guard throws first -- but the string is a pure value, so this returns it
+    /// where a test can see it. `create(request:)` calls exactly this and builds
+    /// no spec of its own; there is no second path for a test to drift onto.
+    ///
+    /// The order of the two gates decides only which refusal a malformed request
+    /// hears first, since neither creates anything. The image goes first because
+    /// it is the failure `PrepareImage` exists to pre-empt, and hearing it here
+    /// means the `Ack` that preceded it was wrong.
+    package func createSpec(
+        for request: Arca_Engine_V1_CreateRequest
+    ) async -> Result<SandboxContainerSpec, Arca_Engine_V1_EngineError> {
+        if case .failure(let error) = await heldImageReferences(for: request.image) {
+            return .failure(error)
+        }
+        // Problem 1's decision, in one expression: the digest form, never a
+        // stored reference. See `SandboxContainerSpec.image`.
+        return sandboxContainerSpec(for: request, image: imageReference(forDigest: request.image))
     }
 
     /// A create failure with the evidence attached.

--- a/Sources/ArcaEngine/SandboxEngineService.swift
+++ b/Sources/ArcaEngine/SandboxEngineService.swift
@@ -79,7 +79,7 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
     /// is true before its code exists induces a consumer to send a request the
     /// engine cannot honour.
     ///
-    /// **Three flags are true, and each one names a live test that drove the
+    /// **Four flags are true, and each one names a live test that drove the
     /// capability from outside this engine's own store.** `Inspect` reports what
     /// the store holds, deliberately, so it can corroborate none of them; every
     /// flag below that is true was earned by an observation of the guest or of
@@ -109,18 +109,22 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
     ///   -- four CPUs and ContainerBridge's 4GiB default, in place of the one
     ///   CPU and 1GiB that were asked for.
     ///
-    /// **`namedVolumes` stays false, and it is not an oversight.** `Create`
-    /// makes the volumes, `volumeDriver` formats each as an EXT4 image at its
-    /// requested capacity, and `parseVolumeMounts` resolves each one and builds
-    /// a `Mount.block` for it -- and the guest mounts none of them. MEASURED
-    /// from the live tier: three volumes of 256MiB, 512MiB and 1GiB arrive in
-    /// the guest as three block devices of exactly 262144, 524288 and 1048576
-    /// 1K-blocks, while `/proc/mounts` names none of the three targets, with no
-    /// warning and no error anywhere in the log. The mount points were ruled out
-    /// as the cause: the same run with an image carrying all three directories
-    /// behaves identically. `the_managed_volumes_are_attached_to_the_guest_but_this_engine_mounts_none_of_them`
-    /// is the instrument that holds this flag down, and it fails the day the
-    /// mount starts working.
+    /// - `namedVolumes`: the guest's own `/proc/mounts` names all three managed
+    ///   targets, each backed by a distinct ext4 block device whose size in
+    ///   `/proc/partitions` is the capacity that target's volume was declared
+    ///   with -- 262144, 524288 and 1048576 1K-blocks for 256MiB, 512MiB and
+    ///   1GiB -- and the guest writes a token into each and reads it back.
+    ///   Earned by
+    ///   `mounts::the_managed_volumes_are_mounted_at_their_declared_targets_and_writable`.
+    ///   SEEN TO FAIL, against this repository at 6c77bb8: the same test reported
+    ///   `/home/workspace/.local is not mounted in the guest`, with the guest's
+    ///   overlay reading
+    ///   `lowerdir=/mnt/layer4:/mnt/layer3:/mnt/layer2:/mnt/layer1:/mnt/layer0`
+    ///   -- five lowerdirs for a two-layer image, because vminitd counted
+    ///   /dev/vdc upwards and swallowed the three volume devices as layers.
+    ///   The writability half of that test passed even then, which is why it is
+    ///   not the assertion that carries the claim: the targets exist in the
+    ///   image, so the write landed in the container's own overlay.
     ///
     /// `tty` and `signals` are milestone 3's, with `Exec`. `offline` stays
     /// `.unverified` until milestone 4 proves it.
@@ -138,7 +142,7 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
                 capabilities.engineVersion = version
                 capabilities.contractMinor = 0
                 capabilities.projectMount = true
-                capabilities.namedVolumes = false
+                capabilities.namedVolumes = true
                 capabilities.tty = false
                 capabilities.signals = false
                 capabilities.loopbackPublish = true

--- a/Sources/ArcaEngine/SandboxEngineService.swift
+++ b/Sources/ArcaEngine/SandboxEngineService.swift
@@ -12,10 +12,13 @@ import SandboxEngineProto
 ///
 /// **In this build, one of the eleven is implemented: `Capabilities`.** The
 /// other ten answer `unsupported_capability` inside their response `oneof`.
-/// `Inspect` and `ListResources` joined that list deliberately rather than by
-/// omission -- see the note on each -- because this process does not call
-/// `initialize()` on any manager, and an uninitialised manager does not report
-/// "I cannot tell", it reports "nothing exists".
+/// `Inspect` and `ListResources` joined that list because, when they were
+/// written, this process called `initialize()` on no manager, and an
+/// uninitialised manager does not report "I cannot tell", it reports "nothing
+/// exists". `ArcaEngineCommand.run()` now initializes all three before it binds
+/// the socket, so that reason has expired: implementing the two is Tasks 7 and
+/// 8's work, and until then they answer `unsupported_capability` because they
+/// are unwritten, not because the state behind them is empty.
 public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvider {
     public let interceptors: Arca_Engine_V1_SandboxEngineServerInterceptorFactoryProtocol? = nil
 
@@ -106,11 +109,11 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
     ///
     /// Unimplemented in this build, and that is a deliberate reversal.
     ///
-    /// An earlier revision answered from `ContainerManager`. Because this
-    /// process never calls `ContainerManager.initialize()` -- see the reasoning
-    /// in `arca-engine`'s `ArcaEngineCommand.run()` -- the only two writers of
-    /// `ContainerManager.containers` never run, so that implementation could
-    /// return exactly one answer: `absent`. `engine.proto`'s `InspectResponse`
+    /// An earlier revision answered from `ContainerManager`. Because the process
+    /// then called `ContainerManager.initialize()` on no manager, the only two
+    /// writers of `ContainerManager.containers` never ran, so that
+    /// implementation could return exactly one answer: `absent`.
+    /// `engine.proto`'s `InspectResponse`
     /// has three arms specifically so that "it is not there" stays
     /// distinguishable from "I could not tell", and those "demand opposite
     /// behaviour from a reconciler": on `absent` a consumer creates the
@@ -120,9 +123,10 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
     /// `unsupported_capability` is the honest answer for a build that holds no
     /// loaded state. It costs the consumer nothing it was getting -- the
     /// previous answer carried no information -- and it cannot be mistaken for
-    /// an observation. The milestone that loads persisted state restores this
-    /// method along with the `Sandbox` translation in `EngineTranslation`,
-    /// which stays in the target, tested, for that purpose.
+    /// an observation. `ArcaEngineCommand.run()` now calls `initialize()` on all
+    /// three managers before it binds the socket, so the state is there; Task 7
+    /// restores this method along with the `Sandbox` translation in
+    /// `EngineTranslation`, which stays in the target, tested, for that purpose.
     func inspect(request: Arca_Engine_V1_InspectRequest) async -> Arca_Engine_V1_InspectResponse {
         Arca_Engine_V1_InspectResponse.with { $0.error = Self.notImplemented("Inspect") }
     }
@@ -246,10 +250,11 @@ public final class SandboxEngineService: Arca_Engine_V1_SandboxEngineAsyncProvid
     /// `engine.proto`'s contract for this method is "Every resource the engine
     /// holds, labelled or not", because a consumer's drift and leak detection
     /// depends on seeing the unlabelled ones. An earlier revision walked
-    /// `ContainerManager`, `VolumeManager` and `NetworkManager`; without
-    /// `initialize()` all three are permanently empty -- containers and volumes
-    /// have no loaded rows, and `NetworkManager.listNetworks()` reads two
-    /// backends that are both nil -- so it returned `[]` under every input. An
+    /// `ContainerManager`, `VolumeManager` and `NetworkManager`; with
+    /// `initialize()` called on none of them all three were permanently empty --
+    /// containers and volumes had no loaded rows, and
+    /// `NetworkManager.listNetworks()` read two backends that were both nil --
+    /// so it returned `[]` under every input. An
     /// empty `ResourceList` is not an error arm: it is a confident report of a
     /// clean host, which is precisely the report that hides a leak.
     ///

--- a/Sources/ArcaEngine/SandboxIdentity.swift
+++ b/Sources/ArcaEngine/SandboxIdentity.swift
@@ -15,7 +15,7 @@ public enum SandboxIdentity {
     /// Safe because ContainerBridge applies no container-name grammar
     /// validation, and because a sandbox id always contains a hyphen -- which
     /// keeps resolveContainerID from reading it as a hex short ID
-    /// (Sources/ContainerBridge/ContainerManager.swift:1930-1934).
+    /// (Sources/ContainerBridge/ContainerManager.swift:2005-2023).
     public static func containerName(forSandboxId id: String) -> String { id }
 
     /// Stored verbatim, echoed back, never interpreted. Deciding whether a

--- a/Sources/ArcaEngine/SandboxIdentity.swift
+++ b/Sources/ArcaEngine/SandboxIdentity.swift
@@ -18,6 +18,49 @@ public enum SandboxIdentity {
     /// (Sources/ContainerBridge/ContainerManager.swift:2005-2023).
     public static func containerName(forSandboxId id: String) -> String { id }
 
+    /// Why this engine will not act under this sandbox id, or nil when it will.
+    ///
+    /// **This exists because `Create` acts on what `resolveContainerID` matches,
+    /// and that matcher is a prefix search.** `request.sandboxID` reaches it
+    /// unvalidated: `ContainerManager.swift:2005-2023` treats any pure-hex
+    /// string of 4 or more characters as a Docker short id, prefix-matches it
+    /// against every container the engine holds, and on more than one match
+    /// returns `matches.sorted().first` -- an arbitrary container chosen by
+    /// string order. `:2001` matches a full 64-character id outright.
+    ///
+    /// While every implemented method was read-only this was harmless: the worst
+    /// outcome was an `Inspect` reporting the wrong container, which the
+    /// consumer's own ownership check catches. `Create` is the first method that
+    /// *acts* on the match -- `createContainer`'s name-conflict check
+    /// (`:1650-1656`) runs through the same resolver, so a hex sandbox id can
+    /// collide with an unrelated container and be refused as a name conflict, or
+    /// worse, be created and then be what a later `Stop` or `Remove` resolves
+    /// to.
+    ///
+    /// Gas Can cannot send such an id -- a sandbox id always carries a hyphen
+    /// (`crates/gascan-core/src/sandbox.rs:168-198`) -- and that is exactly why
+    /// this is enforced here rather than assumed: nothing on this side of the
+    /// socket made it true, and the engine must not depend on a well-behaved
+    /// consumer for a property that decides which container it writes to.
+    ///
+    /// The hex test mirrors `resolveContainerID`'s own character set, including
+    /// its uppercase, rather than reasoning about which forms are reachable. The
+    /// length test is `>= 4` with no upper bound, which is deliberately wider
+    /// than the `< 64` of the prefix arm, because the 64-character case is
+    /// caught by the direct-lookup arm one line above it.
+    public static func refusalReason(forSandboxId id: String) -> String? {
+        if id.isEmpty {
+            return "a sandbox id is required and this request carries none"
+        }
+        let hex = "0123456789abcdefABCDEF"
+        if id.count >= 4 && id.allSatisfy({ hex.contains($0) }) {
+            return "sandbox id \(id) is pure hexadecimal, which this engine's container "
+                + "resolver reads as a Docker id prefix and would match against an unrelated "
+                + "container; a gascan sandbox id always contains a hyphen"
+        }
+        return nil
+    }
+
     /// Stored verbatim, echoed back, never interpreted. Deciding whether a
     /// labelled resource is yours is the consumer's judgment
     /// (engine.proto:144-148).

--- a/Sources/ArcaEngine/ShutdownRequests.swift
+++ b/Sources/ArcaEngine/ShutdownRequests.swift
@@ -1,0 +1,42 @@
+import NIOConcurrencyHelpers
+
+/// Counts shutdown signals, and answers whether any has arrived.
+///
+/// **Locked rather than queue-confined, and it used to be the latter.** Both of
+/// `arca-engine`'s signal sources still share one serial queue, but the engine
+/// also reads this from a `whenComplete` on the listening channel's close, which
+/// runs on a NIO event loop. Two threads, so the confinement argument no longer
+/// holds and a lock replaces it rather than a comment claiming a discipline the
+/// code no longer keeps.
+///
+/// **It lives in this module rather than beside its one caller so that a test
+/// can drive the real type.** It was `private` in the executable, where nothing
+/// can reach it: a review probe for the shutdown observer had to re-declare it,
+/// and a test that drives a re-declaration proves the re-declaration -- the
+/// shape this project has shipped and caught before. `ShutdownObserverTests`
+/// now exercises this one.
+public final class ShutdownRequests: Sendable {
+    private let seen = NIOLockedValueBox(0)
+
+    public init() {}
+
+    /// Records a request and answers whether it was the first.
+    ///
+    /// The increment and the comparison are one critical section, so two
+    /// signals arriving together cannot both be told they were first.
+    public func recordAndReportFirst() -> Bool {
+        seen.withLockedValue { seen in
+            seen += 1
+            return seen == 1
+        }
+    }
+
+    /// Whether any signal has been recorded.
+    ///
+    /// Read to tell a listening socket that closed BECAUSE of a shutdown from
+    /// one that closed on its own. A separate acquire is all this needs: the
+    /// predicate is monotone, and a read that races the very first increment
+    /// resolves to "not yet", which errs toward treating a shutdown that has
+    /// just begun as an unexpected close -- both end the process.
+    public var anyRecorded: Bool { seen.withLockedValue { $0 > 0 } }
+}

--- a/Sources/ContainerBridge/ContainerManager.swift
+++ b/Sources/ContainerBridge/ContainerManager.swift
@@ -291,7 +291,20 @@ public actor ContainerManager {
     }
 
     /// Load persisted containers from StateStore and reconcile with actual state
-    private func loadPersistedState() async throws {
+    ///
+    /// `public` rather than `private` because it is the only VM-free way in
+    /// which `containers` is populated: `initialize()` needs a kernel file and a
+    /// `VmnetNetwork` before it reaches this call, and `createContainer` boots a
+    /// VM. A test that cannot reach this restore loop can only assert on
+    /// `internalContainersRequested(in:)`, the helper -- and a test of the helper
+    /// alone does not notice `listContainers` ignoring `includeInternal`
+    /// (MEASURED: with the `includeInternal` guard reverted to the old
+    /// filter-derived `showInternal`, `swift test --filter ArcaEngineTests`
+    /// still reported `Executed 35 tests, with 0 failures`).
+    ///
+    /// Nothing here touches a VM: it reads the StateStore, decodes the stored
+    /// config, and registers log paths that already exist on disk.
+    public func loadPersistedState() async throws {
         logger.info("Loading persisted container state...")
 
         // Load all containers from database
@@ -552,16 +565,24 @@ public actor ContainerManager {
 
     // MARK: - Container Lifecycle
 
+    /// Docker's rule for asking to see internal containers: a `label` filter
+    /// mentioning `com.arca.internal`. Named and lifted out because the engine
+    /// does not use it -- the engine asks with `includeInternal:` directly --
+    /// and a rule that exists in two places diverges.
+    public static func internalContainersRequested(in filters: [String: [String]]) -> Bool {
+        filters["label"]?.contains { $0.contains("com.arca.internal") } ?? false
+    }
+
     /// List all containers
-    public func listContainers(all: Bool = false, filters: [String: [String]] = [:]) async throws -> [ContainerSummary] {
+    public func listContainers(
+        all: Bool = false,
+        filters: [String: [String]] = [:],
+        includeInternal: Bool
+    ) async throws -> [ContainerSummary] {
         logger.debug("Listing containers", metadata: [
             "all": "\(all)",
             "filters": "\(filters)"
         ])
-
-        // Check if user wants to see internal containers
-        // By default, internal containers (com.arca.internal=true) are hidden
-        let showInternal = filters["label"]?.contains(where: { $0.contains("com.arca.internal") }) ?? false
 
         // Extract label filters for matching
         let labelFilters = filters["label"] ?? []
@@ -586,7 +607,7 @@ public actor ContainerManager {
             }
 
             // Filter out internal containers unless explicitly requested
-            if !showInternal && info.labels["com.arca.internal"] == "true" {
+            if !includeInternal && info.labels["com.arca.internal"] == "true" {
                 return nil
             }
 

--- a/Sources/ContainerBridge/ContainerManager.swift
+++ b/Sources/ContainerBridge/ContainerManager.swift
@@ -182,11 +182,29 @@ public actor ContainerManager {
         }
     }
 
+    /// - Parameter logRoot: Where this manager's containers write stdout and
+    ///   stderr, and the only directory `removeContainer` deletes logs from.
+    ///
+    ///   A root and not a ready-made `ContainerLogManager`, on purpose. The
+    ///   ownership already runs this way -- `logManager` is this actor's
+    ///   `nonisolated let` and every consumer reaches it through here
+    ///   (`ArcaDaemon/Server.swift:29` takes `containerManager.logManager`) --
+    ///   so handing the manager in would move one construction to each caller
+    ///   and give the derivation two spellings free to drift, which is exactly
+    ///   what change 1 of the milestone's design had to unpick for the image
+    ///   store. It is also the weaker seam: a caller that passes a
+    ///   `ContainerLogManager` makes "the log manager uses the caller's root"
+    ///   true by construction, so a test asserting it would pass with this
+    ///   actor ignoring the argument entirely. Taking the root leaves the
+    ///   pass-through falsifiable, and
+    ///   `ContainerBridgePathsTests.testAContainerManagerUsesTheRootsItWasGiven`
+    ///   falsifies it.
     public init(
         imageManager: ImageManager,
         kernelPath: String,
         imageStoreRoot: URL,
         layerCachePath: URL,
+        logRoot: URL,
         stateStore: StateStore,
         logger: Logger
     ) {
@@ -196,7 +214,7 @@ public actor ContainerManager {
         self.layerCachePath = layerCachePath
         self.stateStore = stateStore
         self.logger = logger
-        self.logManager = ContainerLogManager(logger: logger)
+        self.logManager = ContainerLogManager(logRoot: logRoot, logger: logger)
     }
 
     /// The root `initialize()` hands to `Containerization.ContainerManager`,

--- a/Sources/ContainerBridge/ContainerManager.swift
+++ b/Sources/ContainerBridge/ContainerManager.swift
@@ -292,7 +292,7 @@ public actor ContainerManager {
 
     /// Load persisted containers from StateStore and reconcile with actual state
     ///
-    /// `public` rather than `private` because it is the only VM-free way in
+    /// Reachable outside `initialize()` because it is the only VM-free way in
     /// which `containers` is populated: `initialize()` needs a kernel file and a
     /// `VmnetNetwork` before it reaches this call, and `createContainer` boots a
     /// VM. A test that cannot reach this restore loop can only assert on
@@ -302,9 +302,18 @@ public actor ContainerManager {
     /// filter-derived `showInternal`, `swift test --filter ArcaEngineTests`
     /// still reported `Executed 35 tests, with 0 failures`).
     ///
+    /// `package` and NOT `public`, because this must not become callable from
+    /// outside the package: it is not idempotent. A second call takes the
+    /// crash-recovery branch below for every container whose stored status is
+    /// `running`, recording it as exited with code 137 in memory *and* writing
+    /// that back through `stateStore.updateContainerStatus`. Called on a live
+    /// daemon it would orphan every running VM -- the engine would stop
+    /// believing it holds a container that is still running, which is the leak
+    /// class this work exists to close.
+    ///
     /// Nothing here touches a VM: it reads the StateStore, decodes the stored
     /// config, and registers log paths that already exist on disk.
-    public func loadPersistedState() async throws {
+    package func loadPersistedState() async throws {
         logger.info("Loading persisted container state...")
 
         // Load all containers from database

--- a/Sources/ContainerBridge/ContainerManager.swift
+++ b/Sources/ContainerBridge/ContainerManager.swift
@@ -941,7 +941,19 @@ public actor ContainerManager {
 
     /// Convert Docker portBindings to PortMapping array for container list API
     /// Format: {"80/tcp": [PortBinding(hostIp: "0.0.0.0", hostPort: "8080")]} -> [PortMapping(...)]
-    private func convertPortBindingsToMappings(_ portBindings: [String: [PortBinding]]) -> [PortMapping] {
+    ///
+    /// `package` rather than `private` because `ArcaEngine`'s `Inspect` reports a
+    /// sandbox's ports and `Container` has no `ports` field to read them from
+    /// (`Types.swift:68-80`) -- only `hostConfig.portBindings` (`:218`), which is this
+    /// function's input. A second parser over the same `"80/tcp"` strings in
+    /// `ArcaEngine` would be a second place for the format to be read
+    /// differently, and this one is already the parser the restore path (`:420`)
+    /// and the create path (`:1911`) agree on.
+    ///
+    /// `package`, not `public`, following `loadPersistedState()` (`:316`): the
+    /// only caller outside this file is inside this SwiftPM package, so nothing
+    /// outside it needs the wider surface.
+    package func convertPortBindingsToMappings(_ portBindings: [String: [PortBinding]]) -> [PortMapping] {
         var mappings: [PortMapping] = []
 
         for (portProto, bindings) in portBindings {

--- a/Sources/ContainerBridge/ContainerManager.swift
+++ b/Sources/ContainerBridge/ContainerManager.swift
@@ -2358,7 +2358,7 @@ public actor ContainerManager {
 
                 do {
                     // Resolve network name/ID to actual network ID
-                    if let resolvedNetworkID = await networkManager.resolveNetworkID(targetNetwork) {
+                    if let resolvedNetworkID = try await networkManager.resolveNetworkID(targetNetwork) {
                         let containerName = info.name ?? String(dockerID.prefix(12))
                         let attachment = try await networkManager.attachContainerToNetwork(
                             containerID: dockerID,

--- a/Sources/ContainerBridge/ContainerManager.swift
+++ b/Sources/ContainerBridge/ContainerManager.swift
@@ -64,6 +64,21 @@ public actor ContainerManager {
     // State persistence
     private let stateStore: StateStore
 
+    /// Root of the Containerization ImageStore this manager uses. Held as a
+    /// `let` and not derived, because `initfs.ext4` lives inside it: sharing
+    /// this root is what makes two products fight over one initfs.
+    ///
+    /// `nonisolated` for the same reason `logManager` is: an actor's `let` is
+    /// isolated across module boundaries, so a consumer outside ContainerBridge
+    /// cannot read it without `await` unless it is stated here. It is immutable
+    /// and `URL` is `Sendable`, so nothing is given up by saying so.
+    nonisolated public let imageStoreRoot: URL
+
+    /// Directory holding the OverlayFS layer cache. Was hardcoded to
+    /// ~/.arca/layers, which meant every consumer wrote into Arca's tree
+    /// regardless of the state root it was given.
+    nonisolated public let layerCachePath: URL
+
     // Layer unpacker for OverlayFS
     private var overlayUnpacker: OverlayFSUnpacker?
 
@@ -170,14 +185,32 @@ public actor ContainerManager {
     public init(
         imageManager: ImageManager,
         kernelPath: String,
+        imageStoreRoot: URL,
+        layerCachePath: URL,
         stateStore: StateStore,
         logger: Logger
     ) {
         self.imageManager = imageManager
         self.kernelPath = kernelPath
+        self.imageStoreRoot = imageStoreRoot
+        self.layerCachePath = layerCachePath
         self.stateStore = stateStore
         self.logger = logger
         self.logManager = ContainerLogManager(logger: logger)
+    }
+
+    /// The root `initialize()` hands to `Containerization.ContainerManager`,
+    /// and so the directory `initfs.ext4` is built in.
+    ///
+    /// It exists as a method rather than as a use of `imageStoreRoot` at the
+    /// call site so that a test can assert on the value `initialize()` actually
+    /// selects. MEASURED: with `initialize()` passing no `root:` at all --
+    /// falling back to `ImageStore.default` -- a test asserting on the stored
+    /// property alone still reported `Executed 2 tests, with 0 failures`
+    /// (`swift test --filter ContainerBridgePathsTests`). Asserting on this
+    /// method instead puts the selection itself under test.
+    nonisolated public func containerizationRoot() -> URL {
+        imageStoreRoot
     }
 
     /// Set the NetworkManager (called after NetworkManager is initialized)
@@ -240,13 +273,13 @@ public actor ContainerManager {
         nativeManager = try await Containerization.ContainerManager(
             kernel: kernel,
             initfsReference: "arca-vminit:latest",  // Custom vminit loaded and tagged by ArcaDaemon
+            root: containerizationRoot(),
             network: try Containerization.VmnetNetwork()
         )
 
         // Initialize OverlayFS unpacker for parallel layer caching
-        let layerCachePath = NSString(string: "~/.arca/layers").expandingTildeInPath
         overlayUnpacker = OverlayFSUnpacker(
-            layerCachePath: URL(fileURLWithPath: layerCachePath),
+            layerCachePath: layerCachePath,
             stateStore: stateStore,
             logger: logger
         )

--- a/Sources/ContainerBridge/ContainerManager.swift
+++ b/Sources/ContainerBridge/ContainerManager.swift
@@ -2488,8 +2488,10 @@ public actor ContainerManager {
                 return
             }
 
-            // Get WireGuard client for this container
-            if let wireguardClient = await networkManager.getWireGuardClient(containerID: dockerID) {
+            // Get WireGuard client for this container. `try`, not `try?`: the
+            // container has port bindings, and a failure to read which networks
+            // it is on would otherwise publish none of them silently.
+            if let wireguardClient = try await networkManager.getWireGuardClient(containerID: dockerID) {
                 // Ensure we disconnect when done
                 defer {
                     Task {

--- a/Sources/ContainerBridge/ContainerManager.swift
+++ b/Sources/ContainerBridge/ContainerManager.swift
@@ -1140,10 +1140,17 @@ public actor ContainerManager {
         )
 
         // Create container directory path (needed for both unpacking and temp rootfs)
-        // Use default Apple containerization store path
-        let appleStorePath = NSString(string: "~/Library/Application Support/com.apple.containerization").expandingTildeInPath
-        let containerRoot = URL(fileURLWithPath: appleStorePath).appendingPathComponent("containers")
-        let containerPath = containerRoot.appendingPathComponent(dockerID)
+        //
+        // Derived from `manager`'s own store rather than spelt out, because the
+        // directory `manager.create(_:image:rootfs:)` writes into is not ours to
+        // choose: it opens `containerRoot/<id>/bootlog.log`
+        // (containerization/Sources/Containerization/ContainerManager.swift:317),
+        // `containerRoot` is `imageStore.path/"containers"` (ibid.:35-37), and
+        // `imageStore` is `ImageStore(path: root)` for whatever `root:`
+        // `initialize()` passed (ibid.:139-140). Naming Apple's shared store here
+        // agreed with that only while `root:` happened to be Apple's shared
+        // store, and disagreed for every other state root.
+        let containerPath = containerDirectory(in: manager, dockerID: dockerID)
 
         // Ensure container directory exists (base manager expects this)
         try FileManager.default.createDirectory(at: containerPath, withIntermediateDirectories: true)
@@ -4180,16 +4187,39 @@ public actor ContainerManager {
 
     // MARK: - Filesystem Operations
 
+    /// The directory Containerization keeps container `dockerID`'s files in.
+    ///
+    /// One derivation for the two places that need it -- `createNativeContainer`,
+    /// which must create this directory before `manager.create(_:image:rootfs:)`
+    /// opens `bootlog.log` inside it, and `getRootfsPath` below. They disagreed
+    /// until now, the create path naming Apple's shared store outright while
+    /// this one followed the manager.
+    ///
+    /// It takes the manager instead of reading `nativeManager` so that neither
+    /// caller can pass a root: the store is read off the same value the create
+    /// call is made against, which is the only store Containerization will look
+    /// in. It stays `private` deliberately: `createNativeContainer` guards on
+    /// `nativeManager`, which `initialize()` sets only after building a kernel
+    /// and a VM, so no test in this repository can reach the call site -- and a
+    /// derivation a test *could* call would let a green suite stand for a call
+    /// site nothing executes. The call-site proof is Gas Can's live `Create`
+    /// test, not anything in this repository.
+    private func containerDirectory(
+        in manager: Containerization.ContainerManager,
+        dockerID: String
+    ) -> URL {
+        manager.imageStore.path
+            .appendingPathComponent("containers")
+            .appendingPathComponent(dockerID)
+    }
+
     /// Get the path to a container's rootfs.ext4 file
     /// This follows Apple's Containerization framework convention: {imageStore.path}/containers/{id}/rootfs.ext4
     private func getRootfsPath(dockerID: String) -> URL? {
         guard let manager = nativeManager else {
             return nil
         }
-        // Apple's ContainerManager stores containers at: imageStore.path/containers/{id}/rootfs.ext4
-        return manager.imageStore.path
-            .appendingPathComponent("containers")
-            .appendingPathComponent(dockerID)
+        return containerDirectory(in: manager, dockerID: dockerID)
             .appendingPathComponent("rootfs.ext4")
     }
 

--- a/Sources/ContainerBridge/ContainerManager.swift
+++ b/Sources/ContainerBridge/ContainerManager.swift
@@ -192,13 +192,19 @@ public actor ContainerManager {
     ///   so handing the manager in would move one construction to each caller
     ///   and give the derivation two spellings free to drift, which is exactly
     ///   what change 1 of the milestone's design had to unpick for the image
-    ///   store. It is also the weaker seam: a caller that passes a
-    ///   `ContainerLogManager` makes "the log manager uses the caller's root"
-    ///   true by construction, so a test asserting it would pass with this
-    ///   actor ignoring the argument entirely. Taking the root leaves the
-    ///   pass-through falsifiable, and
-    ///   `ContainerBridgePathsTests.testAContainerManagerUsesTheRootsItWasGiven`
-    ///   falsifies it.
+    ///   store. **That is the whole of the argument, and it is enough.**
+    ///
+    ///   CORRECTED: an earlier version of this comment also called the
+    ///   alternative "the weaker seam", claiming a caller-supplied
+    ///   `ContainerLogManager` would make the pass-through true by construction
+    ///   and so unfalsifiable. **That is false, and 13b's reviewer measured it
+    ///   false** by building the counterfactual init and a test against it: an
+    ///   init that ignored a `logManager:` argument failed its test just as this
+    ///   one fails `testAContainerManagerUsesTheRootsItWasGiven` under the same
+    ///   mutation. What makes either seam falsifiable is that the assertion
+    ///   reads back through `manager.logManager` -- the parameter's type has
+    ///   nothing to do with it. A design argument that sounds like a
+    ///   falsifiability argument is worth less than the one it displaced.
     public init(
         imageManager: ImageManager,
         kernelPath: String,

--- a/Sources/ContainerBridge/ContainerManager.swift
+++ b/Sources/ContainerBridge/ContainerManager.swift
@@ -4189,21 +4189,33 @@ public actor ContainerManager {
 
     /// The directory Containerization keeps container `dockerID`'s files in.
     ///
-    /// One derivation for the two places that need it -- `createNativeContainer`,
-    /// which must create this directory before `manager.create(_:image:rootfs:)`
-    /// opens `bootlog.log` inside it, and `getRootfsPath` below. They disagreed
-    /// until now, the create path naming Apple's shared store outright while
-    /// this one followed the manager.
+    /// **One live caller, `createNativeContainer`**, which must create this
+    /// directory before `manager.create(_:image:rootfs:)` opens `bootlog.log`
+    /// inside it. It is a function rather than an expression because the
+    /// derivation drifted once already: the create path named Apple's shared
+    /// store outright while `getRootfsPath` followed the manager, and only one
+    /// of them moved when `ContainerManager` gained an image-store root. That
+    /// `getRootfsPath` has now been deleted -- it had no callers, so only the
+    /// create path's copy of the drift ever executed.
     ///
-    /// It takes the manager instead of reading `nativeManager` so that neither
+    /// It takes the manager instead of reading `nativeManager` so that no
     /// caller can pass a root: the store is read off the same value the create
     /// call is made against, which is the only store Containerization will look
     /// in. It stays `private` deliberately: `createNativeContainer` guards on
     /// `nativeManager`, which `initialize()` sets only after building a kernel
     /// and a VM, so no test in this repository can reach the call site -- and a
     /// derivation a test *could* call would let a green suite stand for a call
-    /// site nothing executes. The call-site proof is Gas Can's live `Create`
-    /// test, not anything in this repository.
+    /// site nothing executes.
+    ///
+    /// **The call-site proof is Gas Can's live `Create` test, and it is not
+    /// optional.** MEASURED 2026-08-13: replacing `manager.imageStore.path`
+    /// below with `ImageStore.default.path` restores the original defect
+    /// exactly, and `swift test --filter ArcaEngineTests` still reports
+    /// `Executed 149 tests, with 0 failures` -- both guards in
+    /// `ContainerBridgePathsTests` stay green. The same mutation drives the live
+    /// tier's `Create` to `NSPOSIXErrorDomain Code=2`, leaves the engine's own
+    /// `<state-root>/images/containers/` empty, and adds a directory to Apple's
+    /// shared store (253 -> 254). **Nothing in this repository can see that.**
     private func containerDirectory(
         in manager: Containerization.ContainerManager,
         dockerID: String
@@ -4211,16 +4223,6 @@ public actor ContainerManager {
         manager.imageStore.path
             .appendingPathComponent("containers")
             .appendingPathComponent(dockerID)
-    }
-
-    /// Get the path to a container's rootfs.ext4 file
-    /// This follows Apple's Containerization framework convention: {imageStore.path}/containers/{id}/rootfs.ext4
-    private func getRootfsPath(dockerID: String) -> URL? {
-        guard let manager = nativeManager else {
-            return nil
-        }
-        return containerDirectory(in: manager, dockerID: dockerID)
-            .appendingPathComponent("rootfs.ext4")
     }
 
     /// Get filesystem changes for a container using OverlayFS upperdir enumeration

--- a/Sources/ContainerBridge/ImageIdentity.swift
+++ b/Sources/ContainerBridge/ImageIdentity.swift
@@ -1,0 +1,77 @@
+// `range(of:options:)` below is Foundation's, not the standard library's. This
+// file compiled without the import -- the symbol was reachable through another
+// module in this target -- which is an accident of what its neighbours import
+// and not something to rely on.
+import Foundation
+
+/// How an image reference is split into the identity of the content it names.
+///
+/// **Not `ImageReference` in `ImageTypes.swift:241`, and the difference is the
+/// reason this exists rather than reusing it.** That type's `repository` is the
+/// bare last path component -- `ImageReference.parse("docker.io/library/alpine")`
+/// reports registry `docker.io`, namespace `library`, repository `alpine`
+/// (`:289-313`). The rule below keeps the whole name: `docker.io/library/alpine`.
+/// Both are defensible readings of the word "repository" and this codebase now
+/// contains both; what it must not do is use one where the other is meant.
+///
+/// The rule here is Gas Can's, mirrored, because it is the rule the comparison
+/// has to survive: `immutable_image_identity`
+/// (`crates/gascan-core/src/runtime.rs:704-715`) drops anything from `@sha256:`
+/// onward, then drops a tag -- the last `:` that comes after the last `/`, so
+/// that the port in `registry.example:5000/repo` is not mistaken for one. The
+/// two sides of the wire have to split identically, or the comparison they meet
+/// in is decided by punctuation rather than by identity.
+///
+/// **One copy, because two components compare the results and a divergence
+/// between them is undetectable.** `ArcaEngine` splits a stored reference to
+/// decide whether it holds requested content (`PrepareImage`), and
+/// `ImageManager.resolveImage` splits the same kind of string to decide which
+/// stored image an exact digest reference names. Those answers must agree: an
+/// `Ack` from `PrepareImage` is a promise that the resolver will find the
+/// content, and `Create` collects on that promise. Two copies of a splitting
+/// rule agree only until one of them is edited.
+///
+/// It lives in `ContainerBridge` because the resolver is here and cannot import
+/// upward. `EngineTranslation.imageRepository(ofReference:)` forwards to
+/// `repository(of:)` and keeps its own name, which is what its call sites
+/// already say.
+public enum ImageIdentity {
+    /// The repository half of an image reference, tag and digest removed.
+    public static func repository(of reference: String) -> String {
+        let name = reference.range(of: "@sha256:", options: .backwards)
+            .map { String(reference[reference.startIndex..<$0.lowerBound]) } ?? reference
+        guard let tagSeparator = name.lastIndex(of: ":") else { return name }
+        if let slash = name.lastIndex(of: "/"), tagSeparator < slash { return name }
+        return String(name[name.startIndex..<tagSeparator])
+    }
+
+    /// A reference that names content exactly, split into the repository it
+    /// claims and the digest the store records it under -- or nil when the
+    /// reference is not one.
+    ///
+    /// This is the form Gas Can sends for every create
+    /// (`immutable_image_reference`, `crates/gascan-core/src/runtime.rs:677-686`)
+    /// and the form Docker itself accepts for `run`, `rmi` and `inspect`.
+    ///
+    /// **Lowercase hex, exactly 64 characters, and nothing else counts.** The
+    /// store records digests lowercase, so accepting an uppercase spelling would
+    /// produce a reference that parses and then matches nothing -- a "no such
+    /// image" for content the store holds. `ArcaEngine`'s `imageStoreDigest(_:)`
+    /// applies the same rule to the wire form, which is what lets the two meet.
+    ///
+    /// The repository half goes through `repository(of:)` rather than being
+    /// taken as the raw prefix, so that `workspace:latest@sha256:<hex>` and
+    /// `workspace@sha256:<hex>` name the same repository -- which they do.
+    public static func exactDigest(of reference: String) -> (repository: String, digest: String)? {
+        guard let separator = reference.range(of: "@sha256:", options: .backwards) else {
+            return nil
+        }
+        let hex = String(reference[separator.upperBound...])
+        guard hex.count == 64,
+              hex.allSatisfy({ $0.isASCII && ($0.isNumber || ("a"..."f").contains($0)) })
+        else { return nil }
+        let name = repository(of: reference)
+        guard !name.isEmpty else { return nil }
+        return (repository: name, digest: "sha256:\(hex)")
+    }
+}

--- a/Sources/ContainerBridge/ImageManager.swift
+++ b/Sources/ContainerBridge/ImageManager.swift
@@ -638,6 +638,101 @@ public actor ImageManager {
         return image
     }
 
+    /// Whether this store holds, in full, the content named by an exact digest.
+    ///
+    /// **The lookup is exact string equality against the digest each stored
+    /// image carries, and deliberately not `resolveImage(nameOrId:)`.** That
+    /// resolver has three arms, and two of them are wrong for a caller asking
+    /// "do you hold this content": the reference arm matches a *tag*
+    /// (`matchesReference` above, which also normalizes registries and falls
+    /// back to suffix matching), so it answers about a name that can be
+    /// remapped to different bytes at any time; and the short-ID arm matches a
+    /// 12-character prefix. A caller building a promise on the answer needs
+    /// neither. Passing `sha256:<hex>` to `resolveImage` would take its long-ID
+    /// arm, which is exact -- but only by coincidence of the input, and a later
+    /// caller passing something else would silently get the forgiving arms.
+    ///
+    /// The digest compared against is the store's own root descriptor digest,
+    /// which for an image imported from a single-manifest OCI layout is an
+    /// index Containerization *synthesizes* during the import
+    /// (`ImageStore+Import.swift:216-224`), not the manifest digest the layout
+    /// named. A caller holding the manifest digest for such an image gets
+    /// `.noImageForDigest` here. That is the safe direction -- a false "not
+    /// held" is recoverable and visible, a false "held" is neither -- but it is
+    /// a real limitation and not an accident.
+    ///
+    /// Three cases and not a `Bool`, for the reason `imageExists(nameOrId:)`
+    /// above is too cheap an answer to build a promise on: it collapses "no
+    /// such image", "the store has a row and cannot produce its bytes", and
+    /// "the read itself failed" into `false`. Those demand different reports.
+    ///
+    /// - Parameter digest: The content digest, in the `sha256:<hex>` form the
+    ///   store records. Anything else matches nothing.
+    /// - Throws: Whatever listing the store throws. A store that cannot be read
+    ///   is not a store that holds nothing.
+    public func heldImageContent(digest: String) async throws -> HeldImageContent {
+        let images = try await imageStore.list()
+        guard let image = images.first(where: { $0.digest == digest }) else {
+            logger.debug("No image holds this content digest", metadata: ["digest": "\(digest)"])
+            return .noImageForDigest
+        }
+
+        // `referencedDigests()` reads the image's own index blob before it can
+        // name anything else, so a throw here is that blob being absent or
+        // undecodable -- which is this image's content missing, reported as
+        // such rather than as a read failure.
+        let referenced: [String]
+        do {
+            referenced = try await image.referencedDigests()
+        } catch {
+            logger.warning("Image index unreadable", metadata: [
+                "reference": "\(image.reference)",
+                "digest": "\(digest)",
+                "error": "\(error)"
+            ])
+            return .blobsMissing(reference: image.reference, digests: [image.digest])
+        }
+
+        // Every blob the image names, fetched from the content store. This is
+        // what separates a store that has a row from a store a container can
+        // actually be created from: `OverlayFSUnpacker.unpack` reads each layer
+        // by digest, and a layer that is not here fails there instead.
+        //
+        // A throw from `getContent` is the blob being absent: its other failure
+        // mode is a digest the image does not reference, and every digest here
+        // came from the image's own reference walk.
+        //
+        // Not exhaustive in one case, deliberately unrepaired: `referencedDigests`
+        // skips the children of a manifest it cannot decode. The manifest's own
+        // digest is still in the list, so such an image is still reported
+        // incomplete -- just without its layers enumerated beneath it.
+        var missing: [String] = []
+        for candidate in referenced {
+            do {
+                _ = try await image.getContent(digest: candidate)
+            } catch {
+                missing.append(generateDockerID(from: candidate))
+            }
+        }
+        guard missing.isEmpty else {
+            logger.warning("Image is missing content it references", metadata: [
+                "reference": "\(image.reference)",
+                "digest": "\(digest)",
+                "missing": "\(missing.joined(separator: ", "))"
+            ])
+            // Sorted because the walk's order follows the index, and a caller
+            // that puts these in a message would otherwise report the same
+            // damaged image two different ways.
+            return .blobsMissing(reference: image.reference, digests: missing.sorted())
+        }
+
+        logger.debug("Image content held in full", metadata: [
+            "reference": "\(image.reference)",
+            "digest": "\(digest)"
+        ])
+        return .held(reference: image.reference)
+    }
+
     /// Normalize image reference to Docker Hub format
     /// Docker convention:
     /// - "alpine" → "docker.io/library/alpine:latest"
@@ -715,6 +810,31 @@ public actor ImageManager {
             labels: config.labels ?? [:]
         )
     }
+}
+
+// MARK: - Held content
+
+/// What an image store can say about content named by an exact digest.
+///
+/// The answer to `heldImageContent(digest:)`. Three cases rather than a `Bool`
+/// because they demand different reports from a caller: content that never
+/// arrived has to be sent, content whose blobs are gone has to be sent again,
+/// and content that is here in full needs nothing. `Equatable` so a test can
+/// state the whole answer rather than one field of it.
+public enum HeldImageContent: Sendable, Equatable {
+    /// The store holds an image under this digest and every blob that image
+    /// names is present. `reference` is the reference it is stored under, so a
+    /// caller that also cares which repository the content arrived as can check
+    /// it without a second lookup.
+    case held(reference: String)
+
+    /// No image in this store carries this digest.
+    case noImageForDigest
+
+    /// An image carries the digest, but the content store cannot produce these
+    /// blobs, in `sha256:<hex>` form. Nothing can be created from the image
+    /// until they arrive.
+    case blobsMissing(reference: String, digests: [String])
 }
 
 // MARK: - Errors

--- a/Sources/ContainerBridge/ImageManager.swift
+++ b/Sources/ContainerBridge/ImageManager.swift
@@ -504,15 +504,49 @@ public actor ImageManager {
     /// - Short reference: nginx:alpine, nginx
     /// - Short ID: 4986bf8c1536 (12 chars)
     /// - Long ID: sha256:4986bf8c15... (full digest)
+    /// - Exact digest reference: nginx@sha256:4986bf8c15... (repository AND digest)
+    ///
+    /// **The exact-digest arm was added because nothing here could resolve the
+    /// only form the sandbox engine is able to use.**
+    /// `ContainerManager.createContainer` resolves an image with the same string
+    /// it records as `ContainerInfo.image` (`:1698` and `:1901`),
+    /// `startContainer` resolves that recorded string again when it rebuilds a
+    /// container from persisted state (`:2218`), and the engine's `Inspect`
+    /// requires the recorded string to be an exact digest reference or it
+    /// answers `invalid_output`. One field, three constraints, and only
+    /// `repository@sha256:<hex>` satisfies all three -- which is also exactly
+    /// what Gas Can sends for every create
+    /// (`crates/gascan-core/src/runtime.rs:677-686`).
+    ///
+    /// Before this arm existed, such a string fell through to `matchesReference`
+    /// below, which compares names and cannot match a digest, so every create
+    /// following a successful `PrepareImage` failed to resolve its own image.
+    ///
+    /// **The change is additive, and the arms below are deliberately left
+    /// reachable for this input.** An exact digest reference is neither
+    /// `isShortID` -- the `@`, the `:` and the repository letters fail
+    /// `^[a-f0-9]{12,64}$` -- nor `isLongID`, whose `hasPrefix("sha256:")` fails
+    /// on the repository prefix. So `matchesReference` still runs for it, which
+    /// is what keeps a store row whose reference literally *is*
+    /// `repository@sha256:<hex>` resolving by exact string match exactly as it
+    /// did before. Nothing that resolved before resolves differently; a form
+    /// that threw can now succeed.
+    ///
+    /// This does change Arca's Docker surface: `docker run|rmi|inspect
+    /// repo@sha256:...` now works where it previously reported "No such image".
+    /// That is Docker's own semantics for the form, and the change is deliberate
+    /// rather than a side effect.
     private func resolveImage(nameOrId: String) async throws -> Containerization.Image {
         // Check if input is a Docker ID (short or long)
         let isShortID = nameOrId.range(of: "^[a-f0-9]{12,64}$", options: .regularExpression) != nil
         let isLongID = nameOrId.hasPrefix("sha256:")
+        let exactDigest = ImageIdentity.exactDigest(of: nameOrId)
 
         logger.debug("Resolving image", metadata: [
             "name_or_id": "\(nameOrId)",
             "is_short_id": "\(isShortID)",
-            "is_long_id": "\(isLongID)"
+            "is_long_id": "\(isLongID)",
+            "is_exact_digest": "\(exactDigest != nil)"
         ])
 
         // For both ID-based and tag-based lookups, we need to list all images
@@ -535,6 +569,31 @@ public actor ImageManager {
             // Match long ID (full digest)
             if isLongID && dockerID == nameOrId {
                 logger.debug("Matched image by long ID", metadata: [
+                    "input": "\(nameOrId)",
+                    "reference": "\(image.reference)",
+                    "digest": "\(image.digest)"
+                ])
+                return image
+            }
+
+            // Match an exact digest reference: both halves, never one.
+            //
+            // The repository is compared as well as the digest, and it is
+            // compared exactly -- no registry normalization -- which is the same
+            // direction the engine's PrepareImage chose. Matching on the digest
+            // alone would resolve `anything-at-all@sha256:<hex>` to this image,
+            // which is a container created from content under a name its caller
+            // never asked for. A false "not found" is visible and recoverable; a
+            // false match is neither.
+            //
+            // Both sides go through ImageIdentity.repository(of:), the one
+            // split, so that the stored `workspace:latest` and the requested
+            // `workspace@sha256:...` meet on `workspace` by the same rule the
+            // engine uses when it decides it holds the content at all.
+            if let exactDigest,
+               image.digest == exactDigest.digest,
+               ImageIdentity.repository(of: image.reference) == exactDigest.repository {
+                logger.debug("Matched image by exact digest reference", metadata: [
                     "input": "\(nameOrId)",
                     "reference": "\(image.reference)",
                     "digest": "\(image.digest)"

--- a/Sources/ContainerBridge/ImageManager.swift
+++ b/Sources/ContainerBridge/ImageManager.swift
@@ -557,15 +557,17 @@ public actor ImageManager {
     /// below, which compares names and cannot match a digest, so every create
     /// following a successful `PrepareImage` failed to resolve its own image.
     ///
-    /// **The change is additive, and the arms below are deliberately left
-    /// reachable for this input.** An exact digest reference is neither
-    /// `isShortID` -- the `@`, the `:` and the repository letters fail
+    /// **The change is additive, and after the ordering fix below it is additive
+    /// by construction rather than by measurement.** An exact digest reference is
+    /// neither `isShortID` -- the `@`, the `:` and the repository letters fail
     /// `^[a-f0-9]{12,64}$` -- nor `isLongID`, whose `hasPrefix("sha256:")` fails
-    /// on the repository prefix. So `matchesReference` still runs for it, which
-    /// is what keeps a store row whose reference literally *is*
-    /// `repository@sha256:<hex>` resolving by exact string match exactly as it
-    /// did before. Nothing that resolved before resolves differently; a form
-    /// that threw can now succeed.
+    /// on the repository prefix. So `matchesReference` still runs for it, and it
+    /// runs *first*: every name arm is tried against every row before the digest
+    /// arm is tried at all. A store row whose reference literally is
+    /// `repository@sha256:<hex>` therefore still resolves by exact string match,
+    /// and no store can be built in which this arm takes a resolution away from
+    /// an arm that existed before it. Nothing that resolved before resolves
+    /// differently; a form that threw can now succeed.
     ///
     /// This does change Arca's Docker surface: `docker run|rmi|inspect
     /// repo@sha256:...` now works where it previously reported "No such image".
@@ -588,6 +590,28 @@ public actor ImageManager {
         // because the stored reference might not match our normalized version
         let images = try await imageStore.list()
 
+        // **One pass per arm, not one pass per row, and the difference is
+        // correctness rather than style.** `imageStore.list()` order is the
+        // store's own and is neither insertion nor sorted order -- MEASURED in
+        // Task 11's re-review, which saw `getImage` and `deleteImage` resolve the
+        // same string to different rows inside one process, and a legitimate
+        // `docker rmi repo@sha256:x` throw on 2 of 5 runs.
+        //
+        // The cause was arm precedence being decided by row order: with the arms
+        // interleaved inside one loop, whichever ROW came first decided which
+        // ARM answered. Two rows can both match one input -- a row literally
+        // named `repo@sha256:x` matches by name, and the row holding that
+        // content matches by digest -- so the answer depended on the store's
+        // enumeration.
+        //
+        // Ordering the arms fixes it at the root and buys three things: the
+        // result is a function of the store's contents rather than its order;
+        // NAME matching always beats CONTENT matching, so the exact-digest arm
+        // can never take a resolution away from an arm that existed before it --
+        // the additive claim now holds by construction rather than by having
+        // failed to find a counterexample; and `deleteImage` can trust that a
+        // digest reference naming a real row resolves to THAT row, which is what
+        // makes its guard deterministic.
         for image in images {
             let dockerID = generateDockerID(from: image.digest)
 
@@ -611,32 +635,9 @@ public actor ImageManager {
                 return image
             }
 
-            // Match an exact digest reference: both halves, never one.
-            //
-            // The repository is compared as well as the digest, and it is
-            // compared exactly -- no registry normalization -- which is the same
-            // direction the engine's PrepareImage chose. Matching on the digest
-            // alone would resolve `anything-at-all@sha256:<hex>` to this image,
-            // which is a container created from content under a name its caller
-            // never asked for. A false "not found" is visible and recoverable; a
-            // false match is neither.
-            //
-            // Both sides go through ImageIdentity.repository(of:), the one
-            // split, so that the stored `workspace:latest` and the requested
-            // `workspace@sha256:...` meet on `workspace` by the same rule the
-            // engine uses when it decides it holds the content at all.
-            if let exactDigest,
-               image.digest == exactDigest.digest,
-               ImageIdentity.repository(of: image.reference) == exactDigest.repository {
-                logger.debug("Matched image by exact digest reference", metadata: [
-                    "input": "\(nameOrId)",
-                    "reference": "\(image.reference)",
-                    "digest": "\(image.digest)"
-                ])
-                return image
-            }
-
-            // Match by reference (tag) - need to check multiple variations
+            // Match by reference (tag) - need to check multiple variations.
+            // Ahead of the digest arm below: a row the caller NAMED is a more
+            // specific answer than a row that merely holds the content.
             if !isShortID && !isLongID {
                 // Try to match the stored reference against the input in various ways
                 if matchesReference(stored: image.reference, input: nameOrId) {
@@ -647,6 +648,41 @@ public actor ImageManager {
                     ])
                     return image
                 }
+            }
+        }
+
+        // Match an exact digest reference: both halves, never one.
+        //
+        // The repository is compared as well as the digest, and it is compared
+        // exactly -- no registry normalization -- which is the same direction the
+        // engine's PrepareImage chose. Matching on the digest alone would resolve
+        // `anything-at-all@sha256:<hex>` to this image, which is a container
+        // created from content under a name its caller never asked for. A false
+        // "not found" is visible and recoverable; a false match is neither.
+        //
+        // Both sides go through ImageIdentity.repository(of:), the one split, so
+        // that the stored `workspace:latest` and the requested
+        // `workspace@sha256:...` meet on `workspace` by the same rule the engine
+        // uses when it decides it holds the content at all.
+        //
+        // Sorted by reference before choosing, so that a store holding the same
+        // content under two names in the same repository answers the same way
+        // twice. Nothing here depends on `list()`'s order.
+        if let exactDigest {
+            let candidates = images
+                .filter {
+                    $0.digest == exactDigest.digest
+                        && ImageIdentity.repository(of: $0.reference) == exactDigest.repository
+                }
+                .sorted { $0.reference < $1.reference }
+            if let image = candidates.first {
+                logger.debug("Matched image by exact digest reference", metadata: [
+                    "input": "\(nameOrId)",
+                    "reference": "\(image.reference)",
+                    "digest": "\(image.digest)",
+                    "candidates": "\(candidates.count)"
+                ])
+                return image
             }
         }
 

--- a/Sources/ContainerBridge/ImageManager.swift
+++ b/Sources/ContainerBridge/ImageManager.swift
@@ -27,6 +27,17 @@ public actor ImageManager {
         self.defaultPlatform = Platform.current
     }
 
+    /// Root of the `ImageStore` this manager loads into.
+    ///
+    /// Exists so that a caller which has to reason about a file *inside* the
+    /// store -- `initfs.ext4`, which Containerization builds at the store's own
+    /// path -- can ask the manager instead of re-deriving that path from the
+    /// same defaults and trusting the two to stay equal.
+    ///
+    /// `nonisolated` because it is fixed at construction: making callers await
+    /// a constant would be the reason they went on hand-deriving it.
+    nonisolated public var storeRoot: URL { imageStore.path }
+
     /// Initialize the image manager
     public func initialize() async throws {
         logger.info("Initializing ImageManager", metadata: [

--- a/Sources/ContainerBridge/ImageManager.swift
+++ b/Sources/ContainerBridge/ImageManager.swift
@@ -612,43 +612,66 @@ public actor ImageManager {
         // failed to find a counterexample; and `deleteImage` can trust that a
         // digest reference naming a real row resolves to THAT row, which is what
         // makes its guard deterministic.
-        for image in images {
-            let dockerID = generateDockerID(from: image.digest)
+        //
+        // **Every arm collects, sorts and takes the first**, including the two ID
+        // arms, and that uniformity is load-bearing rather than tidy. A first
+        // version of this fix ordered the arms but left the ID arms returning
+        // whichever row the loop reached first -- and both can match more than
+        // one row, because two references to one content share a digest. Task
+        // 11's re-review measured five reads of one unchanged store, inside one
+        // process, giving two different answers for a short ID and for a long
+        // ID, on the supposedly-fixed build. Half a fix here is a boundary the
+        // next reader has to know about, and the comment explaining it is what
+        // they would have to find first.
+        //
+        // NOT fixed here, and pre-existing: `deleteImage` deletes by the
+        // resolved row's reference and its digest-reference guard cannot fire
+        // for an ID input, so `docker rmi <short-id>` over content carrying two
+        // names still untags one of them -- now deterministically rather than
+        // arbitrarily. Docker refuses that outright ("image is referenced in
+        // multiple repositories"). Reported rather than fixed: it is not this
+        // change's to make.
 
-            // Match short ID (first 12+ chars)
-            if isShortID && dockerID.replacingOccurrences(of: "sha256:", with: "").hasPrefix(nameOrId) {
-                logger.debug("Matched image by short ID", metadata: [
-                    "input": "\(nameOrId)",
-                    "reference": "\(image.reference)",
-                    "digest": "\(image.digest)"
-                ])
-                return image
-            }
+        // Match short ID (first 12+ chars)
+        if isShortID,
+           let image = firstByReference(images.filter {
+               generateDockerID(from: $0.digest)
+                   .replacingOccurrences(of: "sha256:", with: "").hasPrefix(nameOrId)
+           }) {
+            logger.debug("Matched image by short ID", metadata: [
+                "input": "\(nameOrId)",
+                "reference": "\(image.reference)",
+                "digest": "\(image.digest)"
+            ])
+            return image
+        }
 
-            // Match long ID (full digest)
-            if isLongID && dockerID == nameOrId {
-                logger.debug("Matched image by long ID", metadata: [
-                    "input": "\(nameOrId)",
-                    "reference": "\(image.reference)",
-                    "digest": "\(image.digest)"
-                ])
-                return image
-            }
+        // Match long ID (full digest)
+        if isLongID,
+           let image = firstByReference(images.filter {
+               generateDockerID(from: $0.digest) == nameOrId
+           }) {
+            logger.debug("Matched image by long ID", metadata: [
+                "input": "\(nameOrId)",
+                "reference": "\(image.reference)",
+                "digest": "\(image.digest)"
+            ])
+            return image
+        }
 
-            // Match by reference (tag) - need to check multiple variations.
-            // Ahead of the digest arm below: a row the caller NAMED is a more
-            // specific answer than a row that merely holds the content.
-            if !isShortID && !isLongID {
-                // Try to match the stored reference against the input in various ways
-                if matchesReference(stored: image.reference, input: nameOrId) {
-                    logger.debug("Matched image by reference", metadata: [
-                        "input": "\(nameOrId)",
-                        "reference": "\(image.reference)",
-                        "digest": "\(image.digest)"
-                    ])
-                    return image
-                }
-            }
+        // Match by reference (tag) - need to check multiple variations.
+        // Ahead of the digest arm below: a row the caller NAMED is a more
+        // specific answer than a row that merely holds the content.
+        if !isShortID, !isLongID,
+           let image = firstByReference(images.filter {
+               matchesReference(stored: $0.reference, input: nameOrId)
+           }) {
+            logger.debug("Matched image by reference", metadata: [
+                "input": "\(nameOrId)",
+                "reference": "\(image.reference)",
+                "digest": "\(image.digest)"
+            ])
+            return image
         }
 
         // Match an exact digest reference: both halves, never one.
@@ -664,31 +687,43 @@ public actor ImageManager {
         // that the stored `workspace:latest` and the requested
         // `workspace@sha256:...` meet on `workspace` by the same rule the engine
         // uses when it decides it holds the content at all.
-        //
-        // Sorted by reference before choosing, so that a store holding the same
-        // content under two names in the same repository answers the same way
-        // twice. Nothing here depends on `list()`'s order.
-        if let exactDigest {
-            let candidates = images
-                .filter {
-                    $0.digest == exactDigest.digest
-                        && ImageIdentity.repository(of: $0.reference) == exactDigest.repository
-                }
-                .sorted { $0.reference < $1.reference }
-            if let image = candidates.first {
-                logger.debug("Matched image by exact digest reference", metadata: [
-                    "input": "\(nameOrId)",
-                    "reference": "\(image.reference)",
-                    "digest": "\(image.digest)",
-                    "candidates": "\(candidates.count)"
-                ])
-                return image
-            }
+        if let exactDigest,
+           let image = firstByReference(images.filter {
+               $0.digest == exactDigest.digest
+                   && ImageIdentity.repository(of: $0.reference) == exactDigest.repository
+           }) {
+            logger.debug("Matched image by exact digest reference", metadata: [
+                "input": "\(nameOrId)",
+                "reference": "\(image.reference)",
+                "digest": "\(image.digest)"
+            ])
+            return image
         }
 
         // Not found
         logger.warning("Image not found", metadata: ["name_or_id": "\(nameOrId)"])
         throw ImageManagerError.imageNotFound(nameOrId)
+    }
+
+    /// The one candidate a set of equally-valid matches resolves to.
+    ///
+    /// Every arm of `resolveImage` funnels through this, so "which row wins" is
+    /// decided in one place by one rule rather than four times by
+    /// `imageStore.list()`'s enumeration. The reference is the tie-break because
+    /// it is the only field that distinguishes two rows on one content: they
+    /// share a digest by construction, which is precisely why the ambiguity
+    /// exists.
+    ///
+    /// Ascending, and the direction is arbitrary but must be *fixed*. A test
+    /// pins it (`ImageResolutionTests` requires the `:alpha` row over the
+    /// `:zulu` one), because a tie-break nothing asserts is a tie-break a later
+    /// edit can reverse or delete without anything noticing -- which is exactly
+    /// what happened to the first version of this: both mutations survived the
+    /// whole suite.
+    private func firstByReference(
+        _ candidates: [Containerization.Image]
+    ) -> Containerization.Image? {
+        candidates.min { $0.reference < $1.reference }
     }
 
     /// Check if a stored image reference matches an input reference

--- a/Sources/ContainerBridge/ImageManager.swift
+++ b/Sources/ContainerBridge/ImageManager.swift
@@ -435,6 +435,41 @@ public actor ImageManager {
         // Check if image is in use by containers (if not force)
         if !force {
             // TODO: Check with ContainerManager if image is in use
+
+            // **A digest reference must not delete a row it did not name.**
+            // This method deletes by the RESOLVED row's reference below, not by
+            // the string it was given, and `resolveImage` now resolves
+            // `repo@sha256:<hex>` by content. Without this guard,
+            // `docker rmi alpha@sha256:<digest>` against a store whose only row
+            // is `alpha:latest` untags `alpha:latest` and cleans up the content
+            // behind it -- removing a name the caller never typed. MEASURED in
+            // Task 11's review, before this guard existed:
+            // `deleteImage(alpha@digest)` returned
+            // `untagged: alpha:latest, deleted: sha256:f056fb09b4cd…`, and
+            // `alpha:latest` was gone afterwards. Before the resolver arm the
+            // same call threw `No such image`, so the widening turned an error
+            // into a destructive success.
+            //
+            // Docker's own behaviour is the model, and it is NOT "the digest
+            // form just works": `rmi` by digest removes the digest reference,
+            // and refuses to remove content carrying other references without
+            // `--force`. So a digest reference naming an actual stored row still
+            // deletes exactly that row -- the equality below holds for it -- and
+            // one that resolves to a differently-named row is refused, with the
+            // message saying what to do instead.
+            if let requested = ImageIdentity.exactDigest(of: nameOrId),
+               imageReference != nameOrId {
+                logger.warning("Refusing to delete a row the digest reference did not name", metadata: [
+                    "requested": "\(nameOrId)",
+                    "resolved": "\(imageReference)"
+                ])
+                throw ImageManagerError.deleteFailed(
+                    "\(nameOrId) resolves to \(imageReference), which is a different reference; "
+                        + "deleting it would remove a name that was not asked for. Delete "
+                        + "\(imageReference) by name, or repeat with force to remove the content "
+                        + "held under \(requested.repository)."
+                )
+            }
         }
 
         // Delete the image by reference

--- a/Sources/ContainerBridge/ImageManager.swift
+++ b/Sources/ContainerBridge/ImageManager.swift
@@ -613,7 +613,7 @@ public actor ImageManager {
         // digest reference naming a real row resolves to THAT row, which is what
         // makes its guard deterministic.
         //
-        // **Every arm collects, sorts and takes the first**, including the two ID
+        // **Every arm collects and takes the minimum**, including the two ID
         // arms, and that uniformity is load-bearing rather than tidy. A first
         // version of this fix ordered the arms but left the ID arms returning
         // whichever row the loop reached first -- and both can match more than
@@ -634,7 +634,7 @@ public actor ImageManager {
 
         // Match short ID (first 12+ chars)
         if isShortID,
-           let image = firstByReference(images.filter {
+           let image = minimumByReference(images.filter {
                generateDockerID(from: $0.digest)
                    .replacingOccurrences(of: "sha256:", with: "").hasPrefix(nameOrId)
            }) {
@@ -648,7 +648,7 @@ public actor ImageManager {
 
         // Match long ID (full digest)
         if isLongID,
-           let image = firstByReference(images.filter {
+           let image = minimumByReference(images.filter {
                generateDockerID(from: $0.digest) == nameOrId
            }) {
             logger.debug("Matched image by long ID", metadata: [
@@ -663,7 +663,7 @@ public actor ImageManager {
         // Ahead of the digest arm below: a row the caller NAMED is a more
         // specific answer than a row that merely holds the content.
         if !isShortID, !isLongID,
-           let image = firstByReference(images.filter {
+           let image = minimumByReference(images.filter {
                matchesReference(stored: $0.reference, input: nameOrId)
            }) {
             logger.debug("Matched image by reference", metadata: [
@@ -688,7 +688,7 @@ public actor ImageManager {
         // `workspace@sha256:...` meet on `workspace` by the same rule the engine
         // uses when it decides it holds the content at all.
         if let exactDigest,
-           let image = firstByReference(images.filter {
+           let image = minimumByReference(images.filter {
                $0.digest == exactDigest.digest
                    && ImageIdentity.repository(of: $0.reference) == exactDigest.repository
            }) {
@@ -720,10 +720,23 @@ public actor ImageManager {
     /// edit can reverse or delete without anything noticing -- which is exactly
     /// what happened to the first version of this: both mutations survived the
     /// whole suite.
-    private func firstByReference(
+    ///
+    /// The candidate count is logged on every match, because it is the only
+    /// signal in the logs that a resolution was ambiguous and this rule -- not
+    /// the caller's input -- decided which row the user got. The old
+    /// exact-digest arm logged it; funnelling it through here gives every arm
+    /// what only that one arm used to have.
+    private func minimumByReference(
         _ candidates: [Containerization.Image]
     ) -> Containerization.Image? {
-        candidates.min { $0.reference < $1.reference }
+        guard let chosen = candidates.min(by: { $0.reference < $1.reference }) else {
+            return nil
+        }
+        logger.debug("Chose among matching rows by reference", metadata: [
+            "candidates": "\(candidates.count)",
+            "reference": "\(chosen.reference)"
+        ])
+        return chosen
     }
 
     /// Check if a stored image reference matches an input reference

--- a/Sources/ContainerBridge/ImageManager.swift
+++ b/Sources/ContainerBridge/ImageManager.swift
@@ -666,16 +666,32 @@ public actor ImageManager {
     /// such image", "the store has a row and cannot produce its bytes", and
     /// "the read itself failed" into `false`. Those demand different reports.
     ///
+    /// **Every row carrying the digest is reported, not the first one found.**
+    /// A store holds one row per *reference*, and `tagImage(source:target:)`
+    /// above adds a second reference to content that is already there, so two
+    /// rows can carry one digest. An earlier revision of this returned the
+    /// first match, and a caller that then tested that one reference against
+    /// the name it asked about got a `not_found` decided by `imageStore.list()`
+    /// ordering -- for content the store demonstrably held, naming the wrong
+    /// reference while it did so. The blob walk below is unaffected by that
+    /// multiplicity and is done once: the rows share a root descriptor and a
+    /// content store, so they reference identical blobs by construction.
+    ///
     /// - Parameter digest: The content digest, in the `sha256:<hex>` form the
     ///   store records. Anything else matches nothing.
     /// - Throws: Whatever listing the store throws. A store that cannot be read
     ///   is not a store that holds nothing.
-    public func heldImageContent(digest: String) async throws -> HeldImageContent {
+    package func heldImageContent(digest: String) async throws -> HeldImageContent {
         let images = try await imageStore.list()
-        guard let image = images.first(where: { $0.digest == digest }) else {
+        let matches = images.filter { $0.digest == digest }
+        guard let image = matches.first else {
             logger.debug("No image holds this content digest", metadata: ["digest": "\(digest)"])
             return .noImageForDigest
         }
+        // Sorted for the reason the missing digests below are: `list()`'s order
+        // is the store's, and a caller putting these in a message would
+        // otherwise report one store two different ways across two runs.
+        let references = matches.map(\.reference).sorted()
 
         // `referencedDigests()` reads the image's own index blob before it can
         // name anything else, so a throw here is that blob being absent or
@@ -686,11 +702,11 @@ public actor ImageManager {
             referenced = try await image.referencedDigests()
         } catch {
             logger.warning("Image index unreadable", metadata: [
-                "reference": "\(image.reference)",
+                "references": "\(references.joined(separator: ", "))",
                 "digest": "\(digest)",
                 "error": "\(error)"
             ])
-            return .blobsMissing(reference: image.reference, digests: [image.digest])
+            return .blobsMissing(references: references, digests: [image.digest])
         }
 
         // Every blob the image names, fetched from the content store. This is
@@ -716,21 +732,21 @@ public actor ImageManager {
         }
         guard missing.isEmpty else {
             logger.warning("Image is missing content it references", metadata: [
-                "reference": "\(image.reference)",
+                "references": "\(references.joined(separator: ", "))",
                 "digest": "\(digest)",
                 "missing": "\(missing.joined(separator: ", "))"
             ])
             // Sorted because the walk's order follows the index, and a caller
             // that puts these in a message would otherwise report the same
             // damaged image two different ways.
-            return .blobsMissing(reference: image.reference, digests: missing.sorted())
+            return .blobsMissing(references: references, digests: missing.sorted())
         }
 
         logger.debug("Image content held in full", metadata: [
-            "reference": "\(image.reference)",
+            "references": "\(references.joined(separator: ", "))",
             "digest": "\(digest)"
         ])
-        return .held(reference: image.reference)
+        return .held(references: references)
     }
 
     /// Normalize image reference to Docker Hub format
@@ -821,20 +837,24 @@ public actor ImageManager {
 /// arrived has to be sent, content whose blobs are gone has to be sent again,
 /// and content that is here in full needs nothing. `Equatable` so a test can
 /// state the whole answer rather than one field of it.
-public enum HeldImageContent: Sendable, Equatable {
-    /// The store holds an image under this digest and every blob that image
-    /// names is present. `reference` is the reference it is stored under, so a
-    /// caller that also cares which repository the content arrived as can check
-    /// it without a second lookup.
-    case held(reference: String)
+///
+/// Both content-bearing cases carry `references` as a sorted list and not a
+/// single name, because a store holds one row per reference and a tag adds a
+/// row to content that is already there. A caller deciding anything about the
+/// *name* the content arrived under has to see all of them or it decides on
+/// whichever row the store happened to list first.
+package enum HeldImageContent: Sendable, Equatable {
+    /// The store holds this digest under every reference listed, and every blob
+    /// those rows name is present.
+    case held(references: [String])
 
     /// No image in this store carries this digest.
     case noImageForDigest
 
-    /// An image carries the digest, but the content store cannot produce these
-    /// blobs, in `sha256:<hex>` form. Nothing can be created from the image
-    /// until they arrive.
-    case blobsMissing(reference: String, digests: [String])
+    /// The digest is in the store under these references, but the content store
+    /// cannot produce these blobs, in `sha256:<hex>` form. Nothing can be
+    /// created from the image until they arrive.
+    case blobsMissing(references: [String], digests: [String])
 }
 
 // MARK: - Errors

--- a/Sources/ContainerBridge/LogWriter.swift
+++ b/Sources/ContainerBridge/LogWriter.swift
@@ -116,17 +116,24 @@ public final class ContainerLogManager: @unchecked Sendable {
         public let combinedPath: URL
     }
 
-    public init(logger: Logger) {
+    /// - Parameter logRoot: The directory container log directories are created
+    ///   under, and the directory `removeLogs` deletes from. Supplied by the
+    ///   caller and never defaulted: this class both writes and deletes here,
+    ///   and until Task 13b it derived `~/Library/Application Support/
+    ///   com.apple.arca/logs` for itself, so every `ContainerManager` -- however
+    ///   its own state root was set -- wrote container stdout/stderr into one
+    ///   shared directory and removed containers' logs out of it. A throwaway
+    ///   engine deleting under the operator's real log store is the failure
+    ///   that shape allows.
+    ///
+    ///   A default would put that back the moment a caller omitted the
+    ///   argument, which is the rule the milestone's design states for every
+    ///   `ContainerBridge` change: none takes a default, because a default is
+    ///   how a caller silently keeps the old behaviour after the reason for it
+    ///   has gone.
+    public init(logRoot: URL, logger: Logger) {
         self.logger = logger
-
-        // Use ~/Library/Application Support/com.apple.arca/logs/
-        let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask
-        ).first!
-        self.baseLogDir = appSupport
-            .appendingPathComponent("com.apple.arca")
-            .appendingPathComponent("logs")
+        self.baseLogDir = logRoot
     }
 
     /// Get log directory for a container

--- a/Sources/ContainerBridge/NetworkManager.swift
+++ b/Sources/ContainerBridge/NetworkManager.swift
@@ -2,6 +2,17 @@ import Foundation
 import Logging
 import Containerization
 
+/// The source `NetworkManager.listNetworks()` reads bridge networks from.
+///
+/// `NetworkManager` owns this abstraction rather than the backend: it names the
+/// one capability the listing needs, so a caller can supply a source that fails
+/// without standing in for the rest of `WireGuardNetworkBackend`. `package`
+/// because the only such caller is `ArcaEngineTests`, which is in this package;
+/// nothing outside it has a reason to implement this.
+package protocol BridgeNetworkLister: Sendable {
+    func listNetworks() async throws -> [NetworkMetadata]
+}
+
 /// Manages Docker networks with WireGuard as the default bridge backend:
 /// - WireGuard backend (default): Full Docker compatibility with ~1ms latency
 /// - vmnet backend: High performance native vmnet (limited features, user-created only)
@@ -18,6 +29,27 @@ public actor NetworkManager {
     // Backends
     private var vmnetBackend: VmnetNetworkBackend?
     private var wireGuardBackend: WireGuardNetworkBackend?
+
+    /// A bridge-network source standing in for the WireGuard backend. `nil` in
+    /// production and set only by `setBridgeNetworkLister(_:)`, which exists
+    /// because `listNetworks()` has no other reachable failure: a backend is
+    /// otherwise populated only by `initialize()`, which also creates the
+    /// default `host` network over vmnet and so cannot run in a unit test.
+    private var installedBridgeNetworkLister: (any BridgeNetworkLister)?
+
+    /// The source `listNetworks()` reads, and its only reader.
+    ///
+    /// Computed rather than stored: a stored second reference would have to be
+    /// assigned alongside `wireGuardBackend` in `initialize()`, and dropping
+    /// that one line would leave production listing no bridge networks with
+    /// every test still green. Derived, the backend cannot be installed without
+    /// this seeing it.
+    private var bridgeNetworkLister: (any BridgeNetworkLister)? {
+        if let installed = installedBridgeNetworkLister {
+            return installed
+        }
+        return wireGuardBackend
+    }
 
     // Central network routing: networkID -> driver
     // This avoids "try all backends" pattern and provides O(1) backend lookup
@@ -40,6 +72,17 @@ public actor NetworkManager {
     /// Set the EventEmitter for emitting Docker events
     public func setEventEmitter(_ emitter: EventEmitter) {
         self.eventEmitter = emitter
+    }
+
+    /// Install the bridge-network source `listNetworks()` reads, in place of
+    /// the WireGuard backend, without the rest of `initialize()`.
+    ///
+    /// `package` rather than `public` for the reason `BridgeNetworkLister` is:
+    /// this exists so `ArcaEngineTests` can drive `listNetworks()` against a
+    /// backend that fails. The daemon has no use for it -- it calls
+    /// `initialize()`, which installs the real backend itself.
+    package func setBridgeNetworkLister(_ lister: any BridgeNetworkLister) {
+        self.installedBridgeNetworkLister = lister
     }
 
     /// Initialize the network manager and backends
@@ -542,17 +585,20 @@ public actor NetworkManager {
     }
 
     /// List all networks
-    public func listNetworks() async -> [NetworkMetadata] {
+    ///
+    /// Throws rather than returning a short list. A WireGuard-backend failure
+    /// swallowed by `try?` turns a real failure into a confident report of a
+    /// clean host, which is the report that hides a leak. gascan maps a thrown
+    /// failure to `command_io`; it has no way to see a silently short list.
+    public func listNetworks() async throws -> [NetworkMetadata] {
         var networks: [NetworkMetadata] = []
 
         if let backend = vmnetBackend {
             networks.append(contentsOf: await backend.listNetworks())
         }
 
-        if let backend = wireGuardBackend {
-            if let wgNetworks = try? await backend.listNetworks() {
-                networks.append(contentsOf: wgNetworks)
-            }
+        if let lister = bridgeNetworkLister {
+            networks.append(contentsOf: try await lister.listNetworks())
         }
 
         // Add null driver networks from StateStore
@@ -585,7 +631,11 @@ public actor NetworkManager {
     }
 
     /// Resolve network ID from short ID or name
-    public func resolveNetworkID(_ idOrName: String) async -> String? {
+    ///
+    /// Throws for the same reason `listNetworks()` does: the prefix match below
+    /// is a listing, and a swallowed backend failure here would report "no such
+    /// network" for a network that exists.
+    public func resolveNetworkID(_ idOrName: String) async throws -> String? {
         // Try exact name match first
         if let network = await getNetworkByName(name: idOrName) {
             return network.id
@@ -597,7 +647,7 @@ public actor NetworkManager {
         }
 
         // Try prefix match
-        let allNetworks = await listNetworks()
+        let allNetworks = try await listNetworks()
         let matches = allNetworks.filter { $0.id.hasPrefix(idOrName) }
 
         if matches.count == 1 {

--- a/Sources/ContainerBridge/NetworkManager.swift
+++ b/Sources/ContainerBridge/NetworkManager.swift
@@ -714,13 +714,24 @@ public actor NetworkManager {
     /// left, and it is the harder one to notice.
     ///
     /// vmnet is asked first, and only for a network vmnet owns. Under the old
-    /// order the WireGuard branch answered first and its `[:]` for a vmnet
-    /// network counted as an answer, so the vmnet branch was unreachable
-    /// whenever the backend was up -- which is always, after `initialize()`.
-    /// Routing on which backend owns the network is what `deleteNetwork(id:)`
-    /// already does.
+    /// order the WireGuard branch answered first and its `[:]` counted as an
+    /// answer, so the vmnet branch was unreachable whenever the backend was up
+    /// -- which is always, after `initialize()`. Routing on which backend owns
+    /// the network is what `deleteNetwork(id:)` already does.
+    ///
+    /// What that reordering changes, stated in the direction it actually runs:
+    /// for a vmnet-owned network this now returns `[:]` *without* reading the
+    /// store, where the old order read the store for every ID. It is
+    /// behaviour-neutral today because nothing ever writes a vmnet attachment
+    /// row -- `attachContainerToNetwork`'s `vmnet` case throws
+    /// `dynamicAttachNotSupported` before any store write -- so the store
+    /// answers `[:]` for those networks anyway, and
+    /// `VmnetNetworkBackend.getNetworkAttachments` is itself a hardcoded `[:]`.
+    /// Both orders return `[:]`; the difference is which code is reachable if
+    /// vmnet ever grows real attachments.
     public func getNetworkAttachments(networkID: String) async throws -> [String: NetworkAttachment] {
-        // vmnet keeps its attachments in memory, not in the StateStore.
+        // vmnet tracks no attachment detail of its own, and writes none to the
+        // StateStore -- see the note above.
         if let backend = vmnetBackend, await backend.getNetwork(id: networkID) != nil {
             return await backend.getNetworkAttachments(networkID: networkID)
         }

--- a/Sources/ContainerBridge/NetworkManager.swift
+++ b/Sources/ContainerBridge/NetworkManager.swift
@@ -31,6 +31,64 @@ struct NullDriverNetworks: NetworkLister {
     }
 }
 
+/// The source `NetworkManager` reads container attachments from -- both
+/// directions of the same table: which containers are on a network, and which
+/// networks a container is on.
+///
+/// A second seam rather than two more methods on `NetworkLister`. The two
+/// protocols name different capabilities over different tables, and widening
+/// `NetworkLister` would force `NullDriverNetworks` -- which knows only how to
+/// list `--driver null` networks -- to carry two attachment methods it has no
+/// answer for. It would also let one stub stand in for both concerns, and a
+/// test that fails "some source" cannot say which read it proved. `package`
+/// for the reason `NetworkLister` is: the only implementors outside this file
+/// are in this package's tests.
+package protocol NetworkAttachmentSource: Sendable {
+    func getNetworkAttachments(networkID: String) async throws -> [String: NetworkAttachment]
+    func getContainerNetworks(containerID: String) async throws -> [NetworkMetadata]
+}
+
+/// Attachments as the StateStore holds them.
+///
+/// This is where attachments actually live: `WireGuardNetworkBackend`'s two
+/// methods of these names read `network_attachments` and nothing else -- no
+/// in-memory backend state at all -- and `NetworkManager` was their only
+/// caller. Reading the store directly, rather than through a backend that
+/// `initialize()` alone can install, is what lets the production derivation be
+/// driven with no stub in place: a test can seed a row and read it back
+/// through the same code the daemon runs.
+struct StoredNetworkAttachments: NetworkAttachmentSource {
+    let stateStore: StateStore
+
+    func getNetworkAttachments(networkID: String) async throws -> [String: NetworkAttachment] {
+        var attachments: [String: NetworkAttachment] = [:]
+
+        for stored in try await stateStore.loadAttachmentsForNetwork(networkID: networkID) {
+            attachments[stored.containerID] = NetworkAttachment(
+                networkID: networkID,
+                ip: stored.ipAddress,
+                mac: stored.macAddress,
+                aliases: stored.aliases
+            )
+        }
+
+        return attachments
+    }
+
+    func getContainerNetworks(containerID: String) async throws -> [NetworkMetadata] {
+        let attachedIDs = try await stateStore.getContainerNetworks(containerID: containerID)
+        var networks: [NetworkMetadata] = []
+
+        for persisted in try await stateStore.loadAllNetworks() where attachedIDs.contains(persisted.id) {
+            var network = NetworkMetadata(persisted: persisted)
+            network.containers = try await stateStore.getNetworkContainers(networkID: persisted.id)
+            networks.append(network)
+        }
+
+        return networks
+    }
+}
+
 extension NetworkMetadata {
     /// One stored network as metadata. The single mapping from a persisted row,
     /// so `NullDriverNetworks` and `NetworkManager.getNetwork(id:)` cannot come
@@ -90,6 +148,25 @@ public actor NetworkManager {
     /// way to break deterministically.
     private var installedBridgeNetworkLister: (any NetworkLister)?
     private var installedNullNetworkLister: (any NetworkLister)?
+
+    /// The source standing in for `StoredNetworkAttachments`. `nil` in
+    /// production, and set only by the `package` setter below. Unlike the two
+    /// listers above, the source this replaces *is* reachable without
+    /// `initialize()` -- it reads the StateStore directly -- so the tests that
+    /// matter most here install nothing at all. This exists for the one thing
+    /// they cannot do: make that store read fail on demand.
+    private var installedAttachmentSource: (any NetworkAttachmentSource)?
+
+    /// The source the two attachment reads below derive from, and their only
+    /// reader.
+    ///
+    /// Computed, not stored, for the reason `networkListers` is: a stored copy
+    /// would have to be assigned somewhere, and dropping that assignment would
+    /// leave production reading no attachments -- `docker network prune`
+    /// deleting in-use networks -- with every test still green.
+    private var attachmentSource: any NetworkAttachmentSource {
+        installedAttachmentSource ?? StoredNetworkAttachments(stateStore: stateStore)
+    }
 
     /// The sources `listNetworks()` reads, and its only reader.
     ///
@@ -152,6 +229,19 @@ public actor NetworkManager {
     /// surfaces, not that the null-driver read is one of the sources.
     package func setNullNetworkLister(_ lister: any NetworkLister) {
         self.installedNullNetworkLister = lister
+    }
+
+    /// Install the attachment source `getNetworkAttachments` and
+    /// `getContainerNetworks` read, in place of the StateStore-backed one.
+    ///
+    /// `package` for the reason the two above are, and it exists for one
+    /// purpose: `StateStore` is a concrete actor whose SQLite connection a test
+    /// has no way to break deterministically, so a partial store failure -- the
+    /// one that used to let `docker network prune` delete an in-use network --
+    /// can be reproduced no other way. Production never calls this; it takes
+    /// the `??` default in `attachmentSource`.
+    package func setNetworkAttachmentSource(_ source: any NetworkAttachmentSource) {
+        self.installedAttachmentSource = source
     }
 
     /// Initialize the network manager and backends
@@ -613,20 +703,29 @@ public actor NetworkManager {
     }
 
     /// Get container attachments for a network
-    public func getNetworkAttachments(networkID: String) async -> [String: NetworkAttachment] {
-        // Try WireGuard backend first (default for bridge)
-        if let backend = wireGuardBackend {
-            if let attachments = try? await backend.getNetworkAttachments(networkID: networkID) {
-                return attachments
-            }
-        }
-
-        // Try vmnet backend
+    ///
+    /// Throws rather than returning `[:]`, which is indistinguishable from
+    /// "nothing attached". This is the gate `docker network prune` reads to
+    /// skip networks with active containers: swallowed with `try?`, a transient
+    /// store failure on the attachment read -- while `listNetworks()` still
+    /// succeeded -- made every network look unused and prune **deleted an
+    /// in-use network** and reported success. Task 3 closed the total-failure
+    /// case by making `listNetworks()` throw; the partial failure is what is
+    /// left, and it is the harder one to notice.
+    ///
+    /// vmnet is asked first, and only for a network vmnet owns. Under the old
+    /// order the WireGuard branch answered first and its `[:]` for a vmnet
+    /// network counted as an answer, so the vmnet branch was unreachable
+    /// whenever the backend was up -- which is always, after `initialize()`.
+    /// Routing on which backend owns the network is what `deleteNetwork(id:)`
+    /// already does.
+    public func getNetworkAttachments(networkID: String) async throws -> [String: NetworkAttachment] {
+        // vmnet keeps its attachments in memory, not in the StateStore.
         if let backend = vmnetBackend, await backend.getNetwork(id: networkID) != nil {
             return await backend.getNetworkAttachments(networkID: networkID)
         }
 
-        return [:]
+        return try await attachmentSource.getNetworkAttachments(networkID: networkID)
     }
 
     /// List all networks
@@ -650,21 +749,17 @@ public actor NetworkManager {
     }
 
     /// Get networks for a container
-    public func getContainerNetworks(containerID: String) async -> [NetworkMetadata] {
-        var networks: [NetworkMetadata] = []
-
-        if vmnetBackend != nil {
-            // vmnet backend doesn't track container networks separately
-            // (containers are attached at creation time)
-        }
-
-        if let backend = wireGuardBackend {
-            if let wgNetworks = try? await backend.getContainerNetworks(containerID: containerID) {
-                networks.append(contentsOf: wgNetworks)
-            }
-        }
-
-        return networks
+    ///
+    /// Throws for the same reason `getNetworkAttachments` does, one table over.
+    /// Swallowed with `try?`, a store failure here read to `getWireGuardClient`
+    /// as "this container is on no WireGuard network", and the caller that acts
+    /// on that answer skips publishing the container's port mappings -- a
+    /// container that comes up with its ports silently unmapped.
+    ///
+    /// vmnet is not consulted: it does not track container networks separately,
+    /// as the branch this replaced recorded by doing nothing.
+    public func getContainerNetworks(containerID: String) async throws -> [NetworkMetadata] {
+        return try await attachmentSource.getContainerNetworks(containerID: containerID)
     }
 
     /// Resolve network ID from short ID or name
@@ -705,13 +800,18 @@ public actor NetworkManager {
     /// Create a WireGuard client for a container (for port mapping)
     /// Returns nil if container is not attached to any WireGuard networks or container not found
     /// Caller must disconnect the client when done
-    public func getWireGuardClient(containerID: String) async -> WireGuardClient? {
+    ///
+    /// Throws when the attachment read fails. `nil` here means "no client is
+    /// wanted" and the caller publishes no ports on the strength of it, so a
+    /// failure that cannot say whether the container is attached must not
+    /// arrive as `nil`.
+    public func getWireGuardClient(containerID: String) async throws -> WireGuardClient? {
         guard wireGuardBackend != nil else {
             return nil
         }
 
         // Get container networks - if not attached to any WireGuard networks, return nil
-        let networks = await getContainerNetworks(containerID: containerID)
+        let networks = try await getContainerNetworks(containerID: containerID)
         guard !networks.isEmpty else {
             return nil
         }

--- a/Sources/ContainerBridge/NetworkManager.swift
+++ b/Sources/ContainerBridge/NetworkManager.swift
@@ -2,15 +2,66 @@ import Foundation
 import Logging
 import Containerization
 
-/// The source `NetworkManager.listNetworks()` reads bridge networks from.
+/// A source `NetworkManager.listNetworks()` reads networks from.
 ///
 /// `NetworkManager` owns this abstraction rather than the backend: it names the
 /// one capability the listing needs, so a caller can supply a source that fails
 /// without standing in for the rest of `WireGuardNetworkBackend`. `package`
 /// because the only such caller is `ArcaEngineTests`, which is in this package;
 /// nothing outside it has a reason to implement this.
-package protocol BridgeNetworkLister: Sendable {
+package protocol NetworkLister: Sendable {
     func listNetworks() async throws -> [NetworkMetadata]
+}
+
+/// The `null`-driver networks, read from the StateStore.
+///
+/// A `NetworkLister` rather than an inline branch of `listNetworks()`. As a
+/// branch it read each network back through `getNetwork(id:)`, whose `catch`
+/// logs and returns `nil`, so a StateStore failure -- `SQLITE_BUSY` under a
+/// concurrent write, say -- dropped every `--driver null` network from
+/// `docker network ls` and still reported success. Read as a source, through
+/// the same `try` as every other source, it has nowhere left to drop one.
+struct NullDriverNetworks: NetworkLister {
+    let stateStore: StateStore
+
+    func listNetworks() async throws -> [NetworkMetadata] {
+        try await stateStore.loadAllNetworks()
+            .filter { $0.driver == "null" }
+            .map(NetworkMetadata.init(persisted:))
+    }
+}
+
+extension NetworkMetadata {
+    /// One stored network as metadata. The single mapping from a persisted row,
+    /// so `NullDriverNetworks` and `NetworkManager.getNetwork(id:)` cannot come
+    /// to disagree about what a stored network means.
+    ///
+    /// Malformed `options`/`labels` JSON decodes to empty rather than throwing:
+    /// that was the behaviour before this was extracted, and a network is still
+    /// a network without its labels. A failure to *reach* the row is the one
+    /// this task is about, and that is the caller's `try`.
+    init(persisted network: StateStore.PersistedNetwork) {
+        self.init(
+            id: network.id,
+            name: network.name,
+            driver: network.driver,
+            subnet: network.subnet,
+            gateway: network.gateway,
+            ipRange: network.ipRange,
+            containers: [],  // Null networks don't track containers
+            created: network.createdAt,
+            options: Self.decodeStringMap(network.optionsJSON),
+            labels: Self.decodeStringMap(network.labelsJSON),
+            isDefault: network.isDefault
+        )
+    }
+
+    private static func decodeStringMap(_ json: String?) -> [String: String] {
+        guard let json, let data = json.data(using: .utf8) else {
+            return [:]
+        }
+        return (try? JSONDecoder().decode([String: String].self, from: data)) ?? [:]
+    }
 }
 
 /// Manages Docker networks with WireGuard as the default bridge backend:
@@ -30,25 +81,34 @@ public actor NetworkManager {
     private var vmnetBackend: VmnetNetworkBackend?
     private var wireGuardBackend: WireGuardNetworkBackend?
 
-    /// A bridge-network source standing in for the WireGuard backend. `nil` in
-    /// production and set only by `setBridgeNetworkLister(_:)`, which exists
-    /// because `listNetworks()` has no other reachable failure: a backend is
-    /// otherwise populated only by `initialize()`, which also creates the
-    /// default `host` network over vmnet and so cannot run in a unit test.
-    private var installedBridgeNetworkLister: (any BridgeNetworkLister)?
+    /// Sources standing in for the two `listNetworks()` derives. `nil` in
+    /// production and set only by the two `package` setters below, which exist
+    /// because `listNetworks()` has no other reachable failure: the WireGuard
+    /// backend is populated only by `initialize()`, which also creates the
+    /// default `host` network over vmnet and so cannot run in a unit test, and
+    /// `StateStore` is a concrete actor whose SQLite connection a test has no
+    /// way to break deterministically.
+    private var installedBridgeNetworkLister: (any NetworkLister)?
+    private var installedNullNetworkLister: (any NetworkLister)?
 
-    /// The source `listNetworks()` reads, and its only reader.
+    /// The sources `listNetworks()` reads, and its only reader.
     ///
-    /// Computed rather than stored: a stored second reference would have to be
-    /// assigned alongside `wireGuardBackend` in `initialize()`, and dropping
-    /// that one line would leave production listing no bridge networks with
-    /// every test still green. Derived, the backend cannot be installed without
-    /// this seeing it.
-    private var bridgeNetworkLister: (any BridgeNetworkLister)? {
-        if let installed = installedBridgeNetworkLister {
-            return installed
+    /// Computed rather than stored: a stored copy would have to be assigned
+    /// alongside `wireGuardBackend` in `initialize()`, and dropping that one
+    /// line would leave production listing no bridge networks with every test
+    /// still green. Derived, a source cannot be installed without this seeing
+    /// it.
+    private var networkListers: [any NetworkLister] {
+        var listers: [any NetworkLister] = []
+
+        if let bridge = installedBridgeNetworkLister ?? wireGuardBackend {
+            listers.append(bridge)
         }
-        return wireGuardBackend
+        listers.append(
+            installedNullNetworkLister ?? NullDriverNetworks(stateStore: stateStore)
+        )
+
+        return listers
     }
 
     // Central network routing: networkID -> driver
@@ -77,12 +137,21 @@ public actor NetworkManager {
     /// Install the bridge-network source `listNetworks()` reads, in place of
     /// the WireGuard backend, without the rest of `initialize()`.
     ///
-    /// `package` rather than `public` for the reason `BridgeNetworkLister` is:
-    /// this exists so `ArcaEngineTests` can drive `listNetworks()` against a
-    /// backend that fails. The daemon has no use for it -- it calls
-    /// `initialize()`, which installs the real backend itself.
-    package func setBridgeNetworkLister(_ lister: any BridgeNetworkLister) {
+    /// `package` rather than `public` for the reason `NetworkLister` is: this
+    /// exists so `ArcaEngineTests` can drive `listNetworks()` against a backend
+    /// that fails. The daemon has no use for it -- it calls `initialize()`,
+    /// which installs the real backend itself.
+    package func setBridgeNetworkLister(_ lister: any NetworkLister) {
         self.installedBridgeNetworkLister = lister
+    }
+
+    /// Install the `null`-driver source `listNetworks()` reads, in place of the
+    /// StateStore-backed one. `package` for the same reason, and separate from
+    /// the bridge setter so a test can fail one source while the other stands:
+    /// a single setter for both would prove only that *some* source's failure
+    /// surfaces, not that the null-driver read is one of the sources.
+    package func setNullNetworkLister(_ lister: any NetworkLister) {
+        self.installedNullNetworkLister = lister
     }
 
     /// Initialize the network manager and backends
@@ -511,42 +580,18 @@ public actor NetworkManager {
 
         case "null":
             // "null" driver - load from StateStore
+            //
+            // Still returns nil on a failure, unlike listNetworks(): this
+            // answers about one named network, and every caller already treats
+            // nil as "not found". listNetworks() answers about the whole host,
+            // where the same nil becomes a short list reported as success, so it
+            // reads NullDriverNetworks directly rather than looping through here.
             do {
-                let allNetworks = try await stateStore.loadAllNetworks()
-                guard let networkData = allNetworks.first(where: { $0.id == id }) else {
+                guard let network = try await stateStore.loadAllNetworks()
+                    .first(where: { $0.id == id }) else {
                     return nil
                 }
-
-                // Decode options and labels from JSON
-                let options: [String: String]
-                if let optionsJSON = networkData.optionsJSON,
-                   let data = optionsJSON.data(using: .utf8) {
-                    options = (try? JSONDecoder().decode([String: String].self, from: data)) ?? [:]
-                } else {
-                    options = [:]
-                }
-
-                let labels: [String: String]
-                if let labelsJSON = networkData.labelsJSON,
-                   let data = labelsJSON.data(using: .utf8) {
-                    labels = (try? JSONDecoder().decode([String: String].self, from: data)) ?? [:]
-                } else {
-                    labels = [:]
-                }
-
-                return NetworkMetadata(
-                    id: networkData.id,
-                    name: networkData.name,
-                    driver: networkData.driver,
-                    subnet: networkData.subnet,
-                    gateway: networkData.gateway,
-                    ipRange: networkData.ipRange,  // Load ipRange from database
-                    containers: [],  // Null networks don't track containers
-                    created: networkData.createdAt,
-                    options: options,
-                    labels: labels,
-                    isDefault: networkData.isDefault
-                )
+                return NetworkMetadata(persisted: network)
             } catch {
                 logger.error("Failed to load null network", metadata: ["id": "\(id)", "error": "\(error)"])
                 return nil
@@ -597,16 +642,8 @@ public actor NetworkManager {
             networks.append(contentsOf: await backend.listNetworks())
         }
 
-        if let lister = bridgeNetworkLister {
+        for lister in networkListers {
             networks.append(contentsOf: try await lister.listNetworks())
-        }
-
-        // Add null driver networks from StateStore
-        let nullNetworkIDs = networkDrivers.filter { $0.value == "null" }.keys
-        for networkID in nullNetworkIDs {
-            if let network = await getNetwork(id: networkID) {
-                networks.append(network)
-            }
         }
 
         return networks

--- a/Sources/ContainerBridge/OverlayFS/OverlayFSMounter.swift
+++ b/Sources/ContainerBridge/OverlayFS/OverlayFSMounter.swift
@@ -24,10 +24,20 @@ public struct OverlayFSMounter: Sendable {
     /// - Writable block device (for upper/work directories)
     /// - Layer block devices (read-only EXT4 filesystems)
     ///
-    /// Device layout in guest:
+    /// Device layout in guest, as the virtio-blk allocator happens to assign it:
     /// - /dev/vda: initfs (vminit image, read-only, created by VZVirtualMachineManager)
     /// - /dev/vdb: writable.ext4 (contains upper/ and work/ subdirectories, read-write)
     /// - /dev/vdc onwards: layer0.ext4, layer1.ext4, etc. (read-only layers)
+    /// - then whatever `additionalMounts` carries, which includes named-volume block devices
+    ///
+    /// **The guest does not depend on those positions and must not be made to.** Each image is
+    /// formatted with an `ArcaBlockDeviceRole` in its ext4 volume label, and
+    /// `ArcaBoot.prepareOverlayFS` classifies devices by that label alone. What the guest does
+    /// still take from this order is the *relative* order of the layer devices among
+    /// themselves: they are attached bottom-to-top here, the allocator assigns letters in
+    /// attach order, and the guest sorts the labelled layer devices by name to recover the
+    /// stack. Roles are named; order within a role is positional, because a cached
+    /// `layer.ext4` is shared between images and cannot carry an index of its own.
     ///
     /// Mount order is critical:
     /// - First mount is used by LinuxContainer as the rootfs mount
@@ -119,36 +129,11 @@ public struct OverlayFSMounter: Sendable {
         return mounts
     }
 
-    /// Get the writable device path in guest
-    ///
-    /// - Returns: Block device path for writable filesystem (/dev/vdb)
-    public static var writableDevicePath: String {
-        return "/dev/vdb"
-    }
-
-    /// Get mount path for writable filesystem in guest
-    ///
-    /// - Returns: Path where writable device is mounted
-    public static var writableMountPath: String {
-        return "/mnt/writable"
-    }
-
-    /// Get the layer block device paths in guest
-    ///
-    /// Returns the device paths that the guest will see for each layer.
-    /// Block devices start at /dev/vdc (after writable device at /dev/vdb).
-    ///
-    /// - Parameter layerCount: Number of layer block devices attached
-    /// - Returns: Array of block device paths in guest (e.g., ["/dev/vdc", "/dev/vdd", ...])
-    public func buildBlockDevicePaths(layerCount: Int) -> [String] {
-        var blockDevices: [String] = []
-        for i in 0..<layerCount {
-            // Start at 'c' (99) since vdb is writable device
-            let deviceChar = Character(UnicodeScalar(99 + i)!)  // 99 = 'c'
-            blockDevices.append("/dev/vd\(deviceChar)")
-        }
-        return blockDevices
-    }
+    // Removed with the move to labelled devices: `writableDevicePath` (/dev/vdb),
+    // `writableMountPath` and `buildBlockDevicePaths(layerCount:)`. All three computed a guest
+    // device path from a position or a count, which is the inference this change exists to
+    // delete, and none of them had a call site. Keeping them would leave the defect one
+    // `buildBlockDevicePaths` call away from returning.
 
     /// Create writable EXT4 filesystem for upper/work directories
     ///
@@ -176,10 +161,15 @@ public struct OverlayFSMounter: Sendable {
 
         // Create EXT4 filesystem using Apple's ContainerizationEXT4 framework
         // This is the same method used for creating temp-rootfs.ext4
+        //
+        // The volume label is how vminitd finds this device. It no longer assumes /dev/vdb:
+        // it scans every virtio-blk device and mounts the one labelled `arca.writable` at
+        // /mnt/writable. See ArcaBlockDeviceRole.
         let sizeBytes = UInt64(sizeMB) * 1024 * 1024  // Convert MB to bytes
         let formatter = try ContainerizationEXT4.EXT4.Formatter(
             FilePath(path),
-            minDiskSize: sizeBytes
+            minDiskSize: sizeBytes,
+            volumeLabel: ArcaBlockDeviceRole.overlayWritable.volumeLabel
         )
         try formatter.close()
 

--- a/Sources/ContainerBridge/OverlayFS/OverlayFSUnpacker.swift
+++ b/Sources/ContainerBridge/OverlayFS/OverlayFSUnpacker.swift
@@ -8,7 +8,9 @@ import ContainerizationOCI
 /// Arca-specific OverlayFS unpacker with layer caching and database integration
 ///
 /// This wrapper extends Apple's Containerization framework with:
-/// - Layer caching at ~/.arca/layers/{digest}/layer.ext4
+/// - Layer caching at {layerCachePath}/{digest}/layer.ext4 -- the path is this
+///   type's own init parameter, and it is `<state-root>/layers` under
+///   `arca-engine`, `~/.arca/layers` only under `ArcaDaemon`
 /// - Database integration for cache tracking
 /// - Parallel layer unpacking for performance
 ///

--- a/Sources/ContainerBridge/StateStore.swift
+++ b/Sources/ContainerBridge/StateStore.swift
@@ -704,8 +704,9 @@ public actor StateStore {
         ])
     }
 
-    /// Load all networks from database
-    public func loadAllNetworks() throws -> [(
+    /// One network as it is stored. Named so that the callers which map it to
+    /// `NetworkMetadata` can say what they take without restating eleven fields.
+    public typealias PersistedNetwork = (
         id: String,
         name: String,
         driver: String,
@@ -717,7 +718,10 @@ public actor StateStore {
         optionsJSON: String?,
         labelsJSON: String?,
         isDefault: Bool
-    )] {
+    )
+
+    /// Load all networks from database
+    public func loadAllNetworks() throws -> [PersistedNetwork] {
         var result: [(
             id: String, name: String, driver: String, scope: String,
             createdAt: Date, subnet: String, gateway: String,

--- a/Sources/ContainerBridge/WireGuardNetworkBackend.swift
+++ b/Sources/ContainerBridge/WireGuardNetworkBackend.swift
@@ -947,36 +947,12 @@ public actor WireGuardNetworkBackend {
         )
     }
 
-    /// Get container attachments for a network
-    public func getNetworkAttachments(networkID: String) async throws -> [String: NetworkAttachment] {
-        let attachments = try await stateStore.loadAttachmentsForNetwork(networkID: networkID)
-        var result: [String: NetworkAttachment] = [:]
-
-        for attachment in attachments {
-            result[attachment.containerID] = NetworkAttachment(
-                networkID: networkID,
-                ip: attachment.ipAddress,
-                mac: attachment.macAddress,
-                aliases: attachment.aliases
-            )
-        }
-
-        return result
-    }
-
-    /// Get networks for a container
-    public func getContainerNetworks(containerID: String) async throws -> [NetworkMetadata] {
-        let networkIDs = try await stateStore.getContainerNetworks(containerID: containerID)
-        var networks: [NetworkMetadata] = []
-
-        for networkID in networkIDs {
-            if let network = try await loadNetwork(id: networkID) {
-                networks.append(network)
-            }
-        }
-
-        return networks
-    }
+    // Attachment reads are not here: `StoredNetworkAttachments` in
+    // NetworkManager.swift owns them. They read `network_attachments` and no
+    // in-memory backend state, so routing them through a backend that only
+    // `NetworkManager.initialize()` can install cost the ability to test them
+    // and bought nothing. Do not add a second copy here: two answers to "who
+    // is attached" is what `docker network prune` would then delete on.
 
     /// Clean up in-memory network state for a stopped/exited container
     /// Called when container stops to ensure state is clean for restart

--- a/Sources/ContainerBridge/WireGuardNetworkBackend.swift
+++ b/Sources/ContainerBridge/WireGuardNetworkBackend.swift
@@ -22,6 +22,11 @@ import ArcaIP
 /// - ~1ms latency (kernel-space routing)
 /// - Single kernel-space routing decision per packet
 /// - No vsock relay overhead (direct vmnet UDP)
+/// The bridge-network source `NetworkManager.listNetworks()` reads in
+/// production. The conformance is empty: `listNetworks()` below already has the
+/// signature the protocol asks for.
+extension WireGuardNetworkBackend: BridgeNetworkLister {}
+
 public actor WireGuardNetworkBackend {
     private let logger: Logger
     private let stateStore: StateStore

--- a/Sources/ContainerBridge/WireGuardNetworkBackend.swift
+++ b/Sources/ContainerBridge/WireGuardNetworkBackend.swift
@@ -22,11 +22,6 @@ import ArcaIP
 /// - ~1ms latency (kernel-space routing)
 /// - Single kernel-space routing decision per packet
 /// - No vsock relay overhead (direct vmnet UDP)
-/// The bridge-network source `NetworkManager.listNetworks()` reads in
-/// production. The conformance is empty: `listNetworks()` below already has the
-/// signature the protocol asks for.
-extension WireGuardNetworkBackend: BridgeNetworkLister {}
-
 public actor WireGuardNetworkBackend {
     private let logger: Logger
     private let stateStore: StateStore
@@ -1147,3 +1142,8 @@ public actor WireGuardNetworkBackend {
         return block.contains(address)
     }
 }
+
+/// The bridge-network source `NetworkManager.listNetworks()` reads in
+/// production. The conformance is empty: `listNetworks()` above already has the
+/// signature the protocol asks for.
+extension WireGuardNetworkBackend: NetworkLister {}

--- a/Sources/DockerAPI/Handlers/ContainerHandlers.swift
+++ b/Sources/DockerAPI/Handlers/ContainerHandlers.swift
@@ -69,7 +69,11 @@ public struct ContainerHandlers: Sendable {
 
         do {
             // Get containers from ContainerManager
-            var containers = try await containerManager.listContainers(all: all, filters: filters)
+            var containers = try await containerManager.listContainers(
+                all: all,
+                filters: filters,
+                includeInternal: ContainerManager.internalContainersRequested(in: filters)
+            )
 
             // Apply limit if specified
             if let limit = limit, limit > 0 {
@@ -1564,7 +1568,7 @@ public struct ContainerHandlers: Sendable {
 
         // Get all containers (including stopped ones)
         do {
-            let containers = try await containerManager.listContainers(all: true)
+            let containers = try await containerManager.listContainers(all: true, includeInternal: false)
 
             // Filter for stopped containers (not running)
             for container in containers {

--- a/Sources/DockerAPI/Handlers/ImageHandlers.swift
+++ b/Sources/DockerAPI/Handlers/ImageHandlers.swift
@@ -387,7 +387,7 @@ public struct ImageHandlers: Sendable {
             let danglingOnly = filters?["dangling"]?.first == "true" || filters?["dangling"]?.first == "1"
 
             // Get all container image IDs to check usage
-            let containers = try await containerManager.listContainers(all: true)
+            let containers = try await containerManager.listContainers(all: true, includeInternal: false)
             let usedImageIDs = Set(containers.map { $0.imageID })
 
             logger.debug("Image prune scan", metadata: [

--- a/Sources/DockerAPI/Handlers/NetworkHandlers.swift
+++ b/Sources/DockerAPI/Handlers/NetworkHandlers.swift
@@ -39,9 +39,13 @@ public struct NetworkHandlers: Sendable {
             "filters": "\(filters)"
         ])
 
-        // networkManager.listNetworks() doesn't throw - it returns an array directly
-        // No failure case for listing (empty array on no networks)
-        let allNetworks = await networkManager.listNetworks()
+        let allNetworks: [NetworkMetadata]
+        do {
+            allNetworks = try await networkManager.listNetworks()
+        } catch {
+            logger.error("Failed to list networks", metadata: ["error": "\(error)"])
+            return .failure(NetworkError.listFailed(errorDescription(error)))
+        }
 
         // Apply sync filters first
         var filteredMetadata = applyFilters(allNetworks, filters: filters)
@@ -99,9 +103,18 @@ public struct NetworkHandlers: Sendable {
         }
 
         // Try resolving as name or ID
-        let resolvedID = await networkManager.resolveNetworkID(id) ?? id
+        let resolvedID: String
+        do {
+            resolvedID = try await networkManager.resolveNetworkID(id) ?? id
+        } catch {
+            logger.error("Failed to resolve network", metadata: [
+                "id": "\(id)",
+                "error": "\(error)"
+            ])
+            return .failure(NetworkError.inspectFailed(errorDescription(error)))
+        }
 
-        // networkManager methods don't throw - they return optionals
+        // networkManager.getNetwork does not throw - it returns an optional
         // Failure case handled via guard statement
         guard let metadata = await networkManager.getNetwork(id: resolvedID) else {
             return .failure(NetworkError.notFound(id))
@@ -201,7 +214,7 @@ public struct NetworkHandlers: Sendable {
 
         do {
             // Resolve network name or ID to full network ID
-            guard let resolvedID = await networkManager.resolveNetworkID(id) else {
+            guard let resolvedID = try await networkManager.resolveNetworkID(id) else {
                 return .failure(NetworkError.notFound(id))
             }
 
@@ -265,7 +278,7 @@ public struct NetworkHandlers: Sendable {
             }
 
             // Resolve network name or ID to full network ID
-            guard let resolvedNetworkID = await networkManager.resolveNetworkID(networkID) else {
+            guard let resolvedNetworkID = try await networkManager.resolveNetworkID(networkID) else {
                 return .failure(NetworkError.notFound("network \(networkID) not found"))
             }
 
@@ -518,7 +531,13 @@ public struct NetworkHandlers: Sendable {
         }
 
         // Get all networks from NetworkManager
-        let allNetworks = await networkManager.listNetworks()
+        let allNetworks: [NetworkMetadata]
+        do {
+            allNetworks = try await networkManager.listNetworks()
+        } catch {
+            logger.error("Failed to list networks for prune", metadata: ["error": "\(error)"])
+            return .failure(NetworkError.pruneFailed(errorDescription(error)))
+        }
 
         var deletedNetworkNames: [String] = []
 

--- a/Sources/DockerAPI/Handlers/NetworkHandlers.swift
+++ b/Sources/DockerAPI/Handlers/NetworkHandlers.swift
@@ -57,11 +57,24 @@ public struct NetworkHandlers: Sendable {
         var filteredMetadata = applyFilters(allNetworks, filters: filters)
 
         // Apply dangling filter (async - requires checking attachments)
+        //
+        // `dangling` *is* the attachment read: a failure that read as `[:]`
+        // would report every network as dangling, which is the answer that
+        // sends a user to delete networks that are in use.
         if let danglingValues = filters["dangling"], !danglingValues.isEmpty {
             if let dangling = parseBool(danglingValues[0]) {
                 var danglingFiltered: [NetworkMetadata] = []
                 for network in filteredMetadata {
-                    let attachments = await networkManager.getNetworkAttachments(networkID: network.id)
+                    let attachments: [String: NetworkAttachment]
+                    do {
+                        attachments = try await networkManager.getNetworkAttachments(networkID: network.id)
+                    } catch {
+                        logger.error("Failed to read network attachments", metadata: [
+                            "id": "\(network.id)",
+                            "error": "\(error)"
+                        ])
+                        return .failure(NetworkError.listFailed(errorDescription(error)))
+                    }
                     let isDangling = attachments.isEmpty
                     if dangling == isDangling {
                         danglingFiltered.append(network)
@@ -73,8 +86,13 @@ public struct NetworkHandlers: Sendable {
 
         // Convert to Docker API format
         var networks: [Network] = []
-        for metadata in filteredMetadata {
-            networks.append(await convertToDockerNetwork(metadata))
+        do {
+            for metadata in filteredMetadata {
+                networks.append(try await convertToDockerNetwork(metadata))
+            }
+        } catch {
+            logger.error("Failed to read network attachments", metadata: ["error": "\(error)"])
+            return .failure(NetworkError.listFailed(errorDescription(error)))
         }
 
         logger.info("Listed networks", metadata: ["count": "\(networks.count)"])
@@ -125,7 +143,16 @@ public struct NetworkHandlers: Sendable {
         guard let metadata = await networkManager.getNetwork(id: resolvedID) else {
             return .failure(NetworkError.notFound(id))
         }
-        let network = await convertToDockerNetwork(metadata)
+        let network: Network
+        do {
+            network = try await convertToDockerNetwork(metadata)
+        } catch {
+            logger.error("Failed to read network attachments", metadata: [
+                "id": "\(resolvedID)",
+                "error": "\(error)"
+            ])
+            return .failure(NetworkError.inspectFailed(errorDescription(error)))
+        }
 
         logger.info("Inspected network", metadata: [
             "id": "\(network.id)",
@@ -465,7 +492,7 @@ public struct NetworkHandlers: Sendable {
     }
 
     /// Convert NetworkMetadata to Docker API Network format
-    private func convertToDockerNetwork(_ metadata: NetworkMetadata) async -> Network {
+    private func convertToDockerNetwork(_ metadata: NetworkMetadata) async throws -> Network {
         // Format created timestamp as ISO8601
         let iso8601Formatter = ISO8601DateFormatter()
         let createdString = iso8601Formatter.string(from: metadata.created)
@@ -478,7 +505,7 @@ public struct NetworkHandlers: Sendable {
         let ipam = IPAM(driver: "default", config: [ipamConfig])
 
         // Get container attachments for this network
-        let attachments = await networkManager.getNetworkAttachments(networkID: metadata.id)
+        let attachments = try await networkManager.getNetworkAttachments(networkID: metadata.id)
         var containers: [String: NetworkContainer] = [:]
 
         for (containerID, attachment) in attachments {
@@ -553,8 +580,26 @@ public struct NetworkHandlers: Sendable {
                 continue
             }
 
-            // Skip networks with active containers
-            let attachments = await networkManager.getNetworkAttachments(networkID: network.id)
+            // Skip networks with active containers.
+            //
+            // A failure here abandons the whole prune rather than treating the
+            // network as unused: `[:]` and "could not tell" are the same value,
+            // and the difference between them is whether the next few lines
+            // delete a network somebody's containers are on. Networks already
+            // deleted in this pass stay deleted -- each was read successfully
+            // and was genuinely unused -- but the error is what the caller
+            // gets, and their names are not reported. Docker's own prune
+            // reports an error the same way.
+            let attachments: [String: NetworkAttachment]
+            do {
+                attachments = try await networkManager.getNetworkAttachments(networkID: network.id)
+            } catch {
+                logger.error("Failed to read network attachments for prune", metadata: [
+                    "id": "\(network.id)",
+                    "error": "\(error)"
+                ])
+                return .failure(NetworkError.pruneFailed(errorDescription(error)))
+            }
             if !attachments.isEmpty {
                 continue
             }

--- a/Sources/DockerAPI/Handlers/NetworkHandlers.swift
+++ b/Sources/DockerAPI/Handlers/NetworkHandlers.swift
@@ -25,8 +25,14 @@ public struct NetworkHandlers: Sendable {
     }
 
     /// Get error description from Swift errors
+    ///
+    /// `String(describing:)`, not `localizedDescription`: a Swift `enum … :
+    /// Error` carries no localized description, so Foundation renders it as
+    /// "The operation couldn't be completed. (… error N.)". That would reach
+    /// gascan and the CLI as `failed to list networks: <content-free string>`,
+    /// discarding the very signal `listNetworks()` now throws in order to carry.
     private func errorDescription(_ error: Error) -> String {
-        return error.localizedDescription
+        return String(describing: error)
     }
 
     /// Handle GET /networks

--- a/Sources/DockerAPI/Handlers/SystemHandlers.swift
+++ b/Sources/DockerAPI/Handlers/SystemHandlers.swift
@@ -67,7 +67,7 @@ public struct SystemHandlers: Sendable {
         let processInfo = ProcessInfo.processInfo
 
         // Get actual container counts
-        let containers = (try? await containerManager.listContainers(all: true, filters: [:])) ?? []
+        let containers = (try? await containerManager.listContainers(all: true, filters: [:], includeInternal: false)) ?? []
         let totalContainers = containers.count
         let runningContainers = containers.filter { $0.state == "running" }.count
         let pausedContainers = containers.filter { $0.state == "paused" }.count

--- a/Sources/arca-engine/ArcaEngineCommand.swift
+++ b/Sources/arca-engine/ArcaEngineCommand.swift
@@ -289,7 +289,7 @@ struct ServeCommand: AsyncParsableCommand {
         // and is recorded as the follow-up it is.
         //
         // Until then the mutation that matters here -- changing the line below
-        // back to `engine.onClose` -- leaves `swift test` at 151 passing, and
+        // back to `engine.onClose` -- leaves `swift test` at 157 passing, and
         // Gas Can's live tier is the only thing that catches it. Every rate
         // above is that tier's output.
         let quiesced = group.next().makePromise(of: Void.self)
@@ -517,29 +517,3 @@ struct ServeCommand: AsyncParsableCommand {
     }
 }
 
-/// Counts shutdown signals, and answers whether any has arrived.
-///
-/// **Locked rather than queue-confined, and it used to be the latter.** Both
-/// signal sources still share one serial queue, but `serve()` now also reads
-/// this from a `whenComplete` on the listening channel's close, which runs on a
-/// NIO event loop. Two threads, so the confinement argument no longer holds and
-/// a lock replaces it rather than a comment claiming a discipline the code no
-/// longer keeps.
-private final class ShutdownRequests: Sendable {
-    private let seen = NIOLockedValueBox(0)
-
-    /// Records a request and answers whether it was the first.
-    func recordAndReportFirst() -> Bool {
-        seen.withLockedValue { seen in
-            seen += 1
-            return seen == 1
-        }
-    }
-
-    /// Whether any signal has been recorded.
-    ///
-    /// Read to tell a listening socket that closed BECAUSE of a shutdown from
-    /// one that closed on its own. The handler records before it initiates, so
-    /// by the time a graceful close reaches the observer this is already true.
-    var anyRecorded: Bool { seen.withLockedValue { $0 > 0 } }
-}

--- a/Sources/arca-engine/ArcaEngineCommand.swift
+++ b/Sources/arca-engine/ArcaEngineCommand.swift
@@ -209,6 +209,11 @@ struct ServeCommand: AsyncParsableCommand {
     /// swapping the async `shutdownGracefully()` for a blocking
     /// `syncShutdownGracefully()` on a Dispatch thread were each measured and
     /// each still crashed.
+    ///
+    /// **That fix was necessary and it was not sufficient, because it released
+    /// the wrong objects.** Scoping the server here says nothing about the
+    /// connections the server ACCEPTED, and those are what `quiesced` below is
+    /// about.
     private func serve(
         service: SandboxEngineService,
         group: MultiThreadedEventLoopGroup,
@@ -221,15 +226,105 @@ struct ServeCommand: AsyncParsableCommand {
         )
         logger.info("engine listening", metadata: ["socket": "\(socketPath)"])
 
+        // **What this waits for is every ACCEPTED connection to have gone, and
+        // that is a different event from the listening socket closing.** It
+        // used to wait for `engine.onClose`, which is the LISTENING channel's
+        // `closeFuture`, and `ServerQuiescingHelper` closes that immediately --
+        // before the connections it has just asked to quiesce have finished
+        // doing so. So `run()` shut the event-loop group down underneath live
+        // channels: each one's `closeFuture` callback then tried to schedule
+        // `ChannelCollector.channelRemoved` on a loop that had gone, which NIO
+        // reports as `Cannot schedule tasks on an EventLoop that has already
+        // shut down`; the collector therefore never reached
+        // `shutdownCompleted()`, and deallocated still holding the promise it
+        // makes at `QuiescingHelper.swift:141` -- `Fatal error: leaking
+        // promise`, `Trace/BPT trap: 5`, exit 133.
+        //
+        // MEASURED with Gas Can's `shutdown.rs`, which stops 32 engines per
+        // figure because at this rate a single clean shutdown is worth nothing.
+        // Two binaries built from this file, run interleaved rather than
+        // A-then-B: awaiting `onClose`, **6 crashes in 192**; awaiting
+        // `quiesced`, **0 in 192**. The container case, 32 engines each:
+        // **12/32 (38%)** against `onClose`.
+        //
+        // **The defect never needed a container.** `docs/status/START-HERE.md`
+        // recorded it as happening "once containers have been created", and
+        // that was a correlate: an engine that never created one still crashed
+        // 1 time in 96. A container widens the window -- more accepted traffic,
+        // more to tear down -- it does not change the bug.
+        //
+        // **Handing `initiateGracefulShutdown` a promise rather than `nil` is a
+        // consequence of the wait and NOT the fix**, and that was measured
+        // rather than argued. A third binary that passes `quiesced` in and
+        // still awaits `onClose` -- the promise made, never waited on -- runs at
+        // **22/32 (69%)**, WORSE than the original. The crash does not go
+        // quiet, it changes address: the leaked promise stops being the
+        // collector's at `QuiescingHelper.swift:141` and becomes this
+        // function's own, which the trace names as `ArcaEngineCommand.swift`.
+        // The `Cannot schedule tasks` line is unchanged throughout, and that is
+        // the tell -- the group is still going down under live channels, and
+        // only the bookkeeping moved.
+        //
+        // **NOTHING IN THIS REPOSITORY CAN PROVE ANY OF IT, and a test was
+        // attempted rather than assumed away.** The claim is about two futures
+        // of a running server with an accepted connection outliving its
+        // listener, and no unit test can hold one there: a connection
+        // grpc-swift has finished configuring is closed by the same GOAWAY
+        // quiescing sends, and a raw socket it has not finished configuring
+        // cannot be observed to have been accepted -- so either fixture decides
+        // the assertion by a race. `serve()` is private and needs a real
+        // process besides. Gas Can's live tier is the instrument, and every
+        // rate above is its output.
+        let quiesced = group.next().makePromise(of: Void.self)
+
         // Held for the whole run: a DispatchSourceSignal stops delivering the
         // moment it is deallocated, so a source that is not kept alive is a
         // handler that silently never fires. Cancelling them here also drops
         // the last references these closures hold to the engine.
-        let signals = Self.installShutdownHandler(logger: logger, for: engine)
+        let signals = Self.installShutdownHandler(
+            logger: logger,
+            for: engine,
+            quiesced: quiesced
+        )
         defer { signals.forEach { $0.cancel() } }
 
-        try await engine.onClose.get()
+        try await quiesced.futureResult.get()
         try await engine.shutDown()
+    }
+
+    /// How long a graceful shutdown waits for accepted connections to drain
+    /// before stopping anyway.
+    ///
+    /// Ten seconds is chosen against the two clocks that already bound this
+    /// process from outside, so that the engine is the one that decides: Gas
+    /// Can's live tier gives a stopping engine 30s before it calls the
+    /// supervisor stuck (`LiveEngine::stop`), and launchd's `ExitTimeOut`
+    /// defaults to 20s before it escalates to SIGKILL. A drain that has not
+    /// finished in ten has met something that will not finish, and being
+    /// SIGKILLed instead would run none of the cleanup below.
+    ///
+    /// **Nothing measures this number**, and it is a policy rather than a
+    /// finding: an ordinary drain here completes in milliseconds.
+    private static let shutdownGrace = TimeAmount.seconds(10)
+
+    /// Gives up the socket path and ends the process.
+    ///
+    /// Both callers are past the point where returning is possible -- one is
+    /// an operator's second signal, the other a drain that ran out of grace --
+    /// and both must leave the path as `shutDown()` would.
+    private static func releaseAndExit(_ engine: EngineServer, logger: Logger) -> Never {
+        do {
+            try engine.releaseSocketPath()
+        } catch {
+            // Reported rather than dropped: whoever starts the next engine on
+            // this path has to reason about what is left there, and this is the
+            // only moment anything knows.
+            logger.error("could not release the socket path", metadata: ["error": "\(error)"])
+        }
+        // Qualified: bare `exit` inside a `ParsableCommand` resolves to
+        // ArgumentParser's own `exit(withError:)` instance method, and the
+        // compiler rejects it here rather than quietly calling something else.
+        Foundation.exit(EXIT_SUCCESS)
     }
 
     /// Turns SIGTERM and SIGINT into a graceful close, and a repeat of either
@@ -249,9 +344,18 @@ struct ServeCommand: AsyncParsableCommand {
     /// RPCs, and a client holding a stream open can hold the engine open with
     /// it. Without a second signal that forces the issue, "handles SIGTERM"
     /// would be true and "can be stopped" would not.
+    ///
+    /// **That paragraph was written before the code did any of it, and it is
+    /// true for the first time now.** Until `serve()` started waiting on
+    /// `quiesced`, one signal ended the process whatever a client was doing:
+    /// the wait was on the LISTENING channel's close, which
+    /// `ServerQuiescingHelper` performs synchronously, so nothing ever waited
+    /// for an in-flight RPC and the second signal had nothing left to force.
+    /// The wait is real now, so the escalation has to be.
     private static func installShutdownHandler(
         logger: Logger,
-        for engine: EngineServer
+        for engine: EngineServer,
+        quiesced: EventLoopPromise<Void>
     ) -> [DispatchSourceSignal] {
         // One serial queue shared by both sources, so the two handlers can
         // never run concurrently and `asked` needs no lock of its own.
@@ -263,10 +367,59 @@ struct ServeCommand: AsyncParsableCommand {
             source.setEventHandler {
                 if asked.recordAndReportFirst() {
                     logger.info("shutting down gracefully", metadata: ["signal": "\(number)"])
-                    engine.server.initiateGracefulShutdown(promise: nil)
+                    engine.server.initiateGracefulShutdown(promise: quiesced)
+
+                    // **The drain is bounded, and it has to be, because
+                    // quiescing cannot close every connection it asks to
+                    // close.** `ServerQuiescingHelper` sends each accepted
+                    // channel a `ChannelShouldQuiesceEvent`; grpc-swift turns
+                    // that into a GOAWAY and closes the connection once its
+                    // streams finish -- but only for a connection whose
+                    // protocol it has finished negotiating. One that has been
+                    // accepted and has sent nothing yet is in no protocol at
+                    // all, nothing closes it, and the drain waits on it for as
+                    // long as the peer cares to hold the socket.
+                    //
+                    // MEASURED, and it is not theoretical. A raw socket
+                    // connected to the engine and left silent held the first
+                    // SIGTERM open past 5s, **5 times out of 5**. It also
+                    // reached the live tier by accident: with the drain
+                    // unbounded,
+                    // `shutdown::the_engine_exits_cleanly_with_a_client_channel_still_open`
+                    // hung past its 30s bound once in roughly 200 engines --
+                    // a tonic channel whose HTTP/2 preface had not been
+                    // exchanged when the signal landed is exactly that state.
+                    //
+                    // So "handles SIGTERM" must not depend on a peer being
+                    // well behaved. The escalation below is the operator's
+                    // lever and this is the one that needs no operator.
+                    let forced = quiesced.futureResult.eventLoop.scheduleTask(in: shutdownGrace) {
+                        logger.notice(
+                            "connections did not drain within the grace period; closing anyway",
+                            metadata: ["grace": "\(shutdownGrace)"]
+                        )
+                        releaseAndExit(engine, logger: logger)
+                    }
+                    // Same event loop as the promise, so a drain that finishes
+                    // first and this cancellation are ordered against each
+                    // other rather than racing.
+                    quiesced.futureResult.whenComplete { _ in forced.cancel() }
                 } else {
                     logger.notice("closing immediately", metadata: ["signal": "\(number)"])
                     engine.server.close(promise: nil)
+
+                    // **Ending the process here rather than letting `serve()`
+                    // return, because what is being escalated past is the wait
+                    // for accepted connections to close.** Closing the
+                    // listening channel does not close them -- NIO's accepted
+                    // channels outlive their listener -- so returning would
+                    // leave `quiesced` pending for exactly as long as the
+                    // client holds its connection, and completing `quiesced`
+                    // instead would shut the event-loop group down with those
+                    // channels still registered, which is the crash the
+                    // graceful path exists to avoid. Nothing after this needs
+                    // the group.
+                    releaseAndExit(engine, logger: logger)
                 }
             }
             source.resume()

--- a/Sources/arca-engine/ArcaEngineCommand.swift
+++ b/Sources/arca-engine/ArcaEngineCommand.swift
@@ -19,12 +19,33 @@ struct ArcaEngineCommand: AsyncParsableCommand {
     @Option(name: .customLong("state-root"), help: "Directory holding engine state.")
     var stateRoot: String
 
+    // Read-only inputs, separate from --state-root and from each other. None of
+    // the three is defaulted and none falls back to ~/.arca: a default is how a
+    // process silently ends up pointed at another product's state.
+    @Option(name: .customLong("kernel-path"), help: "Path of the Linux kernel image to boot sandboxes with.")
+    var kernelPath: String
+
+    @Option(name: .customLong("vminit-layout"), help: "Directory holding the arca-vminit OCI layout.")
+    var vminitLayout: String
+
     @Option(name: .customLong("log-level"), help: "trace, debug, info, notice, warning, error.")
     var logLevel: String = "info"
 
     func run() async throws {
         var logger = Logger(label: "arca-engine")
         logger.logLevel = Logger.Level(rawValue: logLevel) ?? .info
+
+        // First, and before anything is created or constructed: a bad input
+        // must cost a clear error naming which option and which path, not a
+        // half-initialised engine that answers unsupported_capability for
+        // everything that matters. This runs ahead of the socket directory too,
+        // so a refusal leaves nothing behind on disk.
+        let inputs = EngineInputs(
+            stateRoot: URL(fileURLWithPath: stateRoot),
+            kernelPath: URL(fileURLWithPath: kernelPath),
+            vminitLayout: URL(fileURLWithPath: vminitLayout)
+        )
+        try validateEngineInputs(inputs)
 
         // The socket's mode is set to 0600 immediately after bind (EngineServer),
         // but bind returns an already-listening server, so there is a brief
@@ -38,7 +59,9 @@ struct ArcaEngineCommand: AsyncParsableCommand {
         // suite stay green while the engine's real image-store root changed:
         // TestSupport held a hand-copy of these lines, so the tests exercised a
         // replica of the wiring rather than the wiring. See EnginePaths.
-        let paths = EnginePaths(stateRoot: URL(fileURLWithPath: stateRoot))
+        // The kernel is not among them: it is a read-only input the engine is
+        // handed, not state the engine owns.
+        let paths = EnginePaths(stateRoot: inputs.stateRoot)
 
         // initialize() is deliberately never called on any manager here, and
         // the reason it cannot be is worth stating in full, because it decides
@@ -71,9 +94,10 @@ struct ArcaEngineCommand: AsyncParsableCommand {
         //
         // So Inspect and ListResources answer unsupported_capability rather
         // than "absent" and "nothing here" -- see the notes on each in
-        // SandboxEngineService. A later milestone gives ContainerBridge a
-        // read-only load path that neither starts a VM nor writes, calls it
-        // here behind a --kernel-path option, and restores both methods.
+        // SandboxEngineService. --kernel-path and --vminit-layout now name the
+        // first two of those three preconditions, and a later task in this
+        // milestone calls initialize() once the third is in hand and restores
+        // both methods.
         //
         // The managers are still constructed and handed to the service: the
         // dependency edge they create is a property gascan's release gate
@@ -88,14 +112,14 @@ struct ArcaEngineCommand: AsyncParsableCommand {
         )
         let containerManager = ContainerManager(
             imageManager: imageManager,
-            kernelPath: paths.kernel.path,
+            kernelPath: inputs.kernelPath.path,
             imageStoreRoot: paths.imageStoreRoot,
             layerCachePath: paths.layerCache,
             stateStore: stateStore,
             logger: logger
         )
         let config = ArcaConfig(
-            kernelPath: paths.kernel.path,
+            kernelPath: inputs.kernelPath.path,
             socketPath: paths.socket.path,
             logLevel: logLevel
         )

--- a/Sources/arca-engine/ArcaEngineCommand.swift
+++ b/Sources/arca-engine/ArcaEngineCommand.swift
@@ -63,45 +63,19 @@ struct ArcaEngineCommand: AsyncParsableCommand {
         // handed, not state the engine owns.
         let paths = EnginePaths(stateRoot: inputs.stateRoot)
 
-        // initialize() is deliberately never called on any manager here, and
-        // the reason it cannot be is worth stating in full, because it decides
-        // which RPCs this build may implement.
+        // Every manager below is rooted in the state root this engine owns, and
+        // that ownership is the design: a state root shared with a live
+        // ArcaDaemon is the hazard EngineInputs records, and an image store
+        // shared with it is the one EnginePaths records. Nothing here is
+        // derived a second way.
         //
-        // ContainerManager.initialize() requires the kernel file to exist on
-        // disk, an "arca-vminit:latest" image already loaded by ArcaDaemon, and
-        // a live Containerization.VmnetNetwork (ContainerManager.swift:219-244).
-        // Requiring all three would make this engine refuse to start anywhere a
-        // kernel or vminit image is absent, which defeats the point of this
-        // milestone -- a Rust client dialling a real, running engine.
-        //
-        // Its second half is not merely unavailable, it is unsafe here.
-        // loadPersistedState() marks every container whose persisted status is
-        // "running" as exited with code 137 and writes that back to the
-        // StateStore (ContainerManager.swift:316-338). Against a --state-root
-        // that a live ArcaDaemon is also using -- ~/.arca being the natural
-        // choice -- this engine would declare the daemon's running containers
-        // dead. NetworkManager.initialize() is likewise a mutation: it ends in
-        // createDefaultNetworks(), which creates "bridge", "host" (vmnet
-        // driver) and "none" (NetworkManager.swift:87-88).
-        //
-        // The consequence is total, not restart-scoped, and not confined to
-        // containers. The only two writers of ContainerManager.containers are
-        // initialize()'s restore loop and createContainer, which this build
-        // answers unsupported_capability; VolumeManager.volumes is loaded only
-        // from initialize(); NetworkManager.listNetworks() reads two backends
-        // that initialize() is the sole populator of. All three are empty for
-        // the life of the process, under every input.
-        //
-        // So Inspect and ListResources answer unsupported_capability rather
-        // than "absent" and "nothing here" -- see the notes on each in
-        // SandboxEngineService. --kernel-path and --vminit-layout now name the
-        // first two of those three preconditions, and a later task in this
-        // milestone calls initialize() once the third is in hand and restores
-        // both methods.
-        //
-        // The managers are still constructed and handed to the service: the
-        // dependency edge they create is a property gascan's release gate
-        // measures. See the note on SandboxEngineService's stored properties.
+        // initialize() is still not called on any manager. It needs a live
+        // Containerization.VmnetNetwork alongside the kernel and the vminit
+        // image (ContainerBridge/ContainerManager.swift:246-278), and until it
+        // is called, Inspect and ListResources answer unsupported_capability --
+        // see the notes on each in SandboxEngineService. The managers are
+        // constructed and handed to the service regardless: the dependency edge
+        // they create is a property gascan's release gate measures.
         let stateStore = try StateStore(
             path: paths.stateDatabase.path,
             logger: logger
@@ -110,6 +84,18 @@ struct ArcaEngineCommand: AsyncParsableCommand {
             logger: logger,
             imageStorePath: paths.imageStoreRoot
         )
+
+        // Before any manager that resolves an init image. This is the second of
+        // initialize()'s three preconditions, and the engine now satisfies it
+        // itself rather than inheriting an image ArcaDaemon happened to load
+        // into the shared store.
+        _ = try await loadVminit(
+            from: inputs.vminitLayout,
+            into: imageManager,
+            stateRoot: inputs.stateRoot,
+            logger: logger
+        )
+
         let containerManager = ContainerManager(
             imageManager: imageManager,
             kernelPath: inputs.kernelPath.path,

--- a/Sources/arca-engine/ArcaEngineCommand.swift
+++ b/Sources/arca-engine/ArcaEngineCommand.swift
@@ -3,6 +3,7 @@ import ArgumentParser
 import ContainerBridge
 import Foundation
 import Logging
+import NIOConcurrencyHelpers
 import NIOCore
 import NIOPosix
 
@@ -265,28 +266,77 @@ struct ServeCommand: AsyncParsableCommand {
         // the tell -- the group is still going down under live channels, and
         // only the bookkeeping moved.
         //
-        // **NOTHING IN THIS REPOSITORY CAN PROVE ANY OF IT, and a test was
-        // attempted rather than assumed away.** The claim is about two futures
-        // of a running server with an accepted connection outliving its
-        // listener, and no unit test can hold one there: a connection
-        // grpc-swift has finished configuring is closed by the same GOAWAY
-        // quiescing sends, and a raw socket it has not finished configuring
-        // cannot be observed to have been accepted -- so either fixture decides
-        // the assertion by a race. `serve()` is private and needs a real
-        // process besides. Gas Can's live tier is the instrument, and every
-        // rate above is its output.
+        // **A PREVIOUS VERSION OF THIS COMMENT SAID "NOTHING IN THIS
+        // REPOSITORY CAN PROVE ANY OF IT". THAT WAS FALSE AND A REVIEWER
+        // DISPROVED IT BY WRITING THE TEST.** The argument given was that a
+        // raw socket cannot be observed to have been accepted, so the fixture
+        // would decide the assertion by a race. The race is real but it is
+        // SETUP, not assertion, and it fails safe: an unaccepted connection
+        // lets the close drain immediately, so the pending assertion goes red
+        // rather than falsely green. Measured 20 runs, 20 passes, on a
+        // single-threaded loop with `EngineServer.start` and
+        // `SandboxEngineService.forTesting()`, which `EngineServerTests`
+        // already uses.
+        //
+        // The accurate statement is narrower. **The PREMISE is provable here
+        // and is not yet pinned**: that the listener closes while an accepted
+        // connection is still open, so `onClose` completes and `quiesced` does
+        // not. **The CALL SITE is not**, and privacy is not what stops it --
+        // `EngineProcess.swift` already spawns this binary to prove call sites.
+        // `run()` reaches `networkManager.initialize()`, which constructs a real
+        // `VmnetNetwork`, so a test of THIS function needs an entitlement and a
+        // host vmnet. Moving the wait into `ArcaEngine` would remove even that,
+        // and is recorded as the follow-up it is.
+        //
+        // Until then the mutation that matters here -- changing the line below
+        // back to `engine.onClose` -- leaves `swift test` at 151 passing, and
+        // Gas Can's live tier is the only thing that catches it. Every rate
+        // above is that tier's output.
         let quiesced = group.next().makePromise(of: Void.self)
 
         // Held for the whole run: a DispatchSourceSignal stops delivering the
         // moment it is deallocated, so a source that is not kept alive is a
         // handler that silently never fires. Cancelling them here also drops
         // the last references these closures hold to the engine.
+        let asked = ShutdownRequests()
         let signals = Self.installShutdownHandler(
             logger: logger,
             for: engine,
-            quiesced: quiesced
+            quiesced: quiesced,
+            asked: asked
         )
         defer { signals.forEach { $0.cancel() } }
+
+        // **The only thing that completes `quiesced` is the first signal, so a
+        // listening socket that closes for any OTHER reason would leave this
+        // function waiting on a promise nothing will ever fulfil.** That is a
+        // regression this change introduced and it is worse than what it
+        // replaced: awaiting `onClose` at least ended the process, whereas
+        // waiting forever holds the `flock` on the lockfile, which is precisely
+        // what makes `EngineServer.start` refuse the path to a successor. An
+        // engine that cannot serve and cannot be replaced is the worst of the
+        // three outcomes.
+        //
+        // The distinction is "did anything ask for this", not "did the listener
+        // close" -- the graceful path closes the listener itself, by design,
+        // and `asked` is recorded before that close is initiated, so a shutdown
+        // that was asked for always finds this true.
+        //
+        // **Reachability is unmeasured.** Within this function only the two
+        // handlers close the listener, and `EngineServer.start` configures no
+        // idle timeout; the case needs an unrecoverable failure in the server
+        // channel itself. Recorded as a guard whose trigger nothing drives.
+        engine.onClose.whenComplete { _ in
+            guard !asked.anyRecorded else { return }
+            logger.error(
+                """
+                the listening socket closed with no shutdown requested; the engine can no \
+                longer serve and nothing will complete its drain
+                """,
+                metadata: ["socket": "\(socketPath)"]
+            )
+            Self.releaseAndExit(engine, logger: logger, status: EXIT_FAILURE)
+        }
 
         try await quiesced.futureResult.get()
         try await engine.shutDown()
@@ -307,12 +357,29 @@ struct ServeCommand: AsyncParsableCommand {
     /// finding: an ordinary drain here completes in milliseconds.
     private static let shutdownGrace = TimeAmount.seconds(10)
 
-    /// Gives up the socket path and ends the process.
+    /// Gives up the socket path and ends the process with `status`.
     ///
-    /// Both callers are past the point where returning is possible -- one is
-    /// an operator's second signal, the other a drain that ran out of grace --
-    /// and both must leave the path as `shutDown()` would.
-    private static func releaseAndExit(_ engine: EngineServer, logger: Logger) -> Never {
+    /// Every caller is past the point where returning is possible, and each has
+    /// to leave the path exactly as `shutDown()` would.
+    ///
+    /// **`status` is a parameter because the callers do not mean the same
+    /// thing, and collapsing them onto `EXIT_SUCCESS` made a failure
+    /// unobservable.** An operator's second signal ASKED for the remaining
+    /// connections to be abandoned, so abandoning them is success. A drain that
+    /// ran out of grace abandoned them because it could not finish, and so did
+    /// a listener that closed underneath the engine; neither is.
+    ///
+    /// The consumer that matters reads exactly this byte: Gas Can's
+    /// `shutdown.rs` counts `!status.success()`, so while every path exited 0
+    /// its `0/96` could not distinguish 96 completed drains from 96 that gave
+    /// up at ten seconds -- in the instrument that measured this fix. One byte
+    /// carries that distinction, and it is cheaper and harder to lose than a
+    /// second assertion somewhere else would be.
+    private static func releaseAndExit(
+        _ engine: EngineServer,
+        logger: Logger,
+        status: Int32
+    ) -> Never {
         do {
             try engine.releaseSocketPath()
         } catch {
@@ -324,7 +391,7 @@ struct ServeCommand: AsyncParsableCommand {
         // Qualified: bare `exit` inside a `ParsableCommand` resolves to
         // ArgumentParser's own `exit(withError:)` instance method, and the
         // compiler rejects it here rather than quietly calling something else.
-        Foundation.exit(EXIT_SUCCESS)
+        Foundation.exit(status)
     }
 
     /// Turns SIGTERM and SIGINT into a graceful close, and a repeat of either
@@ -355,12 +422,14 @@ struct ServeCommand: AsyncParsableCommand {
     private static func installShutdownHandler(
         logger: Logger,
         for engine: EngineServer,
-        quiesced: EventLoopPromise<Void>
+        quiesced: EventLoopPromise<Void>,
+        asked: ShutdownRequests
     ) -> [DispatchSourceSignal] {
         // One serial queue shared by both sources, so the two handlers can
-        // never run concurrently and `asked` needs no lock of its own.
+        // never run concurrently. `asked` is the caller's because `serve()`
+        // reads it too, from the listening channel's close; it carries its own
+        // lock for that reason.
         let queue = DispatchQueue(label: "arca-engine.shutdown")
-        let asked = ShutdownRequests()
         return [SIGTERM, SIGINT].map { number in
             signal(number, SIG_IGN)
             let source = DispatchSource.makeSignalSource(signal: number, queue: queue)
@@ -394,11 +463,13 @@ struct ServeCommand: AsyncParsableCommand {
                     // well behaved. The escalation below is the operator's
                     // lever and this is the one that needs no operator.
                     let forced = quiesced.futureResult.eventLoop.scheduleTask(in: shutdownGrace) {
-                        logger.notice(
+                        logger.error(
                             "connections did not drain within the grace period; closing anyway",
                             metadata: ["grace": "\(shutdownGrace)"]
                         )
-                        releaseAndExit(engine, logger: logger)
+                        // Non-zero: this is the drain failing, not an operator
+                        // choosing to abandon it. See `releaseAndExit`.
+                        releaseAndExit(engine, logger: logger, status: EXIT_FAILURE)
                     }
                     // Same event loop as the promise, so a drain that finishes
                     // first and this cancellation are ordered against each
@@ -419,7 +490,11 @@ struct ServeCommand: AsyncParsableCommand {
                     // channels still registered, which is the crash the
                     // graceful path exists to avoid. Nothing after this needs
                     // the group.
-                    releaseAndExit(engine, logger: logger)
+                    //
+                    // Zero, unlike the grace-period path above: abandoning the
+                    // remaining connections is what the second signal asked
+                    // for, so doing it is this process succeeding.
+                    releaseAndExit(engine, logger: logger, status: EXIT_SUCCESS)
                 }
             }
             source.resume()
@@ -442,17 +517,29 @@ struct ServeCommand: AsyncParsableCommand {
     }
 }
 
-/// Counts shutdown signals.
+/// Counts shutdown signals, and answers whether any has arrived.
 ///
-/// `@unchecked Sendable` because every access happens on the one serial queue
-/// `installShutdownHandler` gives both of its signal sources; it carries no
-/// synchronisation of its own and must not be used anywhere else.
-private final class ShutdownRequests: @unchecked Sendable {
-    private var seen = 0
+/// **Locked rather than queue-confined, and it used to be the latter.** Both
+/// signal sources still share one serial queue, but `serve()` now also reads
+/// this from a `whenComplete` on the listening channel's close, which runs on a
+/// NIO event loop. Two threads, so the confinement argument no longer holds and
+/// a lock replaces it rather than a comment claiming a discipline the code no
+/// longer keeps.
+private final class ShutdownRequests: Sendable {
+    private let seen = NIOLockedValueBox(0)
 
     /// Records a request and answers whether it was the first.
     func recordAndReportFirst() -> Bool {
-        seen += 1
-        return seen == 1
+        seen.withLockedValue { seen in
+            seen += 1
+            return seen == 1
+        }
     }
+
+    /// Whether any signal has been recorded.
+    ///
+    /// Read to tell a listening socket that closed BECAUSE of a shutdown from
+    /// one that closed on its own. The handler records before it initiates, so
+    /// by the time a graceful close reaches the observer this is already true.
+    var anyRecorded: Bool { seen.withLockedValue { $0 > 0 } }
 }

--- a/Sources/arca-engine/ArcaEngineCommand.swift
+++ b/Sources/arca-engine/ArcaEngineCommand.swift
@@ -84,6 +84,8 @@ struct ArcaEngineCommand: AsyncParsableCommand {
         let containerManager = ContainerManager(
             imageManager: imageManager,
             kernelPath: root.appendingPathComponent("vmlinux").path,
+            imageStoreRoot: root.appendingPathComponent("images"),
+            layerCachePath: root.appendingPathComponent("layers"),
             stateStore: stateStore,
             logger: logger
         )

--- a/Sources/arca-engine/ArcaEngineCommand.swift
+++ b/Sources/arca-engine/ArcaEngineCommand.swift
@@ -6,10 +6,38 @@ import Logging
 import NIOCore
 import NIOPosix
 
+/// The entry point, and nothing else.
+///
+/// It carries no options of its own, and that is forced rather than tidy.
+/// ArgumentParser parses every command in the chain, so a parent holding
+/// REQUIRED options makes them required of its subcommands too: with
+/// `--socket-path` and its three siblings declared here, `arca-engine image
+/// load --state-root R --oci-layout L` exited with `Error: Missing expected
+/// argument '--socket-path <socket-path>'` -- MEASURED against the built binary
+/// before this split. An image load cannot be made to name a socket it will
+/// never bind.
+///
+/// `serve` is the `defaultSubcommand`, so the invocation Gas Can already
+/// ships -- `arca-engine --socket-path ... --state-root ... --kernel-path ...
+/// --vminit-layout ...`, with no subcommand named -- still reaches
+/// `ServeCommand.run()` unchanged. That is not assumed: every test in
+/// `EngineCommandRefusalTests` spawns exactly that form.
 @main
 struct ArcaEngineCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "arca-engine",
+        abstract: "Serves the arca.engine.v1 sandbox-engine contract over a Unix socket.",
+        subcommands: [ServeCommand.self, ImageCommand.self],
+        defaultSubcommand: ServeCommand.self
+    )
+}
+
+/// Serves the contract until it is told to stop. The engine's whole reason for
+/// existing, and now one subcommand among others only because a sibling needed
+/// a parent that demanded nothing.
+struct ServeCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "serve",
         abstract: "Serves the arca.engine.v1 sandbox-engine contract over a Unix socket."
     )
 
@@ -32,8 +60,7 @@ struct ArcaEngineCommand: AsyncParsableCommand {
     var logLevel: String = "info"
 
     func run() async throws {
-        var logger = Logger(label: "arca-engine")
-        logger.logLevel = Logger.Level(rawValue: logLevel) ?? .info
+        let logger = engineLogger(logLevel: logLevel)
 
         // First, and before anything is created or constructed: a bad input
         // must cost a clear error naming which option and which path, not a

--- a/Sources/arca-engine/ArcaEngineCommand.swift
+++ b/Sources/arca-engine/ArcaEngineCommand.swift
@@ -22,11 +22,35 @@ import NIOPosix
 /// --vminit-layout ...`, with no subcommand named -- still reaches
 /// `ServeCommand.run()` unchanged. That is not assumed: every test in
 /// `EngineCommandRefusalTests` spawns exactly that form.
+///
+/// `usage` and `discussion` are spelt out because the split cost them. A root
+/// holding no options of its own generates `USAGE: arca-engine <subcommand>`
+/// and an OPTIONS list holding nothing but `-h`, which is what `--help`
+/// printed until this was written: the four options the engine cannot start
+/// without were reachable only by knowing to type `arca-engine serve --help`
+/// first. Milestone 4 writes a launchd plist against this binary, and whoever
+/// writes it -- or debugs a start that failed -- reads `--help`.
+/// `ImageLoadTests.testHelpDocumentsTheOptionsTheEngineCannotStartWithout` is
+/// what stops this regressing a second time; it regressed silently the first
+/// time because nothing in the suite read help output at all.
 @main
 struct ArcaEngineCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "arca-engine",
         abstract: "Serves the arca.engine.v1 sandbox-engine contract over a Unix socket.",
+        usage: """
+            arca-engine --socket-path <socket-path> --state-root <state-root> \
+            --kernel-path <kernel-path> --vminit-layout <vminit-layout> [--log-level <log-level>]
+            arca-engine image load --state-root <state-root> --oci-layout <oci-layout>
+            """,
+        discussion: """
+            Named with no subcommand -- the first form under USAGE -- arca-engine serves \
+            the contract over the socket given. All four of those options are required and \
+            none is defaulted, because a default is how a process silently ends up pointed \
+            at another product's state; 'arca-engine serve --help' describes what each \
+            takes. 'arca-engine image load --help' covers loading an image into this \
+            engine's own store without serving anything.
+            """,
         subcommands: [ServeCommand.self, ImageCommand.self],
         defaultSubcommand: ServeCommand.self
     )

--- a/Sources/arca-engine/ArcaEngineCommand.swift
+++ b/Sources/arca-engine/ArcaEngineCommand.swift
@@ -82,9 +82,23 @@ struct ArcaEngineCommand: AsyncParsableCommand {
             logger: logger
         )
 
-        // Order matters and mirrors ArcaDaemon: the vminit image must be in the
-        // store before ContainerManager.initialize() asks for it, and
-        // NetworkManager needs a ContainerManager to resolve containers.
+        // Order matters, and it is NOT ArcaDaemon's -- an earlier revision of
+        // this comment claimed parity and there is none. The daemon runs
+        // imageManager, containerManager, networkManager, volumeManager
+        // (ArcaDaemon.swift:74, 208, 232, 258). This runs volume, container,
+        // network, for three reasons of its own:
+        //
+        //   - the vminit image must be in the store before
+        //     ContainerManager.initialize() resolves an initfs from it, which
+        //     the loadVminit above has just done;
+        //   - VolumeManager is first because it is the only one of the three
+        //     that touches nothing but the filesystem and the StateStore. The
+        //     cheap VM-free step ahead of the one that claims a host resource
+        //     means a bad state root is refused before any vmnet network is
+        //     created -- and it is the seam EngineCommandRefusalTests drives,
+        //     since no test may reach the vmnet step;
+        //   - NetworkManager is last of the three because it resolves
+        //     containers through a ContainerManager.
         //
         // Running this at all is what a private state root bought. The restore
         // loop inside ContainerManager.initialize() marks every container the
@@ -92,7 +106,8 @@ struct ArcaEngineCommand: AsyncParsableCommand {
         // a root shared with a live ArcaDaemon that write orphaned the daemon's
         // running VMs. Over this engine's own root the containers it rewrites
         // are the ones that died with the previous instance of this engine,
-        // which is what crash recovery is for.
+        // which is what crash recovery is for -- CrashRecoveryTests drives that
+        // loop directly, which `restored=0` against a fresh root never could.
         //
         // A failure here propagates out of run() and the process exits
         // non-zero. Nothing below binds a socket, so a client never reaches an
@@ -104,6 +119,12 @@ struct ArcaEngineCommand: AsyncParsableCommand {
         try await managers.volumeManager.initialize()
         try await managers.containerManager.initialize()
         try await managers.networkManager.initialize()
+
+        // After all three, as ArcaDaemon does. Without this the engine holds a
+        // ContainerManager that cannot create a container with anonymous
+        // volumes, silently leaks them on Remove, and reports a networked
+        // container as attached to nothing. See EngineManagers.wireCollaborators.
+        await managers.wireCollaborators()
 
         let service = managers.makeService()
 

--- a/Sources/arca-engine/ArcaEngineCommand.swift
+++ b/Sources/arca-engine/ArcaEngineCommand.swift
@@ -33,7 +33,12 @@ struct ArcaEngineCommand: AsyncParsableCommand {
         // path to connect if the directory itself is 0700.
         try createSocketParentDirectory(for: socketPath)
 
-        let root = URL(fileURLWithPath: stateRoot)
+        // Every path below comes from this one derivation, which the tests call
+        // too. Spelling the components out here a second time is what let the
+        // suite stay green while the engine's real image-store root changed:
+        // TestSupport held a hand-copy of these lines, so the tests exercised a
+        // replica of the wiring rather than the wiring. See EnginePaths.
+        let paths = EnginePaths(stateRoot: URL(fileURLWithPath: stateRoot))
 
         // initialize() is deliberately never called on any manager here, and
         // the reason it cannot be is worth stating in full, because it decides
@@ -74,31 +79,31 @@ struct ArcaEngineCommand: AsyncParsableCommand {
         // dependency edge they create is a property gascan's release gate
         // measures. See the note on SandboxEngineService's stored properties.
         let stateStore = try StateStore(
-            path: root.appendingPathComponent("state.db").path,
+            path: paths.stateDatabase.path,
             logger: logger
         )
         let imageManager = try ImageManager(
             logger: logger,
-            imageStorePath: root.appendingPathComponent("images")
+            imageStorePath: paths.imageStoreRoot
         )
         let containerManager = ContainerManager(
             imageManager: imageManager,
-            kernelPath: root.appendingPathComponent("vmlinux").path,
-            imageStoreRoot: root.appendingPathComponent("images"),
-            layerCachePath: root.appendingPathComponent("layers"),
+            kernelPath: paths.kernel.path,
+            imageStoreRoot: paths.imageStoreRoot,
+            layerCachePath: paths.layerCache,
             stateStore: stateStore,
             logger: logger
         )
         let config = ArcaConfig(
-            kernelPath: root.appendingPathComponent("vmlinux").path,
-            socketPath: root.appendingPathComponent("arca.sock").path,
+            kernelPath: paths.kernel.path,
+            socketPath: paths.socket.path,
             logLevel: logLevel
         )
 
         let service = SandboxEngineService(
             containerManager: containerManager,
             volumeManager: VolumeManager(
-                volumesBasePath: root.appendingPathComponent("volumes").path,
+                volumesBasePath: paths.volumesRoot.path,
                 stateStore: stateStore,
                 logger: logger
             ),

--- a/Sources/arca-engine/ArcaEngineCommand.swift
+++ b/Sources/arca-engine/ArcaEngineCommand.swift
@@ -54,35 +54,21 @@ struct ArcaEngineCommand: AsyncParsableCommand {
         // path to connect if the directory itself is 0700.
         try createSocketParentDirectory(for: socketPath)
 
-        // Every path below comes from this one derivation, which the tests call
-        // too. Spelling the components out here a second time is what let the
-        // suite stay green while the engine's real image-store root changed:
-        // TestSupport held a hand-copy of these lines, so the tests exercised a
-        // replica of the wiring rather than the wiring. See EnginePaths.
-        // The kernel is not among them: it is a read-only input the engine is
-        // handed, not state the engine owns.
-        let paths = EnginePaths(stateRoot: inputs.stateRoot)
-
         // Every manager below is rooted in the state root this engine owns, and
         // that ownership is the design: a state root shared with a live
         // ArcaDaemon is the hazard EngineInputs records, and an image store
-        // shared with it is the one EnginePaths records. Nothing here is
-        // derived a second way.
+        // shared with it is the one EnginePaths records.
         //
-        // initialize() is still not called on any manager. It needs a live
-        // Containerization.VmnetNetwork alongside the kernel and the vminit
-        // image (ContainerBridge/ContainerManager.swift:246-278), and until it
-        // is called, Inspect and ListResources answer unsupported_capability --
-        // see the notes on each in SandboxEngineService. The managers are
-        // constructed and handed to the service regardless: the dependency edge
-        // they create is a property gascan's release gate measures.
-        let stateStore = try StateStore(
-            path: paths.stateDatabase.path,
+        // One factory, which the tests call too. Neither the paths nor which
+        // path reaches which constructor argument is spelt out here a second
+        // time: a hand-copy of these lines in TestSupport is what let the suite
+        // stay green while the engine's real image-store root changed. See
+        // EngineManagers.
+        let managers = try EngineManagers(
+            stateRoot: inputs.stateRoot,
+            kernelPath: inputs.kernelPath,
+            logLevel: logLevel,
             logger: logger
-        )
-        let imageManager = try ImageManager(
-            logger: logger,
-            imageStorePath: paths.imageStoreRoot
         )
 
         // Before any manager that resolves an init image. This is the second of
@@ -91,42 +77,35 @@ struct ArcaEngineCommand: AsyncParsableCommand {
         // into the shared store.
         _ = try await loadVminit(
             from: inputs.vminitLayout,
-            into: imageManager,
+            into: managers.imageManager,
             stateRoot: inputs.stateRoot,
             logger: logger
         )
 
-        let containerManager = ContainerManager(
-            imageManager: imageManager,
-            kernelPath: inputs.kernelPath.path,
-            imageStoreRoot: paths.imageStoreRoot,
-            layerCachePath: paths.layerCache,
-            stateStore: stateStore,
-            logger: logger
-        )
-        let config = ArcaConfig(
-            kernelPath: inputs.kernelPath.path,
-            socketPath: paths.socket.path,
-            logLevel: logLevel
-        )
+        // Order matters and mirrors ArcaDaemon: the vminit image must be in the
+        // store before ContainerManager.initialize() asks for it, and
+        // NetworkManager needs a ContainerManager to resolve containers.
+        //
+        // Running this at all is what a private state root bought. The restore
+        // loop inside ContainerManager.initialize() marks every container the
+        // StateStore records as `running` exited 137 and writes that back; over
+        // a root shared with a live ArcaDaemon that write orphaned the daemon's
+        // running VMs. Over this engine's own root the containers it rewrites
+        // are the ones that died with the previous instance of this engine,
+        // which is what crash recovery is for.
+        //
+        // A failure here propagates out of run() and the process exits
+        // non-zero. Nothing below binds a socket, so a client never reaches an
+        // engine that cannot act -- pinned by
+        // EngineCommandRefusalTests.testAManagerThatCannotInitializeRefusesBeforeBindingTheSocket,
+        // which drives this binary because these three calls are unreachable
+        // from a unit test: ContainerManager.initialize() constructs a real
+        // Containerization.VmnetNetwork.
+        try await managers.volumeManager.initialize()
+        try await managers.containerManager.initialize()
+        try await managers.networkManager.initialize()
 
-        let service = SandboxEngineService(
-            containerManager: containerManager,
-            volumeManager: VolumeManager(
-                volumesBasePath: paths.volumesRoot.path,
-                stateStore: stateStore,
-                logger: logger
-            ),
-            networkManager: NetworkManager(
-                config: config,
-                stateStore: stateStore,
-                containerManager: containerManager,
-                logger: logger
-            ),
-            imageManager: imageManager,
-            execManager: ExecManager(containerManager: containerManager, logger: logger),
-            logger: logger
-        )
+        let service = managers.makeService()
 
         let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
         try await serve(service: service, group: group, logger: logger)

--- a/Sources/arca-engine/ArcaEngineCommand.swift
+++ b/Sources/arca-engine/ArcaEngineCommand.swift
@@ -173,8 +173,11 @@ struct ServeCommand: AsyncParsableCommand {
 
         // After all three, as ArcaDaemon does. Without this the engine holds a
         // ContainerManager that cannot create a container with anonymous
-        // volumes, silently leaks them on Remove, and reports a networked
-        // container as attached to nothing. See EngineManagers.wireCollaborators.
+        // volumes, silently leaks them on Remove, reports a networked container
+        // as attached to nothing, and publishes none of a sandbox's ports while
+        // reporting the create as a success. See
+        // EngineManagers.wireCollaborators, which also records why the last of
+        // those four is the one no test in this repository can prove.
         await managers.wireCollaborators()
 
         let service = managers.makeService()

--- a/Sources/arca-engine/EngineLogger.swift
+++ b/Sources/arca-engine/EngineLogger.swift
@@ -1,0 +1,13 @@
+import Logging
+
+/// The logger every `arca-engine` command builds, from the `--log-level` it was
+/// given.
+///
+/// One function rather than the same two lines in each command's `run()`: the
+/// label is what a consumer greps its logs by, and two spellings of it is a
+/// consumer that finds half its logs.
+func engineLogger(logLevel: String) -> Logger {
+    var logger = Logger(label: "arca-engine")
+    logger.logLevel = Logger.Level(rawValue: logLevel) ?? .info
+    return logger
+}

--- a/Sources/arca-engine/ImageCommand.swift
+++ b/Sources/arca-engine/ImageCommand.swift
@@ -1,0 +1,70 @@
+import ArcaEngine
+import ArgumentParser
+import Foundation
+
+/// `arca-engine image ...`, the group that owns everything to do with the
+/// engine's own image store.
+///
+/// A group with no `run()` of its own: ArgumentParser prints its help when it
+/// is invoked bare, which is what should happen to `arca-engine image`.
+struct ImageCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "image",
+        abstract: "Manages the images in this engine's own store.",
+        subcommands: [ImageLoadCommand.self]
+    )
+}
+
+/// `arca-engine image load --state-root <dir> --oci-layout <dir>`.
+///
+/// This subcommand loads and exits. It binds no socket, starts no VM and calls
+/// no manager's `initialize()`, so it runs anywhere -- including CI, where
+/// there is no vmnet entitlement.
+///
+/// Deliberately NOT a merge with `--vminit-layout`, which the served engine
+/// takes at startup: vminit is an input the engine must have before it can
+/// construct a manager, and a workspace image is content a consumer pushes
+/// afterwards. Merging them would put an ordering step into installation.
+///
+/// A shell over `loadWorkspaceImages`, which lives in the `ArcaEngine` library,
+/// and holds no logic of its own beyond parsing and printing: a test target
+/// cannot import an executable, so anything decided here would be undecidable
+/// by any test. The rule is the same one `EnginePaths` and `EngineManagers`
+/// were moved for.
+struct ImageLoadCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "load",
+        abstract: "Loads an OCI image layout into this engine's own image store."
+    )
+
+    /// The engine's own state root, which is what decides the store the images
+    /// land in. Undefaulted, exactly as on the served engine: a default is how
+    /// a process silently ends up writing into another product's state, and the
+    /// store this must never write into is Apple's shared one.
+    @Option(name: .customLong("state-root"), help: "Directory holding engine state.")
+    var stateRoot: String
+
+    @Option(name: .customLong("oci-layout"), help: "Directory holding the OCI image layout to load.")
+    var ociLayout: String
+
+    @Option(name: .customLong("log-level"), help: "trace, debug, info, notice, warning, error.")
+    var logLevel: String = "info"
+
+    func run() async throws {
+        let report = try await loadWorkspaceImages(
+            fromOCILayout: URL(fileURLWithPath: ociLayout),
+            stateRoot: URL(fileURLWithPath: stateRoot),
+            logger: engineLogger(logLevel: logLevel)
+        )
+
+        // On stdout, and naming the store that was actually written to. A load
+        // that reported only "ok" would be indistinguishable from a load that
+        // wrote nothing, and one that reported no path would be
+        // indistinguishable from a load into Apple's shared store -- the exact
+        // outcome this engine's private state root exists to prevent.
+        print("loaded \(report.references.count) image(s) into \(report.storeRoot.path)")
+        for reference in report.references {
+            print(reference)
+        }
+    }
+}

--- a/Sources/arca-engine/ImageCommand.swift
+++ b/Sources/arca-engine/ImageCommand.swift
@@ -11,7 +11,12 @@ import Foundation
 /// Can's `build-arca-engine.sh` grew a listing guard for, after
 /// `swift test --filter <no match>` passed a gate by running no tests.
 /// `ValidationError` is the exit 64 ArgumentParser uses for a command line it
-/// could not act on, and it prints the group's usage with it.
+/// could not act on. What it prints beneath the message is the ROOT's custom
+/// `usage:` -- both forms, then `See 'arca-engine --help'` -- and not this
+/// group's own usage line. MEASURED against the built binary, and it matters to
+/// whoever asserts on this output: the root's usage carries the literal
+/// `arca-engine image load ...`, so a test reading stderr for `load` learns
+/// nothing about the message above it.
 struct ImageCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "image",
@@ -22,7 +27,11 @@ struct ImageCommand: ParsableCommand {
     func run() throws {
         // Read off the configuration rather than written out beside it, so an
         // action a later task adds cannot go missing from the message that
-        // lists what this group can do.
+        // lists what this group can do. Held to by
+        // ImageLoadTests.testTheRefusalNamesEveryActionTheGroupAdvertises,
+        // which compares this list against the one `image --help` generates
+        // from the same array -- a guard that can only bite once there are two
+        // subcommands, which is Task 10.
         //
         // Spelt as an explicit closure and not `compactMap(\.configuration...)`:
         // the key-path form crashes swiftc 6.3.3 in SILGen, `signal 5` while

--- a/Sources/arca-engine/ImageCommand.swift
+++ b/Sources/arca-engine/ImageCommand.swift
@@ -5,14 +5,36 @@ import Foundation
 /// `arca-engine image ...`, the group that owns everything to do with the
 /// engine's own image store.
 ///
-/// A group with no `run()` of its own: ArgumentParser prints its help when it
-/// is invoked bare, which is what should happen to `arca-engine image`.
+/// It has a `run()` only to refuse. ArgumentParser's default for a bare group
+/// is to print help and exit 0, so `arca-engine image && echo ok` printed `ok`
+/// having loaded nothing -- the same "exits 0 having done nothing" shape Gas
+/// Can's `build-arca-engine.sh` grew a listing guard for, after
+/// `swift test --filter <no match>` passed a gate by running no tests.
+/// `ValidationError` is the exit 64 ArgumentParser uses for a command line it
+/// could not act on, and it prints the group's usage with it.
 struct ImageCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "image",
         abstract: "Manages the images in this engine's own store.",
         subcommands: [ImageLoadCommand.self]
     )
+
+    func run() throws {
+        // Read off the configuration rather than written out beside it, so an
+        // action a later task adds cannot go missing from the message that
+        // lists what this group can do.
+        //
+        // Spelt as an explicit closure and not `compactMap(\.configuration...)`:
+        // the key-path form crashes swiftc 6.3.3 in SILGen, `signal 5` while
+        // lowering this function, on the conversion of a key path rooted in an
+        // existential metatype. MEASURED here; the closure compiles.
+        let actions = Self.configuration.subcommands
+            .compactMap { subcommand in subcommand.configuration.commandName }
+            .joined(separator: ", ")
+        throw ValidationError(
+            "'arca-engine image' does nothing on its own; name an action: \(actions)"
+        )
+    }
 }
 
 /// `arca-engine image load --state-root <dir> --oci-layout <dir>`.

--- a/Sources/arca-engine/ImageCommand.swift
+++ b/Sources/arca-engine/ImageCommand.swift
@@ -26,12 +26,14 @@ struct ImageCommand: ParsableCommand {
 
     func run() throws {
         // Read off the configuration rather than written out beside it, so an
-        // action a later task adds cannot go missing from the message that
+        // action added to `subcommands` cannot go missing from the message that
         // lists what this group can do. Held to by
         // ImageLoadTests.testTheRefusalNamesEveryActionTheGroupAdvertises,
         // which compares this list against the one `image --help` generates
-        // from the same array -- a guard that can only bite once there are two
-        // subcommands, which is Task 10.
+        // from the same array. That guard can only bite once a second
+        // subcommand exists, and none is scheduled -- the rest of this
+        // milestone is gRPC methods served over the socket, which add nothing
+        // to this command line.
         //
         // Spelt as an explicit closure and not `compactMap(\.configuration...)`:
         // the key-path form crashes swiftc 6.3.3 in SILGen, `signal 5` while

--- a/Tests/ArcaEngineTests/CapabilitiesTests.swift
+++ b/Tests/ArcaEngineTests/CapabilitiesTests.swift
@@ -18,9 +18,19 @@ final class CapabilitiesTests: XCTestCase {
         XCTAssertNil(engineVersion(from: "0.2.x"))
     }
 
-    /// This build implements no create and no exec, so it claims nothing. A
-    /// capability that is true before its code exists is how a consumer is
-    /// induced to send a request the engine cannot honour.
+    /// **This asserts the false flags as hard as the true ones, and that is the
+    /// point.** A capability that is true before its code exists is how a
+    /// consumer is induced to send a request the engine cannot honour, so the
+    /// four `XCTAssertFalse`s below are not leftovers from an emptier build:
+    /// `namedVolumes` is false because the guest mounts none, `tty` and
+    /// `signals` because `Exec` is not implemented, and `offline` is
+    /// `.unverified` because nothing has proven isolation. See the note on
+    /// `capabilities(request:)` for what earned each of the three that are true.
+    ///
+    /// **This test cannot corroborate any of them.** It reads the same literals
+    /// the source holds; what makes those literals honest is gascan's live
+    /// tier, named in that note, and nothing here. It is a lock against a flag
+    /// moving unnoticed, not evidence that a flag is right.
     ///
     /// Calls the context-free `capabilities(request:)` overload rather than
     /// the protocol-conforming `capabilities(request:context:)`: grpc-swift's
@@ -33,12 +43,12 @@ final class CapabilitiesTests: XCTestCase {
         guard case .capabilities(let capabilities) = response.outcome else {
             return XCTFail("Capabilities must answer with capabilities")
         }
-        XCTAssertFalse(capabilities.projectMount)
+        XCTAssertTrue(capabilities.projectMount)
         XCTAssertFalse(capabilities.namedVolumes)
         XCTAssertFalse(capabilities.tty)
         XCTAssertFalse(capabilities.signals)
-        XCTAssertFalse(capabilities.loopbackPublish)
-        XCTAssertFalse(capabilities.resourceLimits)
+        XCTAssertTrue(capabilities.loopbackPublish)
+        XCTAssertTrue(capabilities.resourceLimits)
         XCTAssertEqual(capabilities.offline, .unverified)
         XCTAssertEqual(capabilities.contractMinor, 0)
         XCTAssertEqual(capabilities.engineVersion.minor, 2)

--- a/Tests/ArcaEngineTests/CapabilitiesTests.swift
+++ b/Tests/ArcaEngineTests/CapabilitiesTests.swift
@@ -21,11 +21,17 @@ final class CapabilitiesTests: XCTestCase {
     /// **This asserts the false flags as hard as the true ones, and that is the
     /// point.** A capability that is true before its code exists is how a
     /// consumer is induced to send a request the engine cannot honour, so the
-    /// four `XCTAssertFalse`s below are not leftovers from an emptier build:
-    /// `namedVolumes` is false because the guest mounts none, `tty` and
-    /// `signals` because `Exec` is not implemented, and `offline` is
-    /// `.unverified` because nothing has proven isolation. See the note on
-    /// `capabilities(request:)` for what earned each of the three that are true.
+    /// `XCTAssertFalse`s below are not leftovers from an emptier build: `tty`
+    /// and `signals` are false because `Exec` is not implemented, and `offline`
+    /// is `.unverified` because nothing has proven isolation. See the note on
+    /// `capabilities(request:)` for what earned each of the four that are true.
+    ///
+    /// `namedVolumes` was one of the falses until vminitd stopped identifying
+    /// its OverlayFS block devices by counting `/dev/vd` letters -- which
+    /// swallowed the volume devices -- and started reading a role out of each
+    /// image's ext4 volume label. This assertion flipping is a deliberate part
+    /// of that change; it failing on its own would mean the flag moved without
+    /// one.
     ///
     /// **This test cannot corroborate any of them.** It reads the same literals
     /// the source holds; what makes those literals honest is gascan's live
@@ -44,7 +50,7 @@ final class CapabilitiesTests: XCTestCase {
             return XCTFail("Capabilities must answer with capabilities")
         }
         XCTAssertTrue(capabilities.projectMount)
-        XCTAssertFalse(capabilities.namedVolumes)
+        XCTAssertTrue(capabilities.namedVolumes)
         XCTAssertFalse(capabilities.tty)
         XCTAssertFalse(capabilities.signals)
         XCTAssertTrue(capabilities.loopbackPublish)

--- a/Tests/ArcaEngineTests/ContainerBridgePathsTests.swift
+++ b/Tests/ArcaEngineTests/ContainerBridgePathsTests.swift
@@ -2,6 +2,7 @@ import ContainerBridge
 import Foundation
 import Logging
 import XCTest
+@testable import ArcaEngine
 
 final class ContainerBridgePathsTests: XCTestCase {
     private func temporaryRoot() -> URL {
@@ -14,7 +15,74 @@ final class ContainerBridgePathsTests: XCTestCase {
     /// builds `imageStore.path/initfs.ext4`. Sharing that store is what forces
     /// ArcaDaemon to delete the file on every start; a private root removes the
     /// need for any coordination.
-    func testTheImageStoreRootIsTheOneItWasGiven() throws {
+    ///
+    /// This drives `SandboxEngineService.forTesting(stateRoot:)`, which derives
+    /// its paths from `EnginePaths` exactly as `arca-engine` does, and reads
+    /// `containerizationRoot()`, the value `initialize()` hands to
+    /// Containerization. Both ends are the production ones: nothing here
+    /// restates the derivation, so a derivation that changed would be caught
+    /// rather than followed.
+    func testTheEngineImageStoreIsUnderItsStateRootAndNotApples() {
+        let root = temporaryRoot()
+        let service = SandboxEngineService.forTesting(stateRoot: root)
+
+        let selected = service.containerManager.containerizationRoot()
+        XCTAssertTrue(
+            selected.path.hasPrefix(root.path),
+            "the engine's image store must live under the state root it was given, got \(selected.path)"
+        )
+        XCTAssertFalse(
+            selected.path.contains("com.apple.containerization"),
+            "the engine's image store must not resolve into Apple's shared store"
+        )
+    }
+
+    /// `~/.arca/layers` was hardcoded, so a dev.gascan-rooted engine would still
+    /// write its layer cache into Arca's tree.
+    func testTheEngineLayerCacheIsUnderItsStateRootAndNotArcas() {
+        let root = temporaryRoot()
+        let service = SandboxEngineService.forTesting(stateRoot: root)
+
+        let cache = service.containerManager.layerCachePath
+        XCTAssertTrue(
+            cache.path.hasPrefix(root.path),
+            "the engine's layer cache must live under the state root it was given, got \(cache.path)"
+        )
+        XCTAssertFalse(
+            cache.path.hasSuffix(".arca/layers"),
+            "the engine's layer cache must not resolve into Arca's tree"
+        )
+    }
+
+    /// Nothing the engine derives escapes the state root. The two tests above
+    /// cover the image store and the layer cache through the wiring; this
+    /// covers the rest of `EnginePaths` -- the state database, the volumes
+    /// directory, the kernel and the configured socket -- which are handed to
+    /// managers this suite does not otherwise read back.
+    func testNoEnginePathEscapesTheStateRoot() {
+        let root = temporaryRoot()
+        let paths = EnginePaths(stateRoot: root)
+
+        for (name, path) in [
+            ("imageStoreRoot", paths.imageStoreRoot),
+            ("layerCache", paths.layerCache),
+            ("stateDatabase", paths.stateDatabase),
+            ("volumesRoot", paths.volumesRoot),
+            ("kernel", paths.kernel),
+            ("socket", paths.socket),
+        ] {
+            XCTAssertTrue(
+                path.path.hasPrefix(root.path + "/"),
+                "\(name) must live under the state root, got \(path.path)"
+            )
+        }
+    }
+
+    /// ContainerBridge's own contract, independent of the engine: a
+    /// `ContainerManager` uses the roots it was handed. ArcaDaemon depends on
+    /// this too, and it is constructed by neither `EnginePaths` nor
+    /// `forTesting`.
+    func testAContainerManagerUsesTheRootsItWasGiven() throws {
         let logger = Logger(label: "paths-tests")
         let root = temporaryRoot()
         let stateStore = try StateStore(
@@ -22,11 +90,12 @@ final class ContainerBridgePathsTests: XCTestCase {
             logger: logger
         )
         let imageStoreRoot = root.appendingPathComponent("images")
+        let layerCachePath = root.appendingPathComponent("layers")
         let manager = ContainerManager(
             imageManager: try ImageManager(logger: logger, imageStorePath: imageStoreRoot),
             kernelPath: root.appendingPathComponent("vmlinux").path,
             imageStoreRoot: imageStoreRoot,
-            layerCachePath: root.appendingPathComponent("layers"),
+            layerCachePath: layerCachePath,
             stateStore: stateStore,
             logger: logger
         )
@@ -34,43 +103,8 @@ final class ContainerBridgePathsTests: XCTestCase {
         // containerizationRoot() and not imageStoreRoot: the stored property is
         // beside the decision, not the decision. MEASURED: with initialize()
         // reverted to pass no `root:` at all, assertions on the property alone
-        // reported "Executed 2 tests, with 0 failures". containerizationRoot()
-        // is the value initialize() hands to Containerization, so reverting the
-        // selection is red.
+        // reported "Executed 2 tests, with 0 failures".
         XCTAssertEqual(manager.containerizationRoot(), imageStoreRoot)
-        XCTAssertEqual(manager.imageStoreRoot, imageStoreRoot)
-        XCTAssertFalse(
-            manager.containerizationRoot().path.contains("com.apple.containerization"),
-            "the engine's image store must not resolve into Apple's shared store"
-        )
-    }
-
-    /// `~/.arca/layers` was hardcoded, so a dev.gascan-rooted engine would still
-    /// write its layer cache into Arca's tree.
-    func testTheLayerCacheIsTheOneItWasGiven() throws {
-        let logger = Logger(label: "paths-tests")
-        let root = temporaryRoot()
-        let stateStore = try StateStore(
-            path: root.appendingPathComponent("state.db").path,
-            logger: logger
-        )
-        let layerCachePath = root.appendingPathComponent("layers")
-        let manager = ContainerManager(
-            imageManager: try ImageManager(
-                logger: logger,
-                imageStorePath: root.appendingPathComponent("images")
-            ),
-            kernelPath: root.appendingPathComponent("vmlinux").path,
-            imageStoreRoot: root.appendingPathComponent("images"),
-            layerCachePath: layerCachePath,
-            stateStore: stateStore,
-            logger: logger
-        )
-
         XCTAssertEqual(manager.layerCachePath, layerCachePath)
-        XCTAssertFalse(
-            manager.layerCachePath.path.hasSuffix(".arca/layers"),
-            "the engine's layer cache must not resolve into Arca's tree"
-        )
     }
 }

--- a/Tests/ArcaEngineTests/ContainerBridgePathsTests.swift
+++ b/Tests/ArcaEngineTests/ContainerBridgePathsTests.swift
@@ -1,0 +1,76 @@
+import ContainerBridge
+import Foundation
+import Logging
+import XCTest
+
+final class ContainerBridgePathsTests: XCTestCase {
+    private func temporaryRoot() -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("arca-paths-\(UUID().uuidString)")
+    }
+
+    /// The engine must not share Apple's containerization image store, because
+    /// `initfs.ext4` is derived from it -- Containerization's ContainerManager
+    /// builds `imageStore.path/initfs.ext4`. Sharing that store is what forces
+    /// ArcaDaemon to delete the file on every start; a private root removes the
+    /// need for any coordination.
+    func testTheImageStoreRootIsTheOneItWasGiven() throws {
+        let logger = Logger(label: "paths-tests")
+        let root = temporaryRoot()
+        let stateStore = try StateStore(
+            path: root.appendingPathComponent("state.db").path,
+            logger: logger
+        )
+        let imageStoreRoot = root.appendingPathComponent("images")
+        let manager = ContainerManager(
+            imageManager: try ImageManager(logger: logger, imageStorePath: imageStoreRoot),
+            kernelPath: root.appendingPathComponent("vmlinux").path,
+            imageStoreRoot: imageStoreRoot,
+            layerCachePath: root.appendingPathComponent("layers"),
+            stateStore: stateStore,
+            logger: logger
+        )
+
+        // containerizationRoot() and not imageStoreRoot: the stored property is
+        // beside the decision, not the decision. MEASURED: with initialize()
+        // reverted to pass no `root:` at all, assertions on the property alone
+        // reported "Executed 2 tests, with 0 failures". containerizationRoot()
+        // is the value initialize() hands to Containerization, so reverting the
+        // selection is red.
+        XCTAssertEqual(manager.containerizationRoot(), imageStoreRoot)
+        XCTAssertEqual(manager.imageStoreRoot, imageStoreRoot)
+        XCTAssertFalse(
+            manager.containerizationRoot().path.contains("com.apple.containerization"),
+            "the engine's image store must not resolve into Apple's shared store"
+        )
+    }
+
+    /// `~/.arca/layers` was hardcoded, so a dev.gascan-rooted engine would still
+    /// write its layer cache into Arca's tree.
+    func testTheLayerCacheIsTheOneItWasGiven() throws {
+        let logger = Logger(label: "paths-tests")
+        let root = temporaryRoot()
+        let stateStore = try StateStore(
+            path: root.appendingPathComponent("state.db").path,
+            logger: logger
+        )
+        let layerCachePath = root.appendingPathComponent("layers")
+        let manager = ContainerManager(
+            imageManager: try ImageManager(
+                logger: logger,
+                imageStorePath: root.appendingPathComponent("images")
+            ),
+            kernelPath: root.appendingPathComponent("vmlinux").path,
+            imageStoreRoot: root.appendingPathComponent("images"),
+            layerCachePath: layerCachePath,
+            stateStore: stateStore,
+            logger: logger
+        )
+
+        XCTAssertEqual(manager.layerCachePath, layerCachePath)
+        XCTAssertFalse(
+            manager.layerCachePath.path.hasSuffix(".arca/layers"),
+            "the engine's layer cache must not resolve into Arca's tree"
+        )
+    }
+}

--- a/Tests/ArcaEngineTests/ContainerBridgePathsTests.swift
+++ b/Tests/ArcaEngineTests/ContainerBridgePathsTests.swift
@@ -207,4 +207,112 @@ final class ContainerBridgePathsTests: XCTestCase {
 
         XCTAssertEqual(manager.storeRoot, storePath)
     }
+
+    // MARK: - Source-text guards on the create path
+    //
+    // READ THIS BEFORE TRUSTING THE TWO TESTS BELOW.
+    //
+    // They read `Sources/ContainerBridge/ContainerManager.swift` as text. They
+    // execute none of it, and they prove nothing about what
+    // `createNativeContainer` does at runtime.
+    //
+    // They are text because the runtime is out of reach, not because text was
+    // preferred. `createNativeContainer` opens with
+    // `guard var manager = nativeManager`, and `nativeManager` is assigned only
+    // by `initialize()`, which builds a `Kernel` and a
+    // `Containerization.VmnetNetwork` -- so the call site needs a kernel image
+    // and a VM, and this target has neither. Extracting the derivation into
+    // something a test could call instead would prove the derivation and still
+    // not prove the call site used it, which is the shape this project has
+    // shipped repeatedly: a well-formed test over a function, and nothing
+    // asserting that the caller called it.
+    //
+    // The honest call-site instrument is Gas Can's live `Create` test, which is
+    // Task 13's and does not exist yet. These two are a tripwire under the
+    // revert, not a substitute for it.
+
+    /// This file must never name Apple's shared containerization store.
+    ///
+    /// `createNativeContainer` used to build the container directory under a
+    /// hardcoded `~/Library/Application Support/com.apple.containerization`
+    /// while `getRootfsPath` derived the same directory from
+    /// `manager.imageStore.path`. For ArcaDaemon the two agreed, because
+    /// `ArcaDaemon.swift:178` passes `imageStoreRoot: ImageStore.default.path`
+    /// and that *is* Apple's store. For an engine given any other state root
+    /// they did not: Containerization opens
+    /// `imageStore.path/containers/<id>/bootlog.log`
+    /// (containerization/Sources/Containerization/ContainerManager.swift:317,
+    /// :35-37, :139-140), so the bridge created a directory Containerization
+    /// never looked in.
+    ///
+    /// WHAT THIS PROVES: the literal is gone from this file.
+    ///
+    /// WHAT IT DOES NOT PROVE, and what can satisfy it while the bug is back:
+    /// a file that hardcodes a *different* wrong root (`~/.arca/containers`,
+    /// say); a file where `containerDirectory(in:dockerID:)` is correct but
+    /// `createNativeContainer` no longer calls it; any change at all to the
+    /// runtime behaviour of the create path. It also forbids the string in
+    /// comments, deliberately -- a comment asserting the wrong store is how the
+    /// old derivation stayed plausible for as long as it did.
+    func testTheContainerBridgeCreatePathNeverNamesApplesSharedStore() throws {
+        let source = try Self.containerManagerSource()
+
+        XCTAssertFalse(
+            source.contains("com.apple.containerization"),
+            "Sources/ContainerBridge/ContainerManager.swift must not name Apple's "
+                + "shared containerization store: the store a container's directory "
+                + "goes in is whichever root initialize() handed Containerization, "
+                + "and naming Apple's agrees with that only for ArcaDaemon"
+        )
+    }
+
+    /// `<store>/containers/<id>` must be derived in one place in this file.
+    ///
+    /// Two spellings drifting apart is the defect itself, not a stylistic
+    /// concern: the create path and `getRootfsPath` each derived this directory
+    /// and only one of them was moved when `ContainerManager` gained an image
+    /// store root.
+    ///
+    /// Exactly one, not at most one: `at most` passes vacuously over a file
+    /// where the derivation was respelt (`appending(path:)`) and duplicated
+    /// again in the new spelling.
+    ///
+    /// WHAT THIS PROVES: the token `appendingPathComponent("containers")` occurs
+    /// once in this file.
+    ///
+    /// WHAT IT DOES NOT PROVE: that the one occurrence is rooted at the
+    /// manager's store, that either caller reaches it, or anything about
+    /// runtime. A single occurrence rooted at a hardcoded path satisfies it --
+    /// that is what the test above is for, and neither test covers the other's
+    /// gap at runtime.
+    func testTheContainersDirectoryIsDerivedInExactlyOnePlace() throws {
+        let source = try Self.containerManagerSource()
+
+        XCTAssertEqual(
+            source.components(separatedBy: #".appendingPathComponent("containers")"#).count - 1,
+            1,
+            "the <store>/containers/<id> join must be derived once, in "
+                + "containerDirectory(in:dockerID:), and reached by every caller "
+                + "that needs it"
+        )
+    }
+
+    /// The ContainerBridge source both tests above read.
+    ///
+    /// Located from `#filePath` rather than from the test bundle, because the
+    /// bundle holds no sources. A missing or unreadable file fails the test and
+    /// is never skipped: a guard that quietly passes when it cannot find what it
+    /// guards is worse than no guard, and these two are already the weaker half
+    /// of this task's evidence.
+    private static func containerManagerSource(
+        testFile: StaticString = #filePath
+    ) throws -> String {
+        let repoRoot = URL(fileURLWithPath: "\(testFile)")
+            .deletingLastPathComponent()  // ArcaEngineTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // repo root
+        let source = repoRoot
+            .appendingPathComponent("Sources/ContainerBridge/ContainerManager.swift")
+        return try String(contentsOf: source, encoding: .utf8)
+    }
 }

--- a/Tests/ArcaEngineTests/ContainerBridgePathsTests.swift
+++ b/Tests/ArcaEngineTests/ContainerBridgePathsTests.swift
@@ -67,6 +67,46 @@ final class ContainerBridgePathsTests: XCTestCase {
         )
     }
 
+    /// `ContainerLogManager` derived `~/Library/Application Support/
+    /// com.apple.arca/logs` for itself and took no root at all, so every
+    /// engine -- whatever state root it was given -- wrote its containers'
+    /// stdout and stderr into ArcaDaemon's one shared directory, and deleted
+    /// out of it on remove.
+    ///
+    /// Read through `service.containerManager.logManager`, the same object the
+    /// create path, the reload path and `removeLogs` use, so this is the
+    /// engine's real wiring and not a restatement of `EnginePaths`.
+    func testTheEngineContainerLogsAreUnderItsStateRootAndNotTheSharedOne() {
+        let root = temporaryRoot()
+        let service = SandboxEngineService.forTesting(
+            stateRoot: root, kernelPath: Self.externalKernel
+        )
+
+        let logDir = service.containerManager.logManager.containerLogDir(dockerID: "c0ffee")
+        XCTAssertTrue(
+            logDir.path.hasPrefix(root.path + "/"),
+            "the engine's container logs must live under the state root it was "
+                + "given, got \(logDir.path)"
+        )
+        XCTAssertFalse(
+            logDir.path.contains("com.apple.arca"),
+            "the engine's container logs must not resolve into ArcaDaemon's "
+                + "shared log store, got \(logDir.path)"
+        )
+        // Under the state root is not enough. The log root is a sibling of the
+        // image store, not a child of it: the engine must not write its own
+        // files into the directory Containerization owns, and passing
+        // `imageStoreRoot` where `logsRoot` belongs satisfies the containment
+        // check above on its own.
+        XCTAssertFalse(
+            logDir.path.hasPrefix(
+                service.containerManager.containerizationRoot().path + "/"
+            ),
+            "the engine's container logs must not be written inside the image "
+                + "store it hands Containerization, got \(logDir.path)"
+        )
+    }
+
     /// Nothing the engine derives escapes the state root. The two tests above
     /// cover the image store and the layer cache through the wiring; this
     /// covers the rest of `EnginePaths` -- the state database, the volumes
@@ -135,6 +175,7 @@ final class ContainerBridgePathsTests: XCTestCase {
             ("layerCache", paths.layerCache),
             ("stateDatabase", paths.stateDatabase),
             ("volumesRoot", paths.volumesRoot),
+            ("logsRoot", paths.logsRoot),
             ("socket", paths.socket),
         ]
     }
@@ -152,11 +193,13 @@ final class ContainerBridgePathsTests: XCTestCase {
         )
         let imageStoreRoot = root.appendingPathComponent("images")
         let layerCachePath = root.appendingPathComponent("layers")
+        let logRoot = root.appendingPathComponent("logs")
         let manager = ContainerManager(
             imageManager: try ImageManager(logger: logger, imageStorePath: imageStoreRoot),
             kernelPath: root.appendingPathComponent("vmlinux").path,
             imageStoreRoot: imageStoreRoot,
             layerCachePath: layerCachePath,
+            logRoot: logRoot,
             stateStore: stateStore,
             logger: logger
         )
@@ -167,6 +210,66 @@ final class ContainerBridgePathsTests: XCTestCase {
         // reported "Executed 2 tests, with 0 failures".
         XCTAssertEqual(manager.containerizationRoot(), imageStoreRoot)
         XCTAssertEqual(manager.layerCachePath, layerCachePath)
+
+        // The log root through `logManager.containerLogDir(dockerID:)` -- the
+        // resolution the create path (`createLogWriters`), the reload path and
+        // `removeLogs` all go through -- rather than through a stored property
+        // on either type. This is the call-site assertion for the log root:
+        // `ContainerManager` takes a root and builds the `ContainerLogManager`
+        // itself, so a manager that ignored `logRoot:` and rebuilt Application
+        // Support here would fail this line. Handing a ready-made
+        // `ContainerLogManager` in would have made this true by construction.
+        XCTAssertEqual(
+            manager.logManager.containerLogDir(dockerID: "c0ffee"),
+            logRoot.appendingPathComponent("c0ffee")
+        )
+    }
+
+    /// A `ContainerLogManager` writes and deletes under the root it was given,
+    /// and nowhere else.
+    ///
+    /// The assertion above reads the resolved path; this one drives the two
+    /// operations that use it, because the defect had both halves. Container
+    /// output went into `~/Library/Application Support/com.apple.arca/logs`
+    /// whatever root the engine owned, and `removeContainer` -- via
+    /// `ContainerManager.swift`'s `removeLogs` call -- deleted out of that same
+    /// shared directory, so a throwaway engine removing a sandbox deleted under
+    /// the operator's real log store.
+    ///
+    /// WHAT THIS PROVES: `createLogWriters` creates the container's log files
+    /// under the supplied root, and `removeLogs` removes that directory. Both
+    /// against a temporary root, so a regression to the shared derivation both
+    /// leaves this root empty and fails to delete from it.
+    ///
+    /// WHAT IT DOES NOT PROVE: that `createContainer` or `startContainer` reach
+    /// `createLogWriters` at all. Both guard on `nativeManager`, which only
+    /// `initialize()` sets and which needs a kernel and a VM, so those call
+    /// sites are unreachable from this target. The test above covers the root
+    /// `ContainerManager` hands down; what remains unproven here is the hop
+    /// from the hot paths into these two methods, and that is Gas Can's live
+    /// tier to settle.
+    func testALogManagerWritesAndDeletesOnlyUnderTheRootItWasGiven() throws {
+        let logRoot = temporaryRoot().appendingPathComponent("logs")
+        let manager = ContainerLogManager(
+            logRoot: logRoot, logger: Logger(label: "paths-tests")
+        )
+        let containerDir = logRoot.appendingPathComponent("c0ffee")
+
+        _ = try manager.createLogWriters(dockerID: "c0ffee")
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: containerDir.appendingPathComponent("stdout.log").path
+            ),
+            "createLogWriters must create the container's log files under the "
+                + "root it was given, nothing appeared at \(containerDir.path)"
+        )
+
+        try manager.removeLogs(dockerID: "c0ffee")
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: containerDir.path),
+            "removeLogs must delete the container's directory under the root it "
+                + "was given, \(containerDir.path) survived"
+        )
     }
 
     /// `initfs.ext4` is not a path the engine picks, it is a path

--- a/Tests/ArcaEngineTests/ContainerBridgePathsTests.swift
+++ b/Tests/ArcaEngineTests/ContainerBridgePathsTests.swift
@@ -39,7 +39,7 @@ final class ContainerBridgePathsTests: XCTestCase {
 
         let selected = service.containerManager.containerizationRoot()
         XCTAssertTrue(
-            selected.path.hasPrefix(root.path),
+            selected.path.hasPrefix(root.path + "/"),
             "the engine's image store must live under the state root it was given, got \(selected.path)"
         )
         XCTAssertFalse(
@@ -58,7 +58,7 @@ final class ContainerBridgePathsTests: XCTestCase {
 
         let cache = service.containerManager.layerCachePath
         XCTAssertTrue(
-            cache.path.hasPrefix(root.path),
+            cache.path.hasPrefix(root.path + "/"),
             "the engine's layer cache must live under the state root it was given, got \(cache.path)"
         )
         XCTAssertFalse(
@@ -78,9 +78,57 @@ final class ContainerBridgePathsTests: XCTestCase {
     /// it is `validateEngineInputs`' job rather than this one's.
     func testNoEnginePathEscapesTheStateRoot() {
         let root = temporaryRoot()
-        let paths = EnginePaths(stateRoot: root)
 
-        for (name, path) in [
+        for (name, path) in Self.derivedPaths(under: root) {
+            XCTAssertTrue(
+                path.path.hasPrefix(root.path + "/"),
+                "\(name) must live under the state root, got \(path.path)"
+            )
+        }
+    }
+
+    /// Under the state root is not enough: they must also be different places.
+    ///
+    /// The containment test above, and the two through the wiring, are each
+    /// satisfied by every path collapsing onto one directory. MEASURED with
+    /// `EnginePaths.layerCache` set to `stateRoot/"images"`:
+    /// `swift test --filter ArcaEngineTests` reported `Executed 60 tests, with 1
+    /// failure`, and that one failure was this test -- the other six in this
+    /// file, and every other test in the target, passed over an engine whose
+    /// OverlayFS layer cache would be unpacking layers directly into the
+    /// Containerization content store, beside the blobs and the 512MB
+    /// initfs.ext4 (that size MEASURED on a real start; see Task 6's report).
+    ///
+    /// Pairwise on the derived values rather than a restatement of the
+    /// derivation: spelling `stateRoot/"layers"` out here again is the tautology
+    /// Task 1's review removed, and it would pass over a collapse it had itself
+    /// copied.
+    func testNoTwoEnginePathsNameTheSamePlace() {
+        let root = temporaryRoot()
+        let derived = Self.derivedPaths(under: root)
+
+        for (offset, first) in derived.enumerated() {
+            XCTAssertNotEqual(
+                first.path, root,
+                "\(first.name) must not be the state root itself, got \(first.path.path)"
+            )
+            for second in derived[(offset + 1)...] {
+                XCTAssertNotEqual(
+                    first.path, second.path,
+                    "\(first.name) and \(second.name) must not be the same path, "
+                        + "both are \(first.path.path)"
+                )
+            }
+        }
+    }
+
+    /// Every path `EnginePaths` derives, named. A listing of its members, which
+    /// is why it is not a second derivation: adding a member without adding it
+    /// here leaves that member unchecked by both tests above, and adding it here
+    /// with the wrong spelling does not compile.
+    private static func derivedPaths(under root: URL) -> [(name: String, path: URL)] {
+        let paths = EnginePaths(stateRoot: root)
+        return [
             ("imageStoreRoot", paths.imageStoreRoot),
             ("initfs", paths.initfs),
             ("vminitDigest", paths.vminitDigest),
@@ -88,12 +136,7 @@ final class ContainerBridgePathsTests: XCTestCase {
             ("stateDatabase", paths.stateDatabase),
             ("volumesRoot", paths.volumesRoot),
             ("socket", paths.socket),
-        ] {
-            XCTAssertTrue(
-                path.path.hasPrefix(root.path + "/"),
-                "\(name) must live under the state root, got \(path.path)"
-            )
-        }
+        ]
     }
 
     /// ContainerBridge's own contract, independent of the engine: a

--- a/Tests/ArcaEngineTests/ContainerBridgePathsTests.swift
+++ b/Tests/ArcaEngineTests/ContainerBridgePathsTests.swift
@@ -10,21 +10,32 @@ final class ContainerBridgePathsTests: XCTestCase {
             .appendingPathComponent("arca-paths-\(UUID().uuidString)")
     }
 
+    /// A kernel deliberately outside any state root, because that is the shape
+    /// `--kernel-path` exists to allow: one read-only image shared by however
+    /// many engines, each owning its own state root.
+    private static let externalKernel = URL(fileURLWithPath: "/opt/arca/vmlinux")
+
     /// The engine must not share Apple's containerization image store, because
     /// `initfs.ext4` is derived from it -- Containerization's ContainerManager
     /// builds `imageStore.path/initfs.ext4`. Sharing that store is what forces
     /// ArcaDaemon to delete the file on every start; a private root removes the
     /// need for any coordination.
     ///
-    /// This drives `SandboxEngineService.forTesting(stateRoot:)`, which derives
-    /// its paths from `EnginePaths` exactly as `arca-engine` does, and reads
-    /// `containerizationRoot()`, the value `initialize()` hands to
-    /// Containerization. Both ends are the production ones: nothing here
+    /// This drives `SandboxEngineService.forTesting(stateRoot:kernelPath:)`,
+    /// which derives its paths from `EnginePaths` exactly as `arca-engine`
+    /// does, and reads `containerizationRoot()`, the value `initialize()` hands
+    /// to Containerization. Both ends are the production ones: nothing here
     /// restates the derivation, so a derivation that changed would be caught
     /// rather than followed.
+    ///
+    /// The kernel is passed in from outside the root, as `--kernel-path` allows
+    /// and the assertions below require: nothing the engine *derives* may
+    /// escape the state root, and the kernel is no longer derived.
     func testTheEngineImageStoreIsUnderItsStateRootAndNotApples() {
         let root = temporaryRoot()
-        let service = SandboxEngineService.forTesting(stateRoot: root)
+        let service = SandboxEngineService.forTesting(
+            stateRoot: root, kernelPath: Self.externalKernel
+        )
 
         let selected = service.containerManager.containerizationRoot()
         XCTAssertTrue(
@@ -41,7 +52,9 @@ final class ContainerBridgePathsTests: XCTestCase {
     /// write its layer cache into Arca's tree.
     func testTheEngineLayerCacheIsUnderItsStateRootAndNotArcas() {
         let root = temporaryRoot()
-        let service = SandboxEngineService.forTesting(stateRoot: root)
+        let service = SandboxEngineService.forTesting(
+            stateRoot: root, kernelPath: Self.externalKernel
+        )
 
         let cache = service.containerManager.layerCachePath
         XCTAssertTrue(
@@ -57,8 +70,12 @@ final class ContainerBridgePathsTests: XCTestCase {
     /// Nothing the engine derives escapes the state root. The two tests above
     /// cover the image store and the layer cache through the wiring; this
     /// covers the rest of `EnginePaths` -- the state database, the volumes
-    /// directory, the kernel and the configured socket -- which are handed to
-    /// managers this suite does not otherwise read back.
+    /// directory and the configured socket -- which are handed to managers this
+    /// suite does not otherwise read back.
+    ///
+    /// The kernel is absent because it is no longer derived: it arrives as
+    /// `--kernel-path`, a read-only input the engine may share, and validating
+    /// it is `validateEngineInputs`' job rather than this one's.
     func testNoEnginePathEscapesTheStateRoot() {
         let root = temporaryRoot()
         let paths = EnginePaths(stateRoot: root)
@@ -68,7 +85,6 @@ final class ContainerBridgePathsTests: XCTestCase {
             ("layerCache", paths.layerCache),
             ("stateDatabase", paths.stateDatabase),
             ("volumesRoot", paths.volumesRoot),
-            ("kernel", paths.kernel),
             ("socket", paths.socket),
         ] {
             XCTAssertTrue(

--- a/Tests/ArcaEngineTests/ContainerBridgePathsTests.swift
+++ b/Tests/ArcaEngineTests/ContainerBridgePathsTests.swift
@@ -82,6 +82,8 @@ final class ContainerBridgePathsTests: XCTestCase {
 
         for (name, path) in [
             ("imageStoreRoot", paths.imageStoreRoot),
+            ("initfs", paths.initfs),
+            ("vminitDigest", paths.vminitDigest),
             ("layerCache", paths.layerCache),
             ("stateDatabase", paths.stateDatabase),
             ("volumesRoot", paths.volumesRoot),
@@ -122,5 +124,44 @@ final class ContainerBridgePathsTests: XCTestCase {
         // reported "Executed 2 tests, with 0 failures".
         XCTAssertEqual(manager.containerizationRoot(), imageStoreRoot)
         XCTAssertEqual(manager.layerCachePath, layerCachePath)
+    }
+
+    /// `initfs.ext4` is not a path the engine picks, it is a path
+    /// Containerization derives from whichever image store it is handed
+    /// (containerization/Sources/Containerization/ContainerManager.swift:146).
+    /// `EnginePaths.initfs` must therefore be that derivation and not a second
+    /// route to the same string -- the test above proves it stays under the
+    /// state root, this proves it stays inside the store.
+    func testTheInitfsIsInsideTheImageStoreTheEngineHandsContainerization() {
+        let root = temporaryRoot()
+        let paths = EnginePaths(stateRoot: root)
+        let service = SandboxEngineService.forTesting(
+            stateRoot: root, kernelPath: Self.externalKernel
+        )
+
+        XCTAssertEqual(
+            paths.initfs,
+            service.containerManager.containerizationRoot()
+                .appendingPathComponent("initfs.ext4"),
+            "the initfs the engine deletes must be the one Containerization builds"
+        )
+    }
+
+    /// An `ImageManager` reports the store it was actually given, which is what
+    /// lets ArcaDaemon name its initfs relative to its store instead of
+    /// re-deriving Application Support by hand -- the re-derivation that sat 70
+    /// lines from the comment saying the file avoids it.
+    ///
+    /// A store path is passed in rather than defaulted, because asserting on
+    /// the default would mean touching the real
+    /// `~/Library/Application Support/com.apple.containerization` from a test.
+    func testAnImageManagerReportsTheStoreRootItWasGiven() throws {
+        let root = temporaryRoot()
+        let storePath = root.appendingPathComponent("images")
+        let manager = try ImageManager(
+            logger: Logger(label: "paths-tests"), imageStorePath: storePath
+        )
+
+        XCTAssertEqual(manager.storeRoot, storePath)
     }
 }

--- a/Tests/ArcaEngineTests/ContainerBridgePathsTests.swift
+++ b/Tests/ArcaEngineTests/ContainerBridgePathsTests.swift
@@ -227,11 +227,16 @@ final class ContainerBridgePathsTests: XCTestCase {
     // shipped repeatedly: a well-formed test over a function, and nothing
     // asserting that the caller called it.
     //
-    // The honest call-site instrument is Gas Can's live `Create` test, which is
-    // Task 13's and does not exist yet. These two are a tripwire under the
-    // revert, not a substitute for it.
+    // The honest call-site instrument is Gas Can's live `Create` test. It is
+    // Task 13's to land, and the behaviour it proves has already been MEASURED
+    // by the controller against this commit: a real engine on a real socket
+    // creates a container, the directory appears under the engine's OWN
+    // `<state-root>/images/containers/`, and Apple's shared store is unchanged
+    // across the run. These two tests are a tripwire under the revert, not a
+    // substitute for that.
 
-    /// This file must never name Apple's shared containerization store.
+    /// This file must carry no literal path to Apple's shared containerization
+    /// store.
     ///
     /// `createNativeContainer` used to build the container directory under a
     /// hardcoded `~/Library/Application Support/com.apple.containerization`
@@ -245,16 +250,40 @@ final class ContainerBridgePathsTests: XCTestCase {
     /// :35-37, :139-140), so the bridge created a directory Containerization
     /// never looked in.
     ///
-    /// WHAT THIS PROVES: the literal is gone from this file.
+    /// WHAT THIS PROVES: the literal is gone from this file. Nothing more. The
+    /// name says *carries no literal* rather than *never reaches*, and the
+    /// difference is the whole of what follows.
     ///
-    /// WHAT IT DOES NOT PROVE, and what can satisfy it while the bug is back:
-    /// a file that hardcodes a *different* wrong root (`~/.arca/containers`,
-    /// say); a file where `containerDirectory(in:dockerID:)` is correct but
-    /// `createNativeContainer` no longer calls it; any change at all to the
-    /// runtime behaviour of the create path. It also forbids the string in
-    /// comments, deliberately -- a comment asserting the wrong store is how the
-    /// old derivation stayed plausible for as long as it did.
-    func testTheContainerBridgeCreatePathNeverNamesApplesSharedStore() throws {
+    /// WHAT IT DOES NOT PROVE, and what can satisfy it while the bug is back.
+    /// The first two were MEASURED against this suite rather than reasoned
+    /// about, and each left `Executed 149 tests, with 0 failures`:
+    ///
+    /// - **Apple's store reached by name instead of by literal.** Replace
+    ///   `manager.imageStore.path` in `containerDirectory(in:dockerID:)` with
+    ///   `ImageStore.default.path` and the original defect is back exactly,
+    ///   because `ImageStore.defaultRoot()` returns that same directory. This is
+    ///   the likeliest regression shape rather than a contrived one: that
+    ///   spelling is already in the tree twice, at `ImageManager.swift:23` and
+    ///   `ArcaDaemon.swift:178`.
+    /// - **The literal split across a concatenation or an intermediate
+    ///   constant.** `"com.apple." + "containerization"` re-inlined at the
+    ///   create site defeats `contains` while restoring the behaviour.
+    /// - A file hardcoding a *different* wrong root (`~/.arca/containers`, say);
+    ///   a file where `containerDirectory(in:dockerID:)` is correct but
+    ///   `createNativeContainer` no longer calls it; any change at all to the
+    ///   runtime behaviour of the create path.
+    ///
+    /// **THE INSTRUMENT THAT CATCHES ALL OF THESE IS GAS CAN'S LIVE `Create`
+    /// TEST, AND IT LIVES IN THE OTHER REPOSITORY.** Under the first mutation
+    /// above, MEASURED: it fails with `NSPOSIXErrorDomain Code=2`, finds the
+    /// engine's own `<state-root>/images/containers/` empty, and catches Apple's
+    /// shared store growing by one directory (253 -> 254). These two tests are a
+    /// tripwire for the textual defect and not coverage of the behavioural one.
+    ///
+    /// It also forbids the string in comments, deliberately -- a comment
+    /// asserting the wrong store is how the old derivation stayed plausible for
+    /// as long as it did.
+    func testTheContainerBridgeCreatePathCarriesNoLiteralPathToApplesSharedStore() throws {
         let source = try Self.containerManagerSource()
 
         XCTAssertFalse(
@@ -269,9 +298,11 @@ final class ContainerBridgePathsTests: XCTestCase {
     /// `<store>/containers/<id>` must be derived in one place in this file.
     ///
     /// Two spellings drifting apart is the defect itself, not a stylistic
-    /// concern: the create path and `getRootfsPath` each derived this directory
-    /// and only one of them was moved when `ContainerManager` gained an image
-    /// store root.
+    /// concern: the create path and the since-deleted `getRootfsPath` each
+    /// derived this directory and only one of them was moved when
+    /// `ContainerManager` gained an image-store root. **Only the create path's
+    /// copy ever executed** -- `getRootfsPath` had no callers, which is why the
+    /// drift survived unnoticed and why it is gone rather than corrected.
     ///
     /// Exactly one, not at most one: `at most` passes vacuously over a file
     /// where the derivation was respelt (`appending(path:)`) and duplicated
@@ -281,10 +312,18 @@ final class ContainerBridgePathsTests: XCTestCase {
     /// once in this file.
     ///
     /// WHAT IT DOES NOT PROVE: that the one occurrence is rooted at the
-    /// manager's store, that either caller reaches it, or anything about
-    /// runtime. A single occurrence rooted at a hardcoded path satisfies it --
-    /// that is what the test above is for, and neither test covers the other's
-    /// gap at runtime.
+    /// manager's store, that any caller reaches it, or anything about runtime. A
+    /// single occurrence rooted at a hardcoded path satisfies it -- that is what
+    /// the test above is for, and neither test covers the other's gap at
+    /// runtime.
+    ///
+    /// It counts over the whole file, comments included, so a doc comment that
+    /// *quotes* this token fails the suite. That is why the comment on
+    /// `containerDirectory(in:dockerID:)` describes the join instead of spelling
+    /// it, and a future reader who does not know that will be puzzled by a red
+    /// suite after writing prose. Left as-is rather than narrowed to code: a
+    /// counter that skipped comments would stop forbidding the wrong store in a
+    /// comment, which is the other half of what these two tests are for.
     func testTheContainersDirectoryIsDerivedInExactlyOnePlace() throws {
         let source = try Self.containerManagerSource()
 

--- a/Tests/ArcaEngineTests/CrashRecoveryTests.swift
+++ b/Tests/ArcaEngineTests/CrashRecoveryTests.swift
@@ -1,0 +1,189 @@
+import ContainerBridge
+import Foundation
+import Logging
+import XCTest
+@testable import ArcaEngine
+
+/// The restore loop's crash-recovery write -- the milestone's whole thesis.
+///
+/// `ContainerManager.initialize()` ends in `loadPersistedState()`, which marks
+/// every container the StateStore records as `running` exited with code 137 and
+/// **writes that back** (`ContainerManager.swift:371-393`). That write is what
+/// made `initialize()` unsafe against a state root shared with a live
+/// ArcaDaemon, and giving the engine its own root is what made it safe.
+///
+/// A real start against a fresh root reports `Found persisted containers count=0`
+/// and `restored=0`. That proves the loop RAN and says nothing about what it does
+/// to a `running` row -- which is the only part anyone depends on. Nobody would
+/// learn a mis-decode or a write against the wrong row until an engine restarted
+/// holding live containers, the one moment the write matters.
+///
+/// `loadPersistedState()` is `package` precisely so this can be driven: it is
+/// VM-free and needs no kernel, no vminit and no vmnet, unlike the
+/// `initialize()` that normally calls it. That also makes it the only way the
+/// loop executes at all while `arca-engine` is unsigned, since an unsigned
+/// engine dies at `VmnetNetwork()` before ever reaching it.
+final class CrashRecoveryTests: XCTestCase {
+    private static let unbootedKernel = URL(fileURLWithPath: "/opt/arca/vmlinux")
+    private let logger = Logger(label: "arca-engine-tests")
+
+    /// Two containers, not one, and the survivor carries a distinctive exit
+    /// code.
+    ///
+    /// With a single `running` container, "everything is now 137" and "the
+    /// running one is now 137" are the same observation, and the first is a real
+    /// failure mode: dropping the `status == "running"` guard rewrites every
+    /// stopped container's exit code to 137, so `docker ps -a` would report a
+    /// clean exit as a SIGKILL forever after. The second seed exits 42 and must
+    /// still exit 42.
+    ///
+    /// Asserted in memory AND in the store. The in-memory half alone cannot
+    /// distinguish a correct write from one aimed at the wrong row -- the loop
+    /// builds `ContainerInfo` from its own local `actualExitCode`, so the map
+    /// would read 137 even if `updateContainerStatus` had written to the other
+    /// container. The store is read back through a SECOND `StateStore` over the
+    /// same file, so what is asserted is what persisted, not what one connection
+    /// remembers.
+    ///
+    /// MEASURED, both halves load-bearing (`swift test --filter ArcaEngineTests`):
+    ///
+    /// - with the `status == "running"` guard widened to `if true`, so every row
+    ///   recovers: `Executed 63 tests, with 2 failures` -- the survivor's exit
+    ///   code read 137 instead of 42, in memory and in the store.
+    /// - with the `stateStore.updateContainerStatus` call deleted and the
+    ///   in-memory recovery left intact: `Executed 63 tests, with 3 failures`,
+    ///   and **every in-memory assertion above still passed**. Only the three
+    ///   store assertions caught it. That is the whole reason this test reads the
+    ///   database back.
+    ///
+    /// Restored: `Executed 63 tests, with 0 failures`.
+    func testARunningContainerIsRecoveredAsExited137AndNoOtherRowIsTouched() async throws {
+        let paths = Self.temporaryPaths()
+        let seedStore = try StateStore(path: paths.stateDatabase.path, logger: logger)
+        try await Self.seed(
+            into: seedStore, id: Self.crashedID, name: "crashed-probe",
+            status: "running", running: true, exitCode: 0, finishedAt: nil
+        )
+        try await Self.seed(
+            into: seedStore, id: Self.stoppedID, name: "stopped-probe",
+            status: "exited", running: false, exitCode: 42, finishedAt: Date()
+        )
+
+        let manager = Self.manager(paths: paths, stateStore: seedStore, logger: logger)
+        try await manager.loadPersistedState()
+
+        // In memory, through the public read the engine's Inspect will use.
+        let crashedRead = try await manager.getContainer(id: Self.crashedID)
+        let crashed = try XCTUnwrap(crashedRead)
+        XCTAssertEqual(
+            crashed.state.status, "exited",
+            "a container the StateStore recorded as running died with the previous "
+                + "engine process; the VM is gone and it must not read as running"
+        )
+        XCTAssertEqual(
+            crashed.state.exitCode, 137,
+            "crash recovery reports SIGKILL (128 + 9), which is what killed the VM"
+        )
+
+        let stoppedRead = try await manager.getContainer(id: Self.stoppedID)
+        let stopped = try XCTUnwrap(stoppedRead)
+        XCTAssertEqual(stopped.state.status, "exited")
+        XCTAssertEqual(
+            stopped.state.exitCode, 42,
+            "a container that was already exited must keep the code it exited with; "
+                + "rewriting every row to 137 would report every clean exit as a kill"
+        )
+
+        // In the store, through a second connection over the same database.
+        let reread = try StateStore(path: paths.stateDatabase.path, logger: logger)
+        let rows = try await Dictionary(
+            uniqueKeysWithValues: reread.loadAllContainers().map { ($0.id, $0) }
+        )
+
+        let crashedRow = try XCTUnwrap(rows[Self.crashedID])
+        XCTAssertEqual(
+            crashedRow.status, "exited",
+            "the recovery must be persisted, or the next start recovers it again"
+        )
+        XCTAssertEqual(crashedRow.exitCode, 137)
+        XCTAssertNotNil(
+            crashedRow.finishedAt,
+            "a container recorded as exited with no finish time is a row Inspect "
+                + "cannot answer about"
+        )
+
+        let stoppedRow = try XCTUnwrap(rows[Self.stoppedID])
+        XCTAssertEqual(
+            stoppedRow.exitCode, 42,
+            "the write must land on the crashed container's row and no other; the "
+                + "in-memory assertions above cannot see a write aimed at this one"
+        )
+        XCTAssertEqual(stoppedRow.status, "exited")
+    }
+
+    // MARK: - Fixtures
+
+    /// Docker IDs are 64 characters, and `loadPersistedState()` derives the
+    /// native ID from the first 32 -- two seeds sharing those 32 would overwrite
+    /// each other in `reverseMapping` and one would vanish from every listing.
+    private static let crashedID = String(repeating: "a", count: 64)
+    private static let stoppedID = String(repeating: "b", count: 64)
+
+    private static func temporaryPaths() -> EnginePaths {
+        EnginePaths(
+            stateRoot: URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("arca-crash-recovery-\(UUID().uuidString)")
+        )
+    }
+
+    private static func manager(
+        paths: EnginePaths, stateStore: StateStore, logger: Logger
+    ) -> ContainerManager {
+        ContainerManager(
+            imageManager: try! ImageManager(
+                logger: logger, imageStorePath: paths.imageStoreRoot
+            ),
+            kernelPath: unbootedKernel.path,
+            imageStoreRoot: paths.imageStoreRoot,
+            layerCachePath: paths.layerCache,
+            stateStore: stateStore,
+            logger: logger
+        )
+    }
+
+    private static func seed(
+        into store: StateStore,
+        id: String,
+        name: String,
+        status: String,
+        running: Bool,
+        exitCode: Int,
+        finishedAt: Date?
+    ) async throws {
+        let encoder = JSONEncoder()
+        try await store.saveContainer(
+            id: id,
+            name: name,
+            image: "arca/probe:latest",
+            imageID: "sha256:probe",
+            createdAt: Date(),
+            status: status,
+            running: running,
+            paused: false,
+            restarting: false,
+            pid: 0,
+            exitCode: exitCode,
+            startedAt: Date(),
+            finishedAt: finishedAt,
+            stoppedByUser: false,
+            entrypoint: nil,
+            configJSON: String(
+                decoding: try encoder.encode(
+                    ContainerConfiguration(image: "arca/probe:latest")
+                ),
+                as: UTF8.self
+            ),
+            hostConfigJSON: String(decoding: try encoder.encode(HostConfig()), as: UTF8.self)
+        )
+    }
+}

--- a/Tests/ArcaEngineTests/CrashRecoveryTests.swift
+++ b/Tests/ArcaEngineTests/CrashRecoveryTests.swift
@@ -146,6 +146,7 @@ final class CrashRecoveryTests: XCTestCase {
             kernelPath: unbootedKernel.path,
             imageStoreRoot: paths.imageStoreRoot,
             layerCachePath: paths.layerCache,
+            logRoot: paths.logsRoot,
             stateStore: stateStore,
             logger: logger
         )

--- a/Tests/ArcaEngineTests/CreateTests.swift
+++ b/Tests/ArcaEngineTests/CreateTests.swift
@@ -53,9 +53,21 @@ final class CreateTests: XCTestCase {
     ///
     /// - the two volumes are IN the report, so they were created before the
     ///   network step ran;
-    /// - the container is NOT in the report, and `getContainer` confirms none
-    ///   was made, so the container step is genuinely after the network step
-    ///   rather than merely listed after it.
+    /// - **`failed.error.resource` is the network's name**, so the run stopped
+    ///   at the network step and the container step never ran. That is the
+    ///   assertion which catches a reorder: moving the container block above the
+    ///   network block makes the resource the sandbox id instead. MEASURED in
+    ///   Task 11's review, which performed exactly that move and caught it here
+    ///   and nowhere else.
+    ///
+    /// The `getContainer` check at the end is a **host cross-check, not the
+    /// ordering proof**, and the distinction was a review finding: this doc
+    /// comment used to credit it with the ordering. `createContainer` throws
+    /// `notInitialized` before doing any work (`ContainerManager.swift:1659`),
+    /// so `getContainer` returns nil whatever the order is, and that assertion
+    /// cannot fail in this fixture. It stays because "the engine reported no
+    /// container" and "no container is on the host" are different claims and
+    /// both are worth making -- but it is credited only for what it shows.
     ///
     /// `created` is asserted as a whole set, not for non-emptiness. A create
     /// that reported only its first volume would pass any weaker check while
@@ -97,8 +109,59 @@ final class CreateTests: XCTestCase {
         let container = try await engine.managers.containerManager.getContainer(id: Self.sandboxId)
         XCTAssertNil(
             container,
-            "the container step must not have run: it comes after the network step, and the "
-                + "network step failed"
+            "host cross-check: no container may be left behind by a create that failed before "
+                + "the container step. This cannot fail in this fixture -- see the note above "
+                + "-- so the ordering is proved by the error.resource assertion, not by this"
+        )
+    }
+
+    /// **`create` hands `createContainer` the exact digest reference, not a
+    /// stored tag.**
+    ///
+    /// This is the one assertion the whole of Problem 1 rests on. Widening
+    /// `ImageManager.resolveImage` -- a resolver shared with Arca's Docker
+    /// surface -- was justified by `create` needing to pass
+    /// `repository@sha256:<hex>`, because that same string is what
+    /// `createContainer` records as `ContainerInfo.image` (`:1901`), what
+    /// `startContainer:2218` re-resolves after a restart, and what `Inspect`
+    /// re-parses (`SandboxEngineService.swift:196`).
+    ///
+    /// **Nothing pinned it until now.** Task 11's review replaced the deciding
+    /// line with `references.first ?? …` -- the arrangement Problem 1 explicitly
+    /// rejected -- and all 123 tests passed. Every sandbox would have recorded
+    /// `workspace:latest`, and `Inspect` would have answered `invalid_output`
+    /// for every one of them, with a green suite.
+    ///
+    /// It goes through `createSpec(for:)`, which is the seam `create(request:)`
+    /// itself calls -- not a reconstruction of what it might build -- so there
+    /// is no second path this can drift onto. The digest is the store's own,
+    /// read back from the loaded image, so a spec carrying any other string
+    /// fails here.
+    func testCreateHandsContainerBridgeTheExactDigestReferenceAndNotAStoredTag() async throws {
+        let engine = try await preparedEngine()
+
+        let spec: SandboxContainerSpec
+        switch await engine.service.createSpec(for: engine.request()) {
+        case .failure(let error):
+            return XCTFail("the fixture must translate, got \(error.code): \(error.message)")
+        case .success(let translated):
+            spec = translated
+        }
+
+        XCTAssertEqual(
+            spec.image, "workspace@sha256:\(engine.hex)",
+            "createContainer must be handed the exact digest reference; a stored tag resolves "
+                + "but makes Inspect answer invalid_output for every sandbox this engine creates"
+        )
+        // The store really does hold that content under a TAG, so this is not a
+        // test that would pass by the two strings happening to coincide.
+        let stored = try await engine.managers.imageManager.inspectImage(
+            nameOrId: "workspace:latest"
+        )
+        XCTAssertEqual(
+            stored?.repoTags, ["workspace:latest"],
+            "the store's own reference is a tag, so the digest form above was constructed "
+                + "rather than copied from the row"
         )
     }
 

--- a/Tests/ArcaEngineTests/CreateTests.swift
+++ b/Tests/ArcaEngineTests/CreateTests.swift
@@ -1,0 +1,313 @@
+import ContainerBridge
+import Foundation
+import Logging
+import SandboxEngineProto
+import XCTest
+@testable import ArcaEngine
+
+/// `Create` driven through the engine's own managers: the order the steps run
+/// in, and what a partial failure reports.
+///
+/// **What is proved here and what is not, stated plainly.** `createContainer`
+/// guards on `nativeManager` (`ContainerManager.swift:1659`) and
+/// `NetworkManager.createNetwork` on a WireGuard backend
+/// (`NetworkManager.swift:396-398`); both are assigned only inside an
+/// `initialize()` that constructs a live `Containerization.VmnetNetwork` and
+/// needs the virtualization entitlement. So no test in this target can watch a
+/// sandbox boot.
+///
+/// What that leaves is more useful than it sounds. Both guards throw *before*
+/// doing any work, which means a real `create(request:)` over real managers runs
+/// its steps in order and fails at a known one -- and the report it produces at
+/// that point is exactly the thing `CreateFailed.created` exists for. So the
+/// ordering, the evidence, and the refusals are all measured against production
+/// code here; only the sandbox itself is out of reach:
+///
+/// - **Proved here:** volumes are created before the network, the network before
+///   the container, an offline create makes no network at all, the resources
+///   already created are reported as a set, and every refusal reports an empty
+///   `created` because it happens before the first create.
+/// - **Proved in `CreateTranslationTests`:** every argument `createContainer` is
+///   handed, including the name, the labels, the network mode and the port
+///   bindings.
+/// - **Proved in `ImageResolutionTests`:** that the store resolves the reference
+///   `Create` hands it.
+/// - **NOT proved anywhere in this target:** that the container is created, that
+///   it starts, and that its ports are published. Publication in particular is
+///   routed to Task 13 -- see `EngineManagers.wireCollaborators()` for why no
+///   VM-free test of it would mean anything.
+final class CreateTests: XCTestCase {
+    private let logger = Logger(label: "create-tests")
+    private static let sandboxId = "gascan-sbx-4f2a-9c11"
+
+    // MARK: - Ordering and the evidence a partial failure carries
+
+    /// Volumes are created, the network step then fails, and the report names
+    /// the volumes and nothing else.
+    ///
+    /// This is the ordering test and the `CreateFailed.created` test at once,
+    /// because the two cannot be separated: the report is the only window onto
+    /// the order. The network step fails here for a real reason --
+    /// `createNetwork` needs a WireGuard backend that only `initialize()` builds
+    /// -- and that is what makes the assertion sharp in both directions:
+    ///
+    /// - the two volumes are IN the report, so they were created before the
+    ///   network step ran;
+    /// - the container is NOT in the report, and `getContainer` confirms none
+    ///   was made, so the container step is genuinely after the network step
+    ///   rather than merely listed after it.
+    ///
+    /// `created` is asserted as a whole set, not for non-emptiness. A create
+    /// that reported only its first volume would pass any weaker check while
+    /// leaving the second on the host with nothing that will ever name it --
+    /// which is the precise failure `engine.proto:279-283` describes.
+    func testAFailedNetworkStepReportsTheVolumesAlreadyCreatedAndNoContainer() async throws {
+        let engine = try await preparedEngine()
+
+        let response = await engine.service.create(request: engine.request(
+            volumes: [
+                (name: "gascan-cache-\(Self.sandboxId)", path: "/home/workspace/.cache"),
+                (name: "gascan-config-\(Self.sandboxId)", path: "/home/workspace/.config"),
+            ],
+            network: .networkedName("sbx-net")
+        ))
+
+        guard case .failed(let failed) = response.outcome else {
+            return XCTFail("the network step cannot succeed here, got \(response.outcome as Any)")
+        }
+        XCTAssertEqual(
+            Self.described(failed.created),
+            [
+                "volume gascan-cache-\(Self.sandboxId) gascan/\(Self.sandboxId)",
+                "volume gascan-config-\(Self.sandboxId) gascan/\(Self.sandboxId)",
+            ],
+            "a partial failure must report every resource it created and only those"
+        )
+        XCTAssertEqual(failed.error.resource, "sbx-net", "the failure must name the step that failed")
+
+        let volumes = try await engine.managers.volumeManager.listVolumes().map(\.name).sorted()
+        XCTAssertEqual(
+            volumes,
+            [
+                "gascan-cache-\(Self.sandboxId)",
+                "gascan-config-\(Self.sandboxId)",
+            ],
+            "the reported volumes must be the ones that are really on the host"
+        )
+        let container = try await engine.managers.containerManager.getContainer(id: Self.sandboxId)
+        XCTAssertNil(
+            container,
+            "the container step must not have run: it comes after the network step, and the "
+                + "network step failed"
+        )
+    }
+
+    /// An offline create makes no network resource, and reaches the container
+    /// step.
+    ///
+    /// Two things at once, and both matter. `created` holds the volume and no
+    /// network, so the network step really was skipped rather than run and
+    /// silently succeeded; and the failure comes from `createContainer` itself,
+    /// which is how this test proves the container step is reached at all --
+    /// without it, the test above could not tell "the container step is last"
+    /// from "there is no container step".
+    ///
+    /// `listNetworks` is asserted as well as `created`, because those are
+    /// different claims: one is what the engine reported, the other is what is
+    /// on the host, and an offline sandbox that quietly created a network would
+    /// leak one the consumer was never told about.
+    func testAnOfflineCreateMakesNoNetworkAndReachesTheContainerStep() async throws {
+        let engine = try await preparedEngine()
+
+        let response = await engine.service.create(request: engine.request(
+            volumes: [(name: "gascan-cache-\(Self.sandboxId)", path: "/home/workspace/.cache")],
+            network: .offline(Arca_Engine_V1_Offline())
+        ))
+
+        guard case .failed(let failed) = response.outcome else {
+            return XCTFail("the container step cannot succeed here, got \(response.outcome as Any)")
+        }
+        XCTAssertEqual(
+            Self.described(failed.created),
+            ["volume gascan-cache-\(Self.sandboxId) gascan/\(Self.sandboxId)"],
+            "an offline create must report its volume and no network"
+        )
+        XCTAssertEqual(
+            failed.error.resource, Self.sandboxId,
+            "the failure must be the container step, named by the sandbox id"
+        )
+        XCTAssertEqual(
+            failed.error.message, "ContainerManager not initialized",
+            "and it must be the uninitialised-manager guard rather than an earlier refusal, "
+                + "which is what shows the container step was actually reached"
+        )
+
+        let networks = try await engine.managers.networkManager.listNetworks()
+        XCTAssertEqual(
+            networks.map(\.name), [],
+            "offline means no network attachment, so no network may be created for one"
+        )
+    }
+
+    // MARK: - The refusals that happen before anything is created
+
+    /// The image is resolved from the request's digest: one the store holds gets
+    /// past the gate, one it does not is refused before a single resource is
+    /// made.
+    ///
+    /// The pairing is what makes this a test of the lookup rather than of the
+    /// error path. The two digests differ in one hex character and name the same
+    /// repository, so an engine that refused everything fails the first half and
+    /// one that refused nothing fails the second. The held half is recognised by
+    /// how far it gets: past the image gate, through the volume step, and into
+    /// `createContainer`'s own guard.
+    ///
+    /// The refused half asserts `created` is empty AND that no volume reached
+    /// the host. Those are separate failures -- a create that made the volume
+    /// and reported nothing is the leak, not the refusal.
+    func testAHeldDigestPassesTheImageGateAndAnAbsentOneIsRefusedBeforeAnythingIsCreated() async throws {
+        let engine = try await preparedEngine()
+        let volumes = [(name: "gascan-cache-\(Self.sandboxId)", path: "/home/workspace/.cache")]
+
+        // The refused half runs first, deliberately: it asserts that the host is
+        // untouched, and that assertion is only worth making while the host is
+        // known to be empty.
+        let flipped = engine.hex.first == "0"
+            ? "1" + engine.hex.dropFirst()
+            : "0" + engine.hex.dropFirst()
+        let absent = await engine.service.create(
+            request: engine.request(volumes: volumes, hex: String(flipped))
+        )
+        guard case .failed(let refused) = absent.outcome else {
+            return XCTFail("a digest the store lacks must be refused, got \(absent.outcome as Any)")
+        }
+        XCTAssertEqual(refused.error.code, "not_found")
+        XCTAssertEqual(refused.error.resource, "workspace@sha256:\(flipped)")
+        XCTAssertEqual(
+            refused.created, [],
+            "a create refused at the image gate must report nothing created"
+        )
+        let untouched = try await engine.managers.volumeManager.listVolumes().map(\.name)
+        XCTAssertEqual(untouched, [], "and must not have created anything either")
+
+        let held = await engine.service.create(request: engine.request(volumes: volumes))
+        guard case .failed(let past) = held.outcome else {
+            return XCTFail("expected the container-step failure, got \(held.outcome as Any)")
+        }
+        XCTAssertEqual(
+            past.error.resource, Self.sandboxId,
+            "a digest the store holds must get past the image gate and reach the container step"
+        )
+    }
+
+    /// A hex sandbox id is refused before any resource is made.
+    ///
+    /// `CreateTranslationTests` proves the refusal itself; this proves it stands
+    /// in front of the volume step in the real method, which is the only place
+    /// the ordering can go wrong.
+    func testAHexSandboxIdIsRefusedBeforeAnyVolumeIsCreated() async throws {
+        let engine = try await preparedEngine()
+
+        let response = await engine.service.create(request: engine.request(
+            sandboxId: "deadbeefcafe",
+            volumes: [(name: "gascan-cache-x", path: "/home/workspace/.cache")]
+        ))
+
+        guard case .failed(let failed) = response.outcome else {
+            return XCTFail("a hex sandbox id must be refused, got \(response.outcome as Any)")
+        }
+        XCTAssertEqual(failed.error.code, "invalid_resource_identity")
+        XCTAssertEqual(failed.created, [])
+        let untouched = try await engine.managers.volumeManager.listVolumes().map(\.name)
+        XCTAssertEqual(untouched, [], "the refusal must come before the volume step")
+    }
+
+    // MARK: - Fixtures
+
+    /// A resource as `kind name managed_by/sandbox_id`.
+    ///
+    /// Compared as strings so that the whole of `created` is one equality: kind,
+    /// name and both owner labels for every resource, in order. Asserting the
+    /// messages field by field would leave the owner unchecked on the resource
+    /// nobody thought to check.
+    private static func described(_ resources: [Arca_Engine_V1_Resource]) -> [String] {
+        resources.map { resource in
+            let kind = "\(resource.identity.kind)".replacingOccurrences(of: "RESOURCE_KIND_", with: "")
+            return "\(kind.lowercased()) \(resource.identity.name) "
+                + "\(resource.owner.managedBy)/\(resource.owner.sandboxID)"
+        }
+    }
+
+    private struct PreparedEngine {
+        let managers: EngineManagers
+        let service: SandboxEngineService
+        /// Read back from the store rather than computed: Containerization
+        /// synthesizes an index during import, so the digest the store records
+        /// is not one this test could state in advance.
+        let hex: String
+
+        func request(
+            sandboxId: String = CreateTests.sandboxId,
+            volumes: [(name: String, path: String)] = [],
+            network: Arca_Engine_V1_Network.OneOf_Mode = .offline(Arca_Engine_V1_Offline()),
+            hex overrideHex: String? = nil
+        ) -> Arca_Engine_V1_CreateRequest {
+            var request = CreateTranslationTests.request(
+                sandboxId: sandboxId,
+                owner: Arca_Engine_V1_OwnerLabels.with {
+                    $0.managedBy = "gascan"
+                    $0.sandboxID = CreateTests.sandboxId
+                },
+                volumes: volumes.map { (name: $0.name, path: $0.path, capacity: UInt64(0)) },
+                network: network
+            )
+            request.image = Arca_Engine_V1_ImageDigest.with {
+                $0.repository = "workspace"
+                $0.sha256Hex = overrideHex ?? hex
+            }
+            return request
+        }
+    }
+
+    /// The engine's own managers over a throwaway state root, holding one real
+    /// workspace image loaded through the path `arca-engine image load` uses.
+    ///
+    /// `VolumeManager.initialize()` is the only `initialize()` called: it
+    /// touches the filesystem and the store and nothing else. `ContainerManager`
+    /// and `NetworkManager` are left uninitialised deliberately -- theirs
+    /// construct a live `VmnetNetwork` -- and their guards are what these tests
+    /// fail against.
+    private func preparedEngine() async throws -> PreparedEngine {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("arca-create-tests-\(UUID().uuidString)")
+        let stateRoot = root.appendingPathComponent("state")
+        _ = try await loadWorkspaceImages(
+            fromOCILayout: try OCILayoutFixture.write(
+                at: root.appendingPathComponent("workspace"),
+                reference: "workspace:latest",
+                payload: "pushed by the consumer, not by startup"
+            ),
+            stateRoot: stateRoot,
+            logger: logger
+        )
+
+        let managers = try EngineManagers(
+            stateRoot: stateRoot,
+            kernelPath: URL(fileURLWithPath: "/opt/arca/vmlinux"),
+            logLevel: "info",
+            logger: logger
+        )
+        try await managers.volumeManager.initialize()
+        await managers.wireCollaborators()
+
+        let details = try await managers.imageManager.inspectImage(nameOrId: "workspace:latest")
+        let digest = try XCTUnwrap(
+            details?.repoDigests.first, "the store must report a digest for the image it loaded"
+        )
+        return PreparedEngine(
+            managers: managers,
+            service: managers.makeService(),
+            hex: digest.replacingOccurrences(of: "sha256:", with: "")
+        )
+    }
+}

--- a/Tests/ArcaEngineTests/CreateTranslationTests.swift
+++ b/Tests/ArcaEngineTests/CreateTranslationTests.swift
@@ -1,0 +1,401 @@
+import ContainerBridge
+import SandboxEngineProto
+import XCTest
+@testable import ArcaEngine
+
+/// `sandboxContainerSpec(for:image:)`: every `CreateRequest` field translated or
+/// refused.
+///
+/// **These are the half of `Create` that a VM cannot help with, and the half a
+/// VM would hide.** `createContainer` guards on `nativeManager`
+/// (`ContainerManager.swift:1659`), which `initialize()` assigns and
+/// `initialize()` builds a live `Containerization.VmnetNetwork`, so no test in
+/// this target reaches the call. That is not the reason these exist, though: a
+/// test that booted a sandbox and then read its config back would prove the
+/// translation only where ContainerBridge chose to store it, and would say
+/// nothing at all about the fields that are refused -- a refusal produces no
+/// sandbox to inspect.
+///
+/// So the arguments `createContainer` is handed are asserted as a value, here,
+/// and what ContainerBridge does with them afterwards is ContainerBridge's own
+/// behaviour. `create(request:)` builds exactly one of these and passes exactly
+/// these fields; there is no parallel path in which the two could differ.
+final class CreateTranslationTests: XCTestCase {
+    private static let sandboxId = "gascan-sbx-4f2a-9c11"
+    private static let image = "workspace@sha256:" + String(repeating: "a", count: 64)
+
+    // MARK: - The identity the container is created under
+
+    /// The container is named the sandbox id and carries the owner labels
+    /// verbatim.
+    ///
+    /// Both halves are exact equalities rather than "contains": gascan builds
+    /// the expected container identity as the request id itself
+    /// (`crates/gascan-core/src/runtime.rs:954`) and discards any created
+    /// resource whose ownership is not its own (`:962-975`), so a prefix, a
+    /// suffix, or a third label makes every create fail on the consumer's side
+    /// rather than degrade.
+    ///
+    /// The label values are deliberately NOT the sandbox id here. The engine
+    /// stores what it is given and never interprets it (engine.proto:143-148),
+    /// and a fixture whose `sandbox_id` label happened to equal the request's
+    /// `sandbox_id` field would pass just as well against an engine that
+    /// synthesised the labels from the request and ignored `owner` entirely.
+    func testTheContainerIsNamedTheSandboxIdAndCarriesTheOwnerLabelsVerbatim() throws {
+        let spec = try translated(Self.request(owner: Self.owner(
+            managedBy: "some-other-manager", sandboxId: "some-other-id"
+        )))
+
+        XCTAssertEqual(spec.name, Self.sandboxId)
+        XCTAssertEqual(spec.labels, [
+            "dev.gascan.managed-by": "some-other-manager",
+            "dev.gascan.sandbox-id": "some-other-id",
+        ])
+    }
+
+    /// A half-set `OwnerLabels` is refused rather than stored.
+    ///
+    /// An engine that created three volumes and a container under an empty
+    /// `managed_by` would report them all and have the whole report discarded
+    /// by the consumer (`runtime.rs:962-975`) -- four resources on the host and
+    /// a failure that names none of them.
+    func testAHalfSetOwnerIsRefused() {
+        let refusal = Self.refusal(of: Self.request(owner: Self.owner(
+            managedBy: "gascan", sandboxId: ""
+        )))
+        XCTAssertEqual(refusal?.code, "invalid_resource_identity")
+        XCTAssertEqual(refusal?.resource, Self.sandboxId)
+    }
+
+    /// The carried-over finding from Task 7: a pure-hex sandbox id is refused.
+    ///
+    /// `resolveContainerID` prefix-matches any hex string of four or more
+    /// characters against every container the engine holds and returns
+    /// `matches.sorted().first` on more than one hit
+    /// (`ContainerManager.swift:2005-2023`). While every method was read-only
+    /// that cost a wrong report; `Create` acts on the match.
+    ///
+    /// The second half is what makes the first mean something: one hyphen is the
+    /// only difference between the two ids, and it is exactly the character that
+    /// takes a real gascan id off that path.
+    func testAPureHexSandboxIdIsRefusedAndOneHyphenIsEnoughToBeAccepted() throws {
+        let hex = "deadbeefcafe"
+        let refusal = Self.refusal(of: Self.request(sandboxId: hex))
+        XCTAssertEqual(refusal?.code, "invalid_resource_identity")
+        XCTAssertEqual(refusal?.resource, hex)
+
+        let hyphenated = "deadbeef-cafe"
+        let spec = try translated(Self.request(sandboxId: hyphenated))
+        XCTAssertEqual(spec.name, hyphenated)
+    }
+
+    // MARK: - Network
+
+    /// Offline means no network attachment, and `none` is the mode that means
+    /// it.
+    ///
+    /// The pairing is the assertion. `startContainer` skips auto-attachment for
+    /// exactly two modes, `none` and `host` (`ContainerManager.swift:2356`), and
+    /// auto-attaches to `bridge` for everything else including the empty string
+    /// and `default` (`:2359-2363`). So "offline" and "networked" must land on
+    /// different sides of that test, and a translation that emitted `""` for
+    /// offline would attach it to the default bridge -- an offline sandbox with
+    /// egress, reported as created.
+    func testOfflineAttachesNoNetworkAndANamedNetworkIsAttachedByName() throws {
+        let offline = try translated(Self.request(network: .offline(Arca_Engine_V1_Offline())))
+        XCTAssertEqual(offline.networkMode, "none")
+
+        let named = try translated(Self.request(network: .networkedName("sbx-net")))
+        XCTAssertEqual(named.networkMode, "sbx-net")
+    }
+
+    /// A request that states no network mode is refused rather than defaulted.
+    ///
+    /// An unset `oneof` arrives as nil, and the tempting default is offline --
+    /// which would silently give a sandbox that asked for a network no egress,
+    /// or, if the default went the other way, give an offline sandbox egress.
+    func testAnUnsetNetworkModeIsRefused() {
+        var request = Self.request()
+        request.network.mode = nil
+        XCTAssertEqual(Self.refusal(of: request)?.code, "invalid_state")
+    }
+
+    // MARK: - Ports
+
+    /// Ports publish on loopback, and the binding is written in the form the
+    /// publisher needs.
+    ///
+    /// `127.0.0.1` is not cosmetic here: `PortMapManager` spawns the userspace
+    /// proxy that makes a host port reachable only for a loopback host address
+    /// (`PortMapManager.swift:105-107`), and `PortBinding`'s own default is
+    /// `0.0.0.0` (`Types.swift:303`) -- so a translation that omitted the
+    /// address would take the nftables-only path and publish nothing a host
+    /// process could connect to.
+    ///
+    /// This asserts the INPUT to publication and nothing more. Whether a port is
+    /// then actually published passes through two further gates that need a
+    /// booted VM to see; see `EngineManagers.wireCollaborators()`.
+    func testPortsAreWrittenAsLoopbackBindingsKeyedByGuestPort() throws {
+        let spec = try translated(Self.request(ports: [(host: 18080, guest: 8080)]))
+
+        XCTAssertEqual(spec.portBindings.keys.sorted(), ["8080/tcp"])
+        let binding = try XCTUnwrap(spec.portBindings["8080/tcp"]?.first)
+        XCTAssertEqual(binding.hostIp, "127.0.0.1")
+        XCTAssertEqual(binding.hostPort, "18080")
+    }
+
+    /// A guest port mapped twice is refused rather than silently collapsed.
+    ///
+    /// The bindings are a dictionary keyed by guest port, so the second mapping
+    /// would overwrite the first and the consumer would never hear that one of
+    /// the ports it asked for was dropped. The consumer refuses a repeated HOST
+    /// port itself (`crates/gascan-arca/src/translate.rs:120-125`) and says
+    /// nothing about the guest side, so this is the only place it can be caught.
+    func testAGuestPortMappedTwiceIsRefused() {
+        let refusal = Self.refusal(of: Self.request(ports: [
+            (host: 18080, guest: 8080), (host: 18081, guest: 8080),
+        ]))
+        XCTAssertEqual(refusal?.code, "invalid_state")
+        XCTAssertEqual(
+            refusal?.message,
+            "guest port 8080 is mapped twice, and a container's port bindings are keyed by "
+                + "guest port, so one of the two would be lost"
+        )
+    }
+
+    /// And a host port mapped twice, which would collide in the publisher's own
+    /// allocation table (`PortMapManager.swift:93-101`).
+    func testAHostPortMappedTwiceIsRefused() {
+        let refusal = Self.refusal(of: Self.request(ports: [
+            (host: 18080, guest: 8080), (host: 18080, guest: 9090),
+        ]))
+        XCTAssertEqual(refusal?.code, "invalid_state")
+        XCTAssertEqual(refusal?.message, "host port 18080 is mapped twice")
+    }
+
+    /// Zero is not a port. `PortMapping` is `uint32` on the wire, so it is
+    /// representable, and `UInt16(0)` would convert cleanly into a binding that
+    /// means nothing.
+    func testPortZeroIsRefused() {
+        XCTAssertEqual(
+            Self.refusal(of: Self.request(ports: [(host: 0, guest: 8080)]))?.code, "invalid_state"
+        )
+        XCTAssertEqual(
+            Self.refusal(of: Self.request(ports: [(host: 18080, guest: 0)]))?.code, "invalid_state"
+        )
+    }
+
+    // MARK: - Mounts and volumes
+
+    /// The project mount and the named volumes become binds, project first.
+    func testTheProjectMountAndTheVolumesBecomeBinds() throws {
+        let spec = try translated(Self.request(volumes: [
+            (name: "gascan-cache-x", path: "/home/workspace/.cache", capacity: 1 << 30),
+        ]))
+        XCTAssertEqual(spec.binds, [
+            "/Users/someone/project:/workspace",
+            "gascan-cache-x:/home/workspace/.cache",
+        ])
+    }
+
+    /// A guest path that is not absolute is refused.
+    ///
+    /// `parseVolumeMounts` splits a bind on `:` and decides "named volume or
+    /// host path" by whether the source looks like a path
+    /// (`ContainerManager.swift:3767`); a relative guest path would be accepted
+    /// there and mounted somewhere the consumer did not ask for.
+    func testARelativeGuestPathIsRefused() {
+        let refusal = Self.refusal(of: Self.request(volumes: [
+            (name: "gascan-cache-x", path: "home/workspace/.cache", capacity: 1 << 30),
+        ]))
+        XCTAssertEqual(refusal?.code, "invalid_state")
+        XCTAssertEqual(refusal?.resource, "gascan-cache-x")
+    }
+
+    /// A request with no project mount is refused rather than creating a
+    /// sandbox with no project in it.
+    ///
+    /// `ProjectMount` is a message, so an unset one arrives with both paths
+    /// empty and is indistinguishable from one that was never set.
+    func testAMissingProjectMountIsRefused() {
+        var request = Self.request()
+        request.project = Arca_Engine_V1_ProjectMount()
+        XCTAssertEqual(Self.refusal(of: request)?.code, "invalid_state")
+    }
+
+    /// A capacity picks the one driver that can honour it; no capacity picks the
+    /// one that cannot.
+    ///
+    /// `local` is a VirtioFS directory share with no size at all
+    /// (`VolumeManager.swift:126-158`), so a sized volume created on it would be
+    /// a limit the consumer asked for and nothing enforces.
+    func testACapacityPicksTheBlockDriverAndNoCapacityPicksLocal() {
+        let sized = volumeDriver(forCapacityBytes: 1 << 30)
+        XCTAssertEqual(sized.driver, "block")
+        XCTAssertEqual(sized.options, ["size": "1073741824"])
+
+        let unsized = volumeDriver(forCapacityBytes: 0)
+        XCTAssertEqual(unsized.driver, "local")
+        XCTAssertNil(unsized.options)
+    }
+
+    // MARK: - Environment, user, limits, init
+
+    /// Environment arrives as `NAME=value`, and a name carrying `=` is refused.
+    ///
+    /// Accepting it would put a different variable in the guest than the one the
+    /// consumer named, with no error anywhere.
+    func testEnvironmentIsNameEqualsValueAndANameCarryingEqualsIsRefused() throws {
+        let spec = try translated(Self.request(environment: [("TERM", "xterm"), ("LANG", "")]))
+        XCTAssertEqual(spec.env, ["TERM=xterm", "LANG="])
+
+        XCTAssertEqual(
+            Self.refusal(of: Self.request(environment: [("A=B", "c")]))?.code, "invalid_state"
+        )
+    }
+
+    /// The two limits this engine applies, in the units ContainerBridge takes.
+    ///
+    /// `nanoCpus` is whole CPUs times 1e9, which overflows 32 bits at five CPUs,
+    /// so the widening is asserted with a value that would be wrong if the
+    /// multiply happened before it.
+    func testCpusAndMemoryReachContainerBridgeInItsOwnUnits() throws {
+        var request = Self.request()
+        request.resources.cpus = 8
+        request.resources.memoryBytes = 4 << 30
+        let spec = try translated(request)
+
+        XCTAssertEqual(spec.nanoCpus, 8_000_000_000)
+        XCTAssertEqual(spec.memory, 4_294_967_296)
+    }
+
+    /// Unset limits stay unset rather than becoming zero.
+    ///
+    /// `createContainer` writes `memory ?? 0` into the stored `HostConfig`
+    /// (`ContainerManager.swift:1918`) and treats a zero as "unspecified"
+    /// (`:1666`), so the distinction only survives if nil arrives as nil.
+    func testUnsetLimitsAreNotTranslatedAsZero() throws {
+        let spec = try translated(Self.request())
+        XCTAssertNil(spec.nanoCpus)
+        XCTAssertNil(spec.memory)
+    }
+
+    /// The two limits this engine cannot apply are refused, not dropped.
+    ///
+    /// `unsupported_capability` rather than a bad-request code: the request is
+    /// not wrong, this build is short, and the two codes tell a consumer
+    /// opposite things about whether to change the request or give up. The
+    /// sibling backend refuses the same two
+    /// (`crates/gascan-apple/src/translate.rs:214-219`).
+    func testADiskOrProcessLimitIsRefusedAsUnsupported() {
+        var disk = Self.request()
+        disk.resources.diskBytes = 1 << 40
+        XCTAssertEqual(Self.refusal(of: disk)?.code, "unsupported_capability")
+
+        var processes = Self.request()
+        processes.resources.processCount = 512
+        XCTAssertEqual(Self.refusal(of: processes)?.code, "unsupported_capability")
+    }
+
+    /// Both users the contract names are translated; an unspecified one is
+    /// refused rather than defaulted to root.
+    func testBothUsersTranslateAndAnUnspecifiedUserIsRefused() throws {
+        XCTAssertEqual(try translated(Self.request(user: .workspace)).user, "workspace")
+        XCTAssertEqual(try translated(Self.request(user: .root)).user, "root")
+        XCTAssertEqual(Self.refusal(of: Self.request(user: .unspecified))?.code, "invalid_state")
+    }
+
+    /// `init: false` is refused, because this engine cannot serve it.
+    ///
+    /// Every Arca container is a VM whose PID 1 is vminitd
+    /// (`ContainerManager.swift:1946`), so there is no init to switch off and no
+    /// parameter on `createContainer` that would switch it off. Accepting the
+    /// request and creating a sandbox with an init anyway is the silent
+    /// divergence the refusal exists to prevent.
+    func testACreateWithoutAnInitIsRefused() {
+        var request = Self.request()
+        request.init_p = false
+        let refusal = Self.refusal(of: request)
+        XCTAssertEqual(refusal?.code, "unsupported_capability")
+        XCTAssertEqual(
+            refusal?.message,
+            "this engine runs every workspace process under vminitd as PID 1 and cannot "
+                + "create a sandbox without an init"
+        )
+    }
+
+    // MARK: - Fixtures
+
+    private func translated(
+        _ request: Arca_Engine_V1_CreateRequest
+    ) throws -> SandboxContainerSpec {
+        switch sandboxContainerSpec(for: request, image: Self.image) {
+        case .success(let spec):
+            return spec
+        case .failure(let error):
+            XCTFail("expected a translation, got \(error.code): \(error.message)")
+            throw error
+        }
+    }
+
+    private static func refusal(
+        of request: Arca_Engine_V1_CreateRequest
+    ) -> Arca_Engine_V1_EngineError? {
+        switch sandboxContainerSpec(for: request, image: image) {
+        case .success: return nil
+        case .failure(let error): return error
+        }
+    }
+
+    private static func owner(
+        managedBy: String = "gascan", sandboxId: String = CreateTranslationTests.sandboxId
+    ) -> Arca_Engine_V1_OwnerLabels {
+        Arca_Engine_V1_OwnerLabels.with {
+            $0.managedBy = managedBy
+            $0.sandboxID = sandboxId
+        }
+    }
+
+    /// A create every field of which is valid, so that each test above changes
+    /// exactly the one thing it is about.
+    static func request(
+        sandboxId: String = CreateTranslationTests.sandboxId,
+        owner: Arca_Engine_V1_OwnerLabels = CreateTranslationTests.owner(),
+        volumes: [(name: String, path: String, capacity: UInt64)] = [],
+        ports: [(host: UInt32, guest: UInt32)] = [],
+        environment: [(String, String)] = [],
+        network: Arca_Engine_V1_Network.OneOf_Mode = .offline(Arca_Engine_V1_Offline()),
+        user: Arca_Engine_V1_User = .workspace
+    ) -> Arca_Engine_V1_CreateRequest {
+        Arca_Engine_V1_CreateRequest.with { request in
+            request.sandboxID = sandboxId
+            request.owner = owner
+            request.project = Arca_Engine_V1_ProjectMount.with {
+                $0.hostPath = "/Users/someone/project"
+                $0.guestPath = "/workspace"
+            }
+            request.volumes = volumes.map { volume in
+                Arca_Engine_V1_Volume.with {
+                    $0.name = volume.name
+                    $0.guestPath = volume.path
+                    $0.capacityBytes = volume.capacity
+                }
+            }
+            request.ports = ports.map { port in
+                Arca_Engine_V1_PortMapping.with {
+                    $0.hostPort = port.host
+                    $0.guestPort = port.guest
+                }
+            }
+            request.environment = environment.map { variable in
+                Arca_Engine_V1_EnvironmentVariable.with {
+                    $0.name = variable.0
+                    $0.value = variable.1
+                }
+            }
+            request.network = Arca_Engine_V1_Network.with { $0.mode = network }
+            request.user = user
+            request.init_p = true
+        }
+    }
+}

--- a/Tests/ArcaEngineTests/CreateTranslationTests.swift
+++ b/Tests/ArcaEngineTests/CreateTranslationTests.swift
@@ -65,6 +65,12 @@ final class CreateTranslationTests: XCTestCase {
         )))
         XCTAssertEqual(refusal?.code, "invalid_resource_identity")
         XCTAssertEqual(refusal?.resource, Self.sandboxId)
+        XCTAssertEqual(
+            refusal?.message,
+            "create requires both owner labels; this request carries managed_by 'gascan' and "
+                + "sandbox_id '', and a resource created under a half-set owner is one the "
+                + "consumer cannot recognise as its own"
+        )
     }
 
     /// The carried-over finding from Task 7: a pure-hex sandbox id is refused.
@@ -83,6 +89,12 @@ final class CreateTranslationTests: XCTestCase {
         let refusal = Self.refusal(of: Self.request(sandboxId: hex))
         XCTAssertEqual(refusal?.code, "invalid_resource_identity")
         XCTAssertEqual(refusal?.resource, hex)
+        XCTAssertEqual(
+            refusal?.message,
+            "sandbox id \(hex) is pure hexadecimal, which this engine's container resolver "
+                + "reads as a Docker id prefix and would match against an unrelated container; "
+                + "a gascan sandbox id always contains a hyphen"
+        )
 
         let hyphenated = "deadbeef-cafe"
         let spec = try translated(Self.request(sandboxId: hyphenated))
@@ -117,7 +129,63 @@ final class CreateTranslationTests: XCTestCase {
     func testAnUnsetNetworkModeIsRefused() {
         var request = Self.request()
         request.network.mode = nil
-        XCTAssertEqual(Self.refusal(of: request)?.code, "invalid_state")
+        let refusal = Self.refusal(of: request)
+        XCTAssertEqual(refusal?.code, "invalid_state")
+        XCTAssertEqual(
+            refusal?.message,
+            "create must state a network mode -- offline or a named network -- and this "
+                + "request states neither"
+        )
+    }
+
+    /// A networked sandbox that names no network is refused.
+    func testANamedNetworkWithNoNameIsRefused() {
+        let refusal = Self.refusal(of: Self.request(network: .networkedName("")))
+        XCTAssertEqual(refusal?.code, "invalid_resource_identity")
+        XCTAssertEqual(
+            refusal?.message,
+            "a networked sandbox must name its network and this one names none"
+        )
+    }
+
+    /// **An offline sandbox that asks for ports is refused.**
+    ///
+    /// This is the combination the contract permits and no engine can honour.
+    /// Offline means no network attachment, so `getWireGuardClient` returns nil
+    /// (`NetworkManager.swift:819-833`) and the publish gate it feeds has no
+    /// `else` (`ContainerManager.swift:2494-2541`). Accepted, it produces a
+    /// sandbox reported as created and started, whose `Inspect` names the
+    /// binding, that nothing can connect to.
+    ///
+    /// The pairing is what makes this a test of the combination rather than of
+    /// offline or of ports: the same offline request without ports translates,
+    /// and the same ports on a networked request translate. Only the pair is
+    /// refused.
+    func testAnOfflineSandboxThatAsksForPortsIsRefused() throws {
+        let refusal = Self.refusal(of: Self.request(
+            ports: [(host: 18080, guest: 8080)],
+            network: .offline(Arca_Engine_V1_Offline())
+        ))
+        XCTAssertEqual(refusal?.code, "unsupported_capability")
+        XCTAssertEqual(refusal?.resource, Self.sandboxId)
+        XCTAssertEqual(
+            refusal?.message,
+            "this engine cannot publish ports for an offline sandbox: offline means no network "
+                + "attachment, so there is nothing to publish through and the 1 requested port "
+                + "mapping(s) would be silently dropped"
+        )
+
+        let offlineWithoutPorts = try translated(
+            Self.request(network: .offline(Arca_Engine_V1_Offline()))
+        )
+        XCTAssertEqual(offlineWithoutPorts.networkMode, "none", "offline alone is fine")
+
+        let networkedWithPorts = try translated(Self.request(
+            ports: [(host: 18080, guest: 8080)], network: .networkedName("sbx-net")
+        ))
+        XCTAssertEqual(
+            networkedWithPorts.portBindings.keys.sorted(), ["8080/tcp"], "ports alone are fine"
+        )
     }
 
     // MARK: - Ports
@@ -176,12 +244,20 @@ final class CreateTranslationTests: XCTestCase {
     /// Zero is not a port. `PortMapping` is `uint32` on the wire, so it is
     /// representable, and `UInt16(0)` would convert cleanly into a binding that
     /// means nothing.
+    ///
+    /// Both arms assert the message, and the two messages differ, so the host
+    /// and guest halves cannot be transposed without this failing.
     func testPortZeroIsRefused() {
+        let hostZero = Self.refusal(of: Self.request(ports: [(host: 0, guest: 8080)]))
+        XCTAssertEqual(hostZero?.code, "invalid_state")
         XCTAssertEqual(
-            Self.refusal(of: Self.request(ports: [(host: 0, guest: 8080)]))?.code, "invalid_state"
+            hostZero?.message, "port mapping 0:8080 names a number that is not a port"
         )
+
+        let guestZero = Self.refusal(of: Self.request(ports: [(host: 18080, guest: 0)]))
+        XCTAssertEqual(guestZero?.code, "invalid_state")
         XCTAssertEqual(
-            Self.refusal(of: Self.request(ports: [(host: 18080, guest: 0)]))?.code, "invalid_state"
+            guestZero?.message, "port mapping 18080:0 names a number that is not a port"
         )
     }
 
@@ -210,6 +286,20 @@ final class CreateTranslationTests: XCTestCase {
         ]))
         XCTAssertEqual(refusal?.code, "invalid_state")
         XCTAssertEqual(refusal?.resource, "gascan-cache-x")
+        XCTAssertEqual(
+            refusal?.message,
+            "volume gascan-cache-x needs an absolute guest path and carries "
+                + "'home/workspace/.cache'"
+        )
+    }
+
+    /// A volume with no name is refused.
+    func testAVolumeWithNoNameIsRefused() {
+        let refusal = Self.refusal(of: Self.request(volumes: [
+            (name: "", path: "/home/workspace/.cache", capacity: 0),
+        ]))
+        XCTAssertEqual(refusal?.code, "invalid_resource_identity")
+        XCTAssertEqual(refusal?.message, "a volume in this request carries no name")
     }
 
     /// A request with no project mount is refused rather than creating a
@@ -220,7 +310,13 @@ final class CreateTranslationTests: XCTestCase {
     func testAMissingProjectMountIsRefused() {
         var request = Self.request()
         request.project = Arca_Engine_V1_ProjectMount()
-        XCTAssertEqual(Self.refusal(of: request)?.code, "invalid_state")
+        let refusal = Self.refusal(of: request)
+        XCTAssertEqual(refusal?.code, "invalid_state")
+        XCTAssertEqual(
+            refusal?.message,
+            "the project mount needs an absolute host path and an absolute guest path; this "
+                + "request carries '' and ''"
+        )
     }
 
     /// A capacity picks the one driver that can honour it; no capacity picks the
@@ -249,8 +345,19 @@ final class CreateTranslationTests: XCTestCase {
         let spec = try translated(Self.request(environment: [("TERM", "xterm"), ("LANG", "")]))
         XCTAssertEqual(spec.env, ["TERM=xterm", "LANG="])
 
+        let named = Self.refusal(of: Self.request(environment: [("A=B", "c")]))
+        XCTAssertEqual(named?.code, "invalid_state")
         XCTAssertEqual(
-            Self.refusal(of: Self.request(environment: [("A=B", "c")]))?.code, "invalid_state"
+            named?.message,
+            "environment variable name 'A=B' is empty or contains '=', and environment is "
+                + "passed as NAME=value"
+        )
+
+        let unnamed = Self.refusal(of: Self.request(environment: [("", "c")]))
+        XCTAssertEqual(
+            unnamed?.message,
+            "environment variable name '' is empty or contains '=', and environment is "
+                + "passed as NAME=value"
         )
     }
 
@@ -287,14 +394,27 @@ final class CreateTranslationTests: XCTestCase {
     /// opposite things about whether to change the request or give up. The
     /// sibling backend refuses the same two
     /// (`crates/gascan-apple/src/translate.rs:214-219`).
+    ///
+    /// **The messages are what tell these two apart.** Both refusals carry the
+    /// same code and the same `resource`, so asserting those alone leaves the
+    /// pair mutually indistinguishable -- a review mutation collapsed seven
+    /// refusal messages to the literal "unsupported" and the whole suite stayed
+    /// green, this test included. A consumer debugging a refused `Create` has
+    /// only that string.
     func testADiskOrProcessLimitIsRefusedAsUnsupported() {
         var disk = Self.request()
         disk.resources.diskBytes = 1 << 40
-        XCTAssertEqual(Self.refusal(of: disk)?.code, "unsupported_capability")
+        let diskRefusal = Self.refusal(of: disk)
+        XCTAssertEqual(diskRefusal?.code, "unsupported_capability")
+        XCTAssertEqual(diskRefusal?.message, "this engine cannot apply a disk limit")
 
         var processes = Self.request()
         processes.resources.processCount = 512
-        XCTAssertEqual(Self.refusal(of: processes)?.code, "unsupported_capability")
+        let processRefusal = Self.refusal(of: processes)
+        XCTAssertEqual(processRefusal?.code, "unsupported_capability")
+        XCTAssertEqual(
+            processRefusal?.message, "this engine cannot apply a process-count limit"
+        )
     }
 
     /// Both users the contract names are translated; an unspecified one is
@@ -302,7 +422,12 @@ final class CreateTranslationTests: XCTestCase {
     func testBothUsersTranslateAndAnUnspecifiedUserIsRefused() throws {
         XCTAssertEqual(try translated(Self.request(user: .workspace)).user, "workspace")
         XCTAssertEqual(try translated(Self.request(user: .root)).user, "root")
-        XCTAssertEqual(Self.refusal(of: Self.request(user: .unspecified))?.code, "invalid_state")
+        let refusal = Self.refusal(of: Self.request(user: .unspecified))
+        XCTAssertEqual(refusal?.code, "invalid_state")
+        XCTAssertEqual(
+            refusal?.message,
+            "create must name the user the workspace process runs as, and this request names none"
+        )
     }
 
     /// `init: false` is refused, because this engine cannot serve it.
@@ -364,7 +489,13 @@ final class CreateTranslationTests: XCTestCase {
         volumes: [(name: String, path: String, capacity: UInt64)] = [],
         ports: [(host: UInt32, guest: UInt32)] = [],
         environment: [(String, String)] = [],
-        network: Arca_Engine_V1_Network.OneOf_Mode = .offline(Arca_Engine_V1_Offline()),
+        // Networked, NOT offline. This default was `.offline`, which made every
+        // port test above build an offline request carrying port mappings --
+        // the combination this engine refuses -- so the suite positively
+        // asserted the forbidden behaviour while the refusal was missing
+        // altogether. A fixture default is not neutral: it decides what every
+        // test that does not override it is actually about.
+        network: Arca_Engine_V1_Network.OneOf_Mode = .networkedName("sbx-net"),
         user: Arca_Engine_V1_User = .workspace
     ) -> Arca_Engine_V1_CreateRequest {
         Arca_Engine_V1_CreateRequest.with { request in

--- a/Tests/ArcaEngineTests/EngineCommandRefusalTests.swift
+++ b/Tests/ArcaEngineTests/EngineCommandRefusalTests.swift
@@ -134,6 +134,103 @@ final class EngineCommandRefusalTests: XCTestCase {
         )
     }
 
+    /// A manager that cannot initialize is a refusal, and no socket is bound.
+    ///
+    /// This is the milestone's fail-fast claim, and only a spawned binary can
+    /// hold it: the three `initialize()` calls in `run()` are unreachable from a
+    /// unit test, because `ContainerManager.initialize()` constructs a real
+    /// `Containerization.VmnetNetwork` -- a host resource, and the reason no
+    /// test in this target may call it.
+    ///
+    /// `VolumeManager.initialize()` is the seam that makes this testable at all.
+    /// It runs FIRST of the three, so a failure there stops the sequence before
+    /// anything reaches vmnet, on an entitled machine and an unentitled one
+    /// alike. It fails here because `<state-root>/volumes` is a symlink to
+    /// itself: `fileExists` follows it and reports false, so `initialize()`
+    /// tries to create the directory and the kernel refuses the loop. MEASURED
+    /// on this machine: `NSPOSIXErrorDomain Code=5` under
+    /// `NSCocoaErrorDomain Code=512`, with no privileges and no external path
+    /// involved.
+    ///
+    /// The socket assertion is the one that carries the ordering. MEASURED with
+    /// the three calls moved to after `EngineServer.start`:
+    /// `swift test --filter ArcaEngineTests` reported `Executed 60 tests, with 1
+    /// failure`, and that failure was the socket assertion ALONE -- the exit
+    /// status and the message assertion both still passed, because the engine
+    /// binds, then initialize throws, and a throw out of `run()` runs no
+    /// graceful shutdown, so the bound socket is left on disk. Exit status
+    /// cannot tell those two arrangements apart.
+    ///
+    /// MEASURED with the three calls deleted outright: three failures in this
+    /// one test, `exitedOnItsOwn` first, since the engine then serves.
+    func testAManagerThatCannotInitializeRefusesBeforeBindingTheSocket() throws {
+        let root = try temporaryRoot()
+        let kernel = root.appendingPathComponent("vmlinux")
+        try Data("k".utf8).write(to: kernel)
+        let layout = root.appendingPathComponent("vminit")
+        try OCILayoutFixture.write(
+            at: layout, reference: "arca-vminit:latest", payload: "the engine's init"
+        )
+
+        // Named for this run, so the refusal it produces names a directory no
+        // usage line and no other test could have mentioned.
+        let stateRoot = root.appendingPathComponent("state-\(UUID().uuidString.prefix(8))")
+        try FileManager.default.createDirectory(at: stateRoot, withIntermediateDirectories: true)
+        let volumes = stateRoot.appendingPathComponent("volumes")
+        try FileManager.default.createSymbolicLink(
+            atPath: volumes.path, withDestinationPath: volumes.path
+        )
+
+        let socket = root.appendingPathComponent("e.sock")
+        let run = try runEngine(arguments: [
+            "--socket-path", socket.path,
+            "--state-root", stateRoot.path,
+            "--kernel-path", kernel.path,
+            "--vminit-layout", layout.path,
+        ])
+
+        XCTAssertTrue(
+            run.exitedOnItsOwn,
+            "an engine whose managers cannot initialize must exit, not serve; stderr: \(run.errorText)"
+        )
+        XCTAssertNotEqual(
+            run.status, 0,
+            "a manager that cannot initialize must be a non-zero exit; stderr: \(run.errorText)"
+        )
+
+        // Which failure it was. Without this the test passes on any refusal at
+        // all -- a bad kernel, a bad layout, a failure to reach `initialize()`
+        // whatsoever -- and would prove nothing about the initialize sequence.
+        //
+        // Read from the `Error: ` line and NOT from the whole of stderr, which
+        // is the trap this assertion started in. `VolumeManager.initialize()`
+        // logs `volumesBasePath=<state-root>/volumes` at info on its way IN, so
+        // `errorText.contains("volumes") && errorText.contains(<state root>)`
+        // is satisfied by the success path's own log line -- it would have held
+        // over an engine that initialized the volume manager fine and then died
+        // at `VmnetNetwork()`, which is a different claim entirely. Only
+        // ArgumentParser's terminal `Error: ` line carries the thrown error, and
+        // the vmnet failure's line ("failed to create vmnet network with status
+        // ...") names no path at all.
+        let errorLine = run.errorText
+            .split(separator: "\n")
+            .first { $0.hasPrefix("Error: ") }
+            .map(String.init) ?? ""
+        XCTAssertTrue(
+            errorLine.contains(volumes.lastPathComponent)
+                && errorLine.contains(stateRoot.lastPathComponent),
+            "the refusal must be the volume manager's own, naming the directory it "
+                + "could not create under a state root named microseconds ago; "
+                + "the Error line was \(errorLine.isEmpty ? "absent" : errorLine), "
+                + "full stderr: \(run.errorText)"
+        )
+
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: socket.path),
+            "the socket must bind only after every manager initializes, but \(socket.path) exists"
+        )
+    }
+
     // MARK: - Running the binary
 
     private struct EngineRun {

--- a/Tests/ArcaEngineTests/EngineCommandRefusalTests.swift
+++ b/Tests/ArcaEngineTests/EngineCommandRefusalTests.swift
@@ -49,6 +49,25 @@ final class EngineCommandRefusalTests: XCTestCase {
             "the refusal must name the option that was wrong, got: \(run.errorText)"
         )
 
+        // The assertion above is not enough on its own, and cannot be: ArgumentParser
+        // prints a usage line on *any* parse error, on stderr, before `run()` is
+        // entered -- and that usage line contains the literal `--kernel-path`.
+        // MEASURED: with one unrelated required option added to
+        // `ArcaEngineCommand` that this test does not pass, all four of the other
+        // assertions passed on a pure parse failure while `validateEngineInputs`
+        // was never reached.
+        //
+        // The absent kernel's path is a temp path this test invented microseconds
+        // earlier, so no usage line can contain it. Only `EngineStartupError`'s
+        // own `\(name) names nothing that exists: \(path)` puts it on stderr,
+        // which means reaching this assertion at all requires having reached the
+        // validation. Task 5 and Task 6 both edit this command's options.
+        XCTAssertTrue(
+            run.errorText.contains(absentKernel.path),
+            "stderr must carry the validation's own message, naming the path tried, "
+                + "and not merely ArgumentParser's usage line; got: \(run.errorText)"
+        )
+
         // The ordering assertion. `createSocketParentDirectory` runs early in
         // `run()`; if validation moved after it, everything above still passes
         // and only this fails.

--- a/Tests/ArcaEngineTests/EngineCommandRefusalTests.swift
+++ b/Tests/ArcaEngineTests/EngineCommandRefusalTests.swift
@@ -5,7 +5,7 @@ import XCTest
 ///
 /// `EngineStartupTests` calls the validation function directly, which proves the
 /// function and never the call. MEASURED: with `try validateEngineInputs(inputs)`
-/// deleted outright from `ArcaEngineCommand.run()`, all six of those tests, and
+/// deleted outright from `ServeCommand.run()`, all six of those tests, and
 /// the whole suite, reported `Executed 49 tests, with 0 failures`. The same hole
 /// hides the ordering: moving the call after `createSocketParentDirectory` was
 /// equally invisible. Task 6 edits exactly that region of `run()` to add
@@ -21,7 +21,7 @@ final class EngineCommandRefusalTests: XCTestCase {
     /// side effect. Splitting them would spawn the binary three times to assert
     /// three things about the same run.
     func testTheCommandRefusesAMissingKernelBeforeCreatingTheSocketDirectory() throws {
-        let root = try temporaryRoot()
+        let root = try temporaryEngineRoot()
         let socketDirectory = root.appendingPathComponent("sock")
         let absentKernel = root.appendingPathComponent("vmlinux")
         let layout = try validVminitLayout(in: root)
@@ -53,7 +53,7 @@ final class EngineCommandRefusalTests: XCTestCase {
         // prints a usage line on *any* parse error, on stderr, before `run()` is
         // entered -- and that usage line contains the literal `--kernel-path`.
         // MEASURED: with one unrelated required option added to
-        // `ArcaEngineCommand` that this test does not pass, all four of the other
+        // `ServeCommand` that this test does not pass, all four of the other
         // assertions passed on a pure parse failure while `validateEngineInputs`
         // was never reached.
         //
@@ -100,7 +100,7 @@ final class EngineCommandRefusalTests: XCTestCase {
     /// reported `Executed 58 tests, with 0 failures`. Anchoring on `holds ` and
     /// `not ` is what distinguishes the two, at the cost of a reword going red.
     func testTheCommandRefusesALayoutHoldingAnotherImage() throws {
-        let root = try temporaryRoot()
+        let root = try temporaryEngineRoot()
         let kernel = root.appendingPathComponent("vmlinux")
         try Data("k".utf8).write(to: kernel)
         let layout = root.appendingPathComponent("vminit")
@@ -164,7 +164,7 @@ final class EngineCommandRefusalTests: XCTestCase {
     /// MEASURED with the three calls deleted outright: three failures in this
     /// one test, `exitedOnItsOwn` first, since the engine then serves.
     func testAManagerThatCannotInitializeRefusesBeforeBindingTheSocket() throws {
-        let root = try temporaryRoot()
+        let root = try temporaryEngineRoot()
         let kernel = root.appendingPathComponent("vmlinux")
         try Data("k".utf8).write(to: kernel)
         let layout = root.appendingPathComponent("vminit")
@@ -231,100 +231,7 @@ final class EngineCommandRefusalTests: XCTestCase {
         )
     }
 
-    // MARK: - Running the binary
-
-    private struct EngineRun {
-        /// Whether the process ended before the deadline. False means it was
-        /// still running and this test killed it -- the shape a deleted
-        /// validation call takes, since the engine then goes on to serve.
-        let exitedOnItsOwn: Bool
-        let status: Int32
-        let errorText: String
-    }
-
-    /// The built `arca-engine`, found beside the test bundle.
-    ///
-    /// Not a hardcoded `.build/debug/arca-engine`: Gas Can's gate builds the
-    /// checkout with `--configuration release`, which puts both the bundle and
-    /// the binary in `.build/release` instead. Deriving from the bundle is
-    /// correct under either configuration.
-    ///
-    /// A missing binary fails the test. There is no skip: the whole point of
-    /// this file is that the call site is otherwise unproved, so a version that
-    /// quietly passes when it cannot find the binary would restore the hole.
-    private func engineBinary() throws -> URL {
-        let binary = Bundle(for: Self.self)
-            .bundleURL
-            .deletingLastPathComponent()
-            .appendingPathComponent("arca-engine")
-        guard FileManager.default.isExecutableFile(atPath: binary.path) else {
-            throw EngineBinaryMissing(path: binary.path)
-        }
-        return binary
-    }
-
-    private struct EngineBinaryMissing: Error, CustomStringConvertible {
-        let path: String
-        var description: String {
-            "arca-engine was not built beside the test bundle at \(path)"
-        }
-    }
-
-    /// Runs the engine and waits, but never indefinitely.
-    ///
-    /// `waitUntilExit()` alone would hang forever in the exact case this test
-    /// exists to catch: an engine that does not refuse goes on to serve, and a
-    /// hung suite reports nothing.
-    private func runEngine(arguments: [String]) throws -> EngineRun {
-        let process = Process()
-        process.executableURL = try engineBinary()
-        process.arguments = arguments
-
-        let errorPipe = Pipe()
-        process.standardError = errorPipe
-        process.standardOutput = Pipe()
-
-        try process.run()
-
-        let deadline = Date().addingTimeInterval(30)
-        while process.isRunning && Date() < deadline {
-            Thread.sleep(forTimeInterval: 0.02)
-        }
-
-        let exitedOnItsOwn = !process.isRunning
-        if !exitedOnItsOwn {
-            // SIGTERM, which the engine turns into a graceful shutdown, so the
-            // socket is unlinked and nothing is left listening for the next test.
-            process.terminate()
-        }
-        process.waitUntilExit()
-
-        let errorText = String(
-            decoding: errorPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self
-        )
-        return EngineRun(
-            exitedOnItsOwn: exitedOnItsOwn,
-            status: process.terminationStatus,
-            errorText: errorText
-        )
-    }
-
     // MARK: - Fixtures
-
-    /// A short root, removed when the test ends.
-    ///
-    /// Short because a macOS Unix socket path is capped near 104 characters, and
-    /// `NSTemporaryDirectory()` already spends about half of that. With a full
-    /// UUID the engine would fail to bind for that reason instead of the one
-    /// under test -- which matters in the mutation case, where the engine is
-    /// meant to get far enough to serve.
-    private func temporaryRoot() throws -> URL {
-        let root = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("arca-cmd-\(UUID().uuidString.prefix(8))")
-        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
-        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
-        return root
-    }
 
     /// A well-formed vminit layout, so the kernel is the only thing wrong.
     private func validVminitLayout(in root: URL) throws -> URL {

--- a/Tests/ArcaEngineTests/EngineCommandRefusalTests.swift
+++ b/Tests/ArcaEngineTests/EngineCommandRefusalTests.swift
@@ -77,6 +77,52 @@ final class EngineCommandRefusalTests: XCTestCase {
         )
     }
 
+    /// The vminit load runs, and refuses, inside `run()`.
+    ///
+    /// `EngineStartupTests` calls `loadVminit` directly, which proves the
+    /// function and not the call -- the same hole this file exists for, and the
+    /// call is newer than the validation. A wrong reference is the only refusal
+    /// reachable from outside without a 178MB image: the layout below is real,
+    /// well-formed, and holds `vminit:latest`, so the engine can only learn that
+    /// by loading it.
+    ///
+    /// Both assertions carry the layout's own temp path, which no usage line
+    /// can contain, so neither can be satisfied by an ArgumentParser parse
+    /// error printed before `run()` was entered.
+    func testTheCommandRefusesALayoutHoldingAnotherImage() throws {
+        let root = try temporaryRoot()
+        let kernel = root.appendingPathComponent("vmlinux")
+        try Data("k".utf8).write(to: kernel)
+        let layout = root.appendingPathComponent("vminit")
+        try OCILayoutFixture.write(
+            at: layout, reference: "vminit:latest", payload: "not the engine's init"
+        )
+
+        let run = try runEngine(arguments: [
+            "--socket-path", root.appendingPathComponent("e.sock").path,
+            "--state-root", root.appendingPathComponent("state").path,
+            "--kernel-path", kernel.path,
+            "--vminit-layout", layout.path,
+        ])
+
+        XCTAssertTrue(
+            run.exitedOnItsOwn,
+            "the engine must refuse an unknown init image, not serve on it; stderr: \(run.errorText)"
+        )
+        XCTAssertNotEqual(
+            run.status, 0,
+            "a refusal must be a non-zero exit; stderr: \(run.errorText)"
+        )
+        XCTAssertTrue(
+            run.errorText.contains("--vminit-layout") && run.errorText.contains(layout.path),
+            "the refusal must name the option and the layout it read, got: \(run.errorText)"
+        )
+        XCTAssertTrue(
+            run.errorText.contains("arca-vminit:latest") && run.errorText.contains("vminit:latest"),
+            "the refusal must say which image was wanted and which was found, got: \(run.errorText)"
+        )
+    }
+
     // MARK: - Running the binary
 
     private struct EngineRun {

--- a/Tests/ArcaEngineTests/EngineCommandRefusalTests.swift
+++ b/Tests/ArcaEngineTests/EngineCommandRefusalTests.swift
@@ -1,0 +1,166 @@
+import Foundation
+import XCTest
+
+/// Drives the built `arca-engine` binary rather than `validateEngineInputs`.
+///
+/// `EngineStartupTests` calls the validation function directly, which proves the
+/// function and never the call. MEASURED: with `try validateEngineInputs(inputs)`
+/// deleted outright from `ArcaEngineCommand.run()`, all six of those tests, and
+/// the whole suite, reported `Executed 49 tests, with 0 failures`. The same hole
+/// hides the ordering: moving the call after `createSocketParentDirectory` was
+/// equally invisible. Task 6 edits exactly that region of `run()` to add
+/// `initialize()`, so an unproved call site is a live hazard, not a theoretical
+/// one.
+///
+/// Spawning the binary needs no import of it, so this lives in `ArcaEngineTests`
+/// -- the only target Gas Can's release gate runs -- rather than in `ArcaTests`,
+/// which the gate would have to be taught about.
+final class EngineCommandRefusalTests: XCTestCase {
+    /// A refusal must exit, name the option, and leave nothing behind. All three
+    /// in one test because they are one behaviour: validation runs before any
+    /// side effect. Splitting them would spawn the binary three times to assert
+    /// three things about the same run.
+    func testTheCommandRefusesAMissingKernelBeforeCreatingTheSocketDirectory() throws {
+        let root = try temporaryRoot()
+        let socketDirectory = root.appendingPathComponent("sock")
+        let absentKernel = root.appendingPathComponent("vmlinux")
+        let layout = try validVminitLayout(in: root)
+
+        let run = try runEngine(arguments: [
+            "--socket-path", socketDirectory.appendingPathComponent("e.sock").path,
+            "--state-root", root.appendingPathComponent("state").path,
+            "--kernel-path", absentKernel.path,
+            "--vminit-layout", layout.path,
+        ])
+
+        // First, because if the engine served instead of refusing then the exit
+        // status below describes this test's own SIGTERM, not the engine's
+        // decision, and would read as a pass.
+        XCTAssertTrue(
+            run.exitedOnItsOwn,
+            "the engine must refuse and exit, not start serving without a kernel; stderr: \(run.errorText)"
+        )
+        XCTAssertNotEqual(
+            run.status, 0,
+            "a refusal must be a non-zero exit; stderr: \(run.errorText)"
+        )
+        XCTAssertTrue(
+            run.errorText.contains("--kernel-path"),
+            "the refusal must name the option that was wrong, got: \(run.errorText)"
+        )
+
+        // The ordering assertion. `createSocketParentDirectory` runs early in
+        // `run()`; if validation moved after it, everything above still passes
+        // and only this fails.
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: socketDirectory.path),
+            "validation must run before anything is created on disk, but \(socketDirectory.path) exists"
+        )
+    }
+
+    // MARK: - Running the binary
+
+    private struct EngineRun {
+        /// Whether the process ended before the deadline. False means it was
+        /// still running and this test killed it -- the shape a deleted
+        /// validation call takes, since the engine then goes on to serve.
+        let exitedOnItsOwn: Bool
+        let status: Int32
+        let errorText: String
+    }
+
+    /// The built `arca-engine`, found beside the test bundle.
+    ///
+    /// Not a hardcoded `.build/debug/arca-engine`: Gas Can's gate builds the
+    /// checkout with `--configuration release`, which puts both the bundle and
+    /// the binary in `.build/release` instead. Deriving from the bundle is
+    /// correct under either configuration.
+    ///
+    /// A missing binary fails the test. There is no skip: the whole point of
+    /// this file is that the call site is otherwise unproved, so a version that
+    /// quietly passes when it cannot find the binary would restore the hole.
+    private func engineBinary() throws -> URL {
+        let binary = Bundle(for: Self.self)
+            .bundleURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("arca-engine")
+        guard FileManager.default.isExecutableFile(atPath: binary.path) else {
+            throw EngineBinaryMissing(path: binary.path)
+        }
+        return binary
+    }
+
+    private struct EngineBinaryMissing: Error, CustomStringConvertible {
+        let path: String
+        var description: String {
+            "arca-engine was not built beside the test bundle at \(path)"
+        }
+    }
+
+    /// Runs the engine and waits, but never indefinitely.
+    ///
+    /// `waitUntilExit()` alone would hang forever in the exact case this test
+    /// exists to catch: an engine that does not refuse goes on to serve, and a
+    /// hung suite reports nothing.
+    private func runEngine(arguments: [String]) throws -> EngineRun {
+        let process = Process()
+        process.executableURL = try engineBinary()
+        process.arguments = arguments
+
+        let errorPipe = Pipe()
+        process.standardError = errorPipe
+        process.standardOutput = Pipe()
+
+        try process.run()
+
+        let deadline = Date().addingTimeInterval(30)
+        while process.isRunning && Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.02)
+        }
+
+        let exitedOnItsOwn = !process.isRunning
+        if !exitedOnItsOwn {
+            // SIGTERM, which the engine turns into a graceful shutdown, so the
+            // socket is unlinked and nothing is left listening for the next test.
+            process.terminate()
+        }
+        process.waitUntilExit()
+
+        let errorText = String(
+            decoding: errorPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self
+        )
+        return EngineRun(
+            exitedOnItsOwn: exitedOnItsOwn,
+            status: process.terminationStatus,
+            errorText: errorText
+        )
+    }
+
+    // MARK: - Fixtures
+
+    /// A short root, removed when the test ends.
+    ///
+    /// Short because a macOS Unix socket path is capped near 104 characters, and
+    /// `NSTemporaryDirectory()` already spends about half of that. With a full
+    /// UUID the engine would fail to bind for that reason instead of the one
+    /// under test -- which matters in the mutation case, where the engine is
+    /// meant to get far enough to serve.
+    private func temporaryRoot() throws -> URL {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("arca-cmd-\(UUID().uuidString.prefix(8))")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return root
+    }
+
+    /// A well-formed vminit layout, so the kernel is the only thing wrong.
+    private func validVminitLayout(in root: URL) throws -> URL {
+        let layout = root.appendingPathComponent("vminit")
+        try FileManager.default.createDirectory(at: layout, withIntermediateDirectories: true)
+        try Data(#"{"imageLayoutVersion":"1.0.0"}"#.utf8)
+            .write(to: layout.appendingPathComponent("oci-layout"))
+        try Data(#"{"schemaVersion":2,"manifests":[]}"#.utf8)
+            .write(to: layout.appendingPathComponent("index.json"))
+        return layout
+    }
+}

--- a/Tests/ArcaEngineTests/EngineCommandRefusalTests.swift
+++ b/Tests/ArcaEngineTests/EngineCommandRefusalTests.swift
@@ -86,9 +86,19 @@ final class EngineCommandRefusalTests: XCTestCase {
     /// well-formed, and holds `vminit:latest`, so the engine can only learn that
     /// by loading it.
     ///
-    /// Both assertions carry the layout's own temp path, which no usage line
-    /// can contain, so neither can be satisfied by an ArgumentParser parse
-    /// error printed before `run()` was entered.
+    /// Neither message assertion below can be satisfied by ArgumentParser's
+    /// usage line, which it prints on any parse error before `run()` is
+    /// entered: the first carries the layout's own temp path, invented
+    /// microseconds earlier, and the second carries a phrase only
+    /// `EngineStartupError`'s rendering produces.
+    ///
+    /// That second one is deliberately coupled to the message's wording, and
+    /// has to be. `vminit:latest` is a *substring* of `arca-vminit:latest`, so
+    /// `contains("vminit:latest")` is implied by `contains("arca-vminit:latest")`
+    /// and asserts nothing about the found reference. MEASURED: with `\(actual)`
+    /// dropped from `EngineStartupError.description`, the substring pair
+    /// reported `Executed 58 tests, with 0 failures`. Anchoring on `holds ` and
+    /// `not ` is what distinguishes the two, at the cost of a reword going red.
     func testTheCommandRefusesALayoutHoldingAnotherImage() throws {
         let root = try temporaryRoot()
         let kernel = root.appendingPathComponent("vmlinux")
@@ -118,8 +128,9 @@ final class EngineCommandRefusalTests: XCTestCase {
             "the refusal must name the option and the layout it read, got: \(run.errorText)"
         )
         XCTAssertTrue(
-            run.errorText.contains("arca-vminit:latest") && run.errorText.contains("vminit:latest"),
-            "the refusal must say which image was wanted and which was found, got: \(run.errorText)"
+            run.errorText.contains("holds vminit:latest")
+                && run.errorText.contains("not arca-vminit:latest"),
+            "the refusal must say which image was found and which was wanted, got: \(run.errorText)"
         )
     }
 

--- a/Tests/ArcaEngineTests/EngineManagerWiringTests.swift
+++ b/Tests/ArcaEngineTests/EngineManagerWiringTests.swift
@@ -1,0 +1,191 @@
+import ContainerBridge
+import Foundation
+import Logging
+import XCTest
+@testable import ArcaEngine
+
+/// `EngineManagers.wireCollaborators()`, one test per line it contains.
+///
+/// `ContainerManager` holds its `VolumeManager` and `NetworkManager` optionally,
+/// set after construction because `NetworkManager.init` already takes a
+/// `ContainerManager` and one of the two edges has to come later. Every use is
+/// guarded by `if let` or `guard let ... else { return }`, so an unset
+/// collaborator is not an error anywhere -- it is silence. `ArcaDaemon` sets
+/// both (`ArcaDaemon.swift:236`, `:262`); the engine set neither until Task 6's
+/// review found it.
+///
+/// Both tests assert on **behaviour reachable through a public method**, never
+/// on the setter having been called. A test that read back the stored property
+/// would pass over a `wireCollaborators()` that assigned the right object to the
+/// wrong manager, and would prove nothing about what the omission costs.
+///
+/// Both are VM-free by construction: they drive `loadPersistedState()`,
+/// `getContainer` and `removeContainer` over rows seeded into the StateStore.
+/// Nothing here calls `initialize()` on any manager other than `VolumeManager`,
+/// whose `initialize()` touches only the filesystem and the store --
+/// `ContainerManager.initialize()` constructs a real `VmnetNetwork` and no test
+/// in this target may call it.
+final class EngineManagerWiringTests: XCTestCase {
+    private static let unbootedKernel = URL(fileURLWithPath: "/opt/arca/vmlinux")
+    private let logger = Logger(label: "arca-engine-tests")
+
+    /// The `setVolumeManager` line, through the leak its absence causes.
+    ///
+    /// `cleanupVolumesForContainer` (`ContainerManager.swift:4128-4131`) is
+    /// `guard let volumeManager = volumeManager else { return }` -- with no
+    /// volume manager it deletes nothing and reports nothing, and
+    /// `removeContainer` goes on to succeed. The container row is gone,
+    /// CASCADE takes its `volume_mounts` row with it, and the anonymous volume
+    /// is left on disk with nothing pointing at it. `Remove` answering success
+    /// over a leak is exactly the report `ListResources` exists to prevent.
+    ///
+    /// The named volume is the second half of the assertion and is not
+    /// decoration: `cleanupVolumesForContainer` deletes only mounts marked
+    /// anonymous, so a cleanup that deleted every mounted volume would pass a
+    /// single-volume form of this test while destroying user data on `Remove`.
+    func testRemovingAContainerDeletesItsAnonymousVolumeAndSparesTheNamedOne() async throws {
+        let managers = try Self.managers()
+        try await managers.volumeManager.initialize()
+        _ = try await managers.volumeManager.createVolume(
+            name: "anon-vol", driver: "local", driverOpts: nil, labels: nil
+        )
+        _ = try await managers.volumeManager.createVolume(
+            name: "named-vol", driver: "local", driverOpts: nil, labels: nil
+        )
+
+        try await Self.seedContainer(into: managers.stateStore, id: Self.containerID)
+        try await managers.stateStore.saveVolumeMount(
+            containerID: Self.containerID, volumeName: "anon-vol",
+            containerPath: "/data", isAnonymous: true
+        )
+        try await managers.stateStore.saveVolumeMount(
+            containerID: Self.containerID, volumeName: "named-vol",
+            containerPath: "/named", isAnonymous: false
+        )
+
+        await managers.wireCollaborators()
+        try await managers.containerManager.loadPersistedState()
+        try await managers.containerManager.removeContainer(id: Self.containerID)
+
+        let remaining = try await managers.volumeManager.listVolumes().map(\.name).sorted()
+        XCTAssertEqual(
+            remaining, ["named-vol"],
+            "Remove must delete the container's anonymous volume and keep the named "
+                + "one; without the volume manager wired it silently keeps both, and "
+                + "the anonymous one is then unreachable"
+        )
+    }
+
+    /// The `setNetworkManager` line, through what `Inspect` will read.
+    ///
+    /// `getContainer` builds `NetworkSettings.networks` inside
+    /// `if let networkManager = networkManager` (`ContainerManager.swift:826`).
+    /// Unwired, a container attached to a network reports an EMPTY networks
+    /// dictionary -- not an error, not "unknown", but a confident "attached to
+    /// nothing". Task 7 answers `Inspect` from this exact read.
+    ///
+    /// The network is created through `NetworkManager.createNetwork` with the
+    /// `null` driver rather than seeded straight into the StateStore, and that
+    /// is forced rather than stylistic. `getNetwork(id:)` resolves through
+    /// `networkDrivers`, an in-memory map populated either by
+    /// `NetworkManager.initialize()` -- which creates the vmnet `host` network
+    /// and so is off limits here -- or by `createNetwork` itself
+    /// (`NetworkManager.swift:467`). The `null` branch is the one driver whose
+    /// create and whose read both touch nothing but the StateStore
+    /// (`:443-472`, `:671-688`), which is what makes this assertable without a
+    /// host resource.
+    ///
+    /// The assertion is an equality on the network's NAME, not a non-emptiness
+    /// check, and the name is what makes it load-bearing: the attachment row
+    /// carries only the network's id, so a dictionary keyed by `probe-none`
+    /// exists only if the lookup through the network manager actually resolved.
+    func testAnAttachedContainerReportsTheNetworkItIsOn() async throws {
+        let managers = try Self.managers()
+        let networkID = try await managers.networkManager.createNetwork(
+            name: "probe-none",
+            driver: "null",
+            subnet: nil,
+            gateway: nil,
+            ipRange: nil,
+            options: [:],
+            labels: [:]
+        )
+
+        try await Self.seedContainer(into: managers.stateStore, id: Self.containerID)
+        try await managers.stateStore.saveNetworkAttachment(
+            containerID: Self.containerID,
+            networkID: networkID,
+            ipAddress: "172.18.0.2",
+            macAddress: "02:42:ac:12:00:02",
+            aliases: ["probe"]
+        )
+
+        await managers.wireCollaborators()
+        try await managers.containerManager.loadPersistedState()
+
+        let read = try await managers.containerManager.getContainer(id: Self.containerID)
+        let container = try XCTUnwrap(read)
+        let networks = container.networkSettings.networks
+        XCTAssertEqual(
+            networks.keys.sorted(), ["probe-none"],
+            "a container on a network must report that network by name; unwired, "
+                + "this dictionary is empty and Inspect reports it attached to nothing"
+        )
+        XCTAssertEqual(
+            networks["probe-none"]?.ipAddress, "172.18.0.2",
+            "the reported endpoint must carry the seeded attachment's address"
+        )
+        XCTAssertEqual(
+            networks["probe-none"]?.networkID, networkID,
+            "and must name the network it resolved, not some other attachment"
+        )
+    }
+
+    // MARK: - Fixtures
+
+    /// 64 characters, because `loadPersistedState()` keys `reverseMapping` on
+    /// the first 32 and `listContainers` drops any container missing from it.
+    private static let containerID = String(repeating: "a", count: 64)
+
+    /// The engine's own managers over a throwaway state root -- the production
+    /// factory, so what these tests wire is what `arca-engine` wires.
+    private static func managers() throws -> EngineManagers {
+        try EngineManagers(
+            stateRoot: URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("arca-wiring-tests-\(UUID().uuidString)"),
+            kernelPath: unbootedKernel,
+            logLevel: "info",
+            logger: Logger(label: "arca-engine-tests")
+        )
+    }
+
+    /// One exited container. Exited so that `removeContainer` needs no `force`,
+    /// and database-only so that it takes the branch that touches no VM.
+    private static func seedContainer(into store: StateStore, id: String) async throws {
+        let encoder = JSONEncoder()
+        try await store.saveContainer(
+            id: id,
+            name: "wiring-probe",
+            image: "arca/probe:latest",
+            imageID: "sha256:probe",
+            createdAt: Date(),
+            status: "exited",
+            running: false,
+            paused: false,
+            restarting: false,
+            pid: 0,
+            exitCode: 0,
+            startedAt: nil,
+            finishedAt: Date(),
+            stoppedByUser: false,
+            entrypoint: nil,
+            configJSON: String(
+                decoding: try encoder.encode(
+                    ContainerConfiguration(image: "arca/probe:latest")
+                ),
+                as: UTF8.self
+            ),
+            hostConfigJSON: String(decoding: try encoder.encode(HostConfig()), as: UTF8.self)
+        )
+    }
+}

--- a/Tests/ArcaEngineTests/EngineProcess.swift
+++ b/Tests/ArcaEngineTests/EngineProcess.swift
@@ -57,6 +57,21 @@ extension XCTestCase {
     /// command's `defaultSubcommand`. That indirection is deliberately not
     /// spelt out in the arguments: the invocation Gas Can ships names no
     /// subcommand, so neither may the tests that stand for it.
+    ///
+    /// Both pipes are drained from the moment the child starts, and NOT read
+    /// after it exits. A pipe holds about 64KB; a child that fills one blocks
+    /// in `write` and never exits, so a version that waits first and reads
+    /// afterwards would sit out the whole deadline and then report
+    /// `exitedOnItsOwn == false` -- "the engine must load and exit, not serve"
+    /// -- which names a cause that is not the one. Unreachable with
+    /// `OCILayoutFixture`'s kilobyte layout, and reachable the day someone
+    /// points this at a real image with `--log-level trace`.
+    ///
+    /// MEASURED, both patterns against `/bin/sh -c 'seq 1 60000'` (~349KB) on
+    /// this machine under a 5s deadline: reading after the wait reported
+    /// `exitedOnItsOwn=false status=15 bytes=65536` -- stalled at exactly the
+    /// pipe buffer, then killed by the harness's own SIGTERM -- while draining
+    /// from the start reported `exitedOnItsOwn=true status=0 bytes=348894`.
     func runEngine(arguments: [String]) throws -> EngineRun {
         let process = Process()
         process.executableURL = try engineBinary()
@@ -68,6 +83,8 @@ extension XCTestCase {
         process.standardError = errorPipe
 
         try process.run()
+        let output = PipeDrain(outputPipe, name: "stdout")
+        let errors = PipeDrain(errorPipe, name: "stderr")
 
         let deadline = Date().addingTimeInterval(30)
         while process.isRunning && Date() < deadline {
@@ -85,12 +102,8 @@ extension XCTestCase {
         return EngineRun(
             exitedOnItsOwn: exitedOnItsOwn,
             status: process.terminationStatus,
-            outputText: String(
-                decoding: outputPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self
-            ),
-            errorText: String(
-                decoding: errorPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self
-            )
+            outputText: try output.textAtEOF(),
+            errorText: try errors.textAtEOF()
         )
     }
 
@@ -110,9 +123,59 @@ extension XCTestCase {
     }
 }
 
+/// Reads one of a child's pipes to EOF on a thread of its own, so the child is
+/// never blocked writing into a full buffer.
+///
+/// The read end is taken as a raw descriptor rather than as the `FileHandle`
+/// that owns it: a descriptor is `Sendable` and a `FileHandle` is not, and the
+/// work has to cross to another thread. `@unchecked Sendable` for the same
+/// reason `ShutdownRequests` in `ArcaEngineCommand` is -- the two fields are
+/// touched on one thread each, in an order the semaphore fixes.
+private final class PipeDrain: @unchecked Sendable {
+    private var data = Data()
+    private let finished = DispatchSemaphore(value: 0)
+    private let name: String
+
+    init(_ pipe: Pipe, name: String) {
+        self.name = name
+        let descriptor = pipe.fileHandleForReading.fileDescriptor
+        DispatchQueue.global().async { [self] in
+            var buffer = [UInt8](repeating: 0, count: 4096)
+            while true {
+                let count = buffer.withUnsafeMutableBytes { read(descriptor, $0.baseAddress, $0.count) }
+                guard count > 0 else { break }
+                data.append(contentsOf: buffer[0..<count])
+            }
+            finished.signal()
+        }
+    }
+
+    /// Everything the child wrote, once it has closed the pipe.
+    ///
+    /// Bounded, and a timeout throws rather than handing back what arrived so
+    /// far: a partial read returned as if whole is an assertion passing or
+    /// failing on text the child had not finished writing. The wait should be
+    /// instant -- the caller reaps the child first, which closes its end -- so
+    /// reaching the timeout is a defect in this harness and says so.
+    func textAtEOF() throws -> String {
+        guard finished.wait(timeout: .now() + 10) == .success else {
+            throw PipeNeverClosed(name: name)
+        }
+        return String(decoding: data, as: UTF8.self)
+    }
+}
+
+struct PipeNeverClosed: Error, CustomStringConvertible {
+    let name: String
+    var description: String {
+        "the engine's \(name) did not reach EOF within 10s of the process being reaped"
+    }
+}
+
 struct EngineBinaryMissing: Error, CustomStringConvertible {
     let path: String
     var description: String {
         "arca-engine was not built beside the test bundle at \(path)"
     }
 }
+

--- a/Tests/ArcaEngineTests/EngineProcess.swift
+++ b/Tests/ArcaEngineTests/EngineProcess.swift
@@ -1,0 +1,118 @@
+import Foundation
+import XCTest
+
+/// One run of the built `arca-engine`.
+struct EngineRun {
+    /// Whether the process ended before the deadline. False means it was still
+    /// running and the test killed it -- the shape a deleted refusal takes,
+    /// since the engine then goes on to serve.
+    let exitedOnItsOwn: Bool
+    let status: Int32
+    let outputText: String
+    let errorText: String
+}
+
+/// Spawning the real binary, shared by every test that has to prove a call site
+/// rather than a function.
+///
+/// Shared because there are two such files now. `EngineCommandRefusalTests`
+/// proves that `serve` refuses bad inputs before it binds anything;
+/// `ImageLoadTests` proves that `image load` reaches `loadWorkspaceImages` at
+/// all. A second copy of the runner is a second 30-second deadline and a second
+/// way to look for the binary, free to drift from the first.
+///
+/// Spawning needs no import of the executable, which is what lets these tests
+/// live in `ArcaEngineTests` -- the only target Gas Can's release gate runs --
+/// rather than in `ArcaTests`, which the gate would have to be taught about.
+extension XCTestCase {
+    /// The built `arca-engine`, found beside the test bundle.
+    ///
+    /// Not a hardcoded `.build/debug/arca-engine`: Gas Can's gate builds the
+    /// checkout with `--configuration release`, which puts both the bundle and
+    /// the binary in `.build/release` instead. Deriving from the bundle is
+    /// correct under either configuration.
+    ///
+    /// A missing binary fails the test. There is no skip: the whole point of
+    /// these files is that the call site is otherwise unproved, so a version
+    /// that quietly passed when it could not find the binary would restore the
+    /// hole.
+    func engineBinary() throws -> URL {
+        let binary = Bundle(for: Self.self)
+            .bundleURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("arca-engine")
+        guard FileManager.default.isExecutableFile(atPath: binary.path) else {
+            throw EngineBinaryMissing(path: binary.path)
+        }
+        return binary
+    }
+
+    /// Runs the engine and waits, but never indefinitely.
+    ///
+    /// `waitUntilExit()` alone would hang forever in the exact case these tests
+    /// exist to catch: an engine that does not refuse goes on to serve, and a
+    /// hung suite reports nothing.
+    ///
+    /// Callers that pass no subcommand reach `ServeCommand`, which is the root
+    /// command's `defaultSubcommand`. That indirection is deliberately not
+    /// spelt out in the arguments: the invocation Gas Can ships names no
+    /// subcommand, so neither may the tests that stand for it.
+    func runEngine(arguments: [String]) throws -> EngineRun {
+        let process = Process()
+        process.executableURL = try engineBinary()
+        process.arguments = arguments
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+
+        try process.run()
+
+        let deadline = Date().addingTimeInterval(30)
+        while process.isRunning && Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.02)
+        }
+
+        let exitedOnItsOwn = !process.isRunning
+        if !exitedOnItsOwn {
+            // SIGTERM, which the engine turns into a graceful shutdown, so the
+            // socket is unlinked and nothing is left listening for the next test.
+            process.terminate()
+        }
+        process.waitUntilExit()
+
+        return EngineRun(
+            exitedOnItsOwn: exitedOnItsOwn,
+            status: process.terminationStatus,
+            outputText: String(
+                decoding: outputPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self
+            ),
+            errorText: String(
+                decoding: errorPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self
+            )
+        )
+    }
+
+    /// A short root, removed when the test ends.
+    ///
+    /// Short because a macOS Unix socket path is capped near 104 characters, and
+    /// `NSTemporaryDirectory()` already spends about half of that. With a full
+    /// UUID the engine would fail to bind for that reason instead of the one
+    /// under test -- which matters in the mutation case, where the engine is
+    /// meant to get far enough to serve.
+    func temporaryEngineRoot() throws -> URL {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("arca-cmd-\(UUID().uuidString.prefix(8))")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return root
+    }
+}
+
+struct EngineBinaryMissing: Error, CustomStringConvertible {
+    let path: String
+    var description: String {
+        "arca-engine was not built beside the test bundle at \(path)"
+    }
+}

--- a/Tests/ArcaEngineTests/EngineStartupTests.swift
+++ b/Tests/ArcaEngineTests/EngineStartupTests.swift
@@ -1,4 +1,6 @@
+import ContainerBridge
 import Foundation
+import Logging
 import XCTest
 @testable import ArcaEngine
 
@@ -156,6 +158,180 @@ final class EngineStartupTests: XCTestCase {
             try validateEngineInputs(
                 EngineInputs(stateRoot: root, kernelPath: kernelPath, vminitLayout: layout)
             )
+        )
+    }
+
+    // MARK: - Loading vminit into the engine's own store
+
+    private let logger = Logger(label: "engine-startup-tests")
+
+    /// An image manager rooted exactly where `arca-engine` roots its own: at
+    /// `EnginePaths`' image store, under the state root. Not a stub -- the
+    /// digest the regeneration decision turns on is the one the real load
+    /// returns, so a fake source of digests would prove only the fake.
+    private func imageManager(for stateRoot: URL) throws -> ImageManager {
+        try ImageManager(
+            logger: logger, imageStorePath: EnginePaths(stateRoot: stateRoot).imageStoreRoot
+        )
+    }
+
+    /// The digest is recorded so that initfs.ext4 is regenerated when vminit
+    /// changes and only then. Unconditional deletion would rebuild a ~178MB
+    /// image on every start; sharing Apple's path -- which is what ArcaDaemon
+    /// deletes -- would destroy a live daemon's initfs.
+    func testAnUnrecordedDigestReadsAsAbsentAndRoundTrips() throws {
+        let root = temporaryRoot()
+        XCTAssertNil(recordedVminitDigest(stateRoot: root))
+
+        try recordVminitDigest("sha256:abc123", stateRoot: root)
+        XCTAssertEqual(recordedVminitDigest(stateRoot: root), "sha256:abc123")
+
+        try recordVminitDigest("sha256:def456", stateRoot: root)
+        XCTAssertEqual(recordedVminitDigest(stateRoot: root), "sha256:def456")
+    }
+
+    /// The record lives under the state root, never beside Apple's shared
+    /// initfs.ext4.
+    func testTheDigestRecordLivesUnderTheStateRoot() throws {
+        let root = temporaryRoot()
+        try recordVminitDigest("sha256:abc123", stateRoot: root)
+
+        let recorded = root.appendingPathComponent("vminit-digest")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: recorded.path))
+        XCTAssertFalse(recorded.path.contains("com.apple.containerization"))
+    }
+
+    /// The load is the engine's own, into the engine's own store: the image
+    /// lands under the state root and nowhere else, and the digest it returns
+    /// is the one recorded.
+    ///
+    /// This drives `ImageManager.loadFromOCILayout` against a real OCI layout,
+    /// so the digest under test is Containerization's, not the test's.
+    func testLoadingTheLayoutRecordsTheDigestItReturnsUnderTheStateRoot() async throws {
+        let root = temporaryRoot()
+        let layout = root.appendingPathComponent("vminit")
+        try OCILayoutFixture.write(
+            at: layout, reference: "arca-vminit:latest", payload: "a vminit"
+        )
+
+        let digest = try await loadVminit(
+            from: layout, into: try imageManager(for: root), stateRoot: root, logger: logger
+        )
+
+        XCTAssertTrue(
+            digest.hasPrefix("sha256:"),
+            "the recorded key must be the loaded image's digest, got \(digest)"
+        )
+        XCTAssertEqual(recordedVminitDigest(stateRoot: root), digest)
+
+        // A second manager over the same root, so the assertion is that the
+        // image persisted into that store -- not that the manager which loaded
+        // it remembers having done so.
+        let found = await (try imageManager(for: root)).imageExists(
+            nameOrId: "arca-vminit:latest"
+        )
+        XCTAssertTrue(
+            found,
+            "the image must land in the engine's own store, under its state root"
+        )
+    }
+
+    /// The regeneration decision itself, both ways, through the real load.
+    ///
+    /// `testAnUnrecordedDigestReadsAsAbsentAndRoundTrips` covers neither branch:
+    /// MEASURED with the comparison reverted to unconditional regeneration, it
+    /// still passed. Only this test goes red -- and it goes red the other way
+    /// too, with regeneration removed entirely.
+    ///
+    /// Two layouts differing only in their layer bytes stand in for "the vminit
+    /// changed", which is what the record exists to notice.
+    func testAnUnchangedVminitKeepsTheInitfsAndAChangedOneDeletesIt() async throws {
+        let root = temporaryRoot()
+        let paths = EnginePaths(stateRoot: root)
+        let manager = try imageManager(for: root)
+
+        let layout = root.appendingPathComponent("vminit")
+        try OCILayoutFixture.write(
+            at: layout, reference: "arca-vminit:latest", payload: "the first vminit"
+        )
+        let first = try await loadVminit(
+            from: layout, into: manager, stateRoot: root, logger: logger
+        )
+
+        // Stands in for the ~178MB image Containerization builds at this exact
+        // path. Its contents are what the assertions read: the property is
+        // "still the same file", not "some file exists".
+        let built = Data("built from the first vminit".utf8)
+        try FileManager.default.createDirectory(
+            at: paths.imageStoreRoot, withIntermediateDirectories: true
+        )
+        try built.write(to: paths.initfs)
+
+        let again = try await loadVminit(
+            from: layout, into: manager, stateRoot: root, logger: logger
+        )
+        XCTAssertEqual(again, first, "the same layout must load to the same digest")
+        XCTAssertEqual(
+            try? Data(contentsOf: paths.initfs), built,
+            "an unchanged vminit must leave the initfs alone: rebuilding a ~178MB "
+                + "image on every start is the cost this record exists to avoid"
+        )
+
+        let changed = root.appendingPathComponent("vminit-next")
+        try OCILayoutFixture.write(
+            at: changed, reference: "arca-vminit:latest", payload: "the second vminit"
+        )
+        let second = try await loadVminit(
+            from: changed, into: manager, stateRoot: root, logger: logger
+        )
+
+        XCTAssertNotEqual(second, first, "a different vminit must load to a different digest")
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: paths.initfs.path),
+            "a changed vminit must delete the initfs built from the old one, or the "
+                + "engine boots its sandboxes on an init image it no longer has"
+        )
+        XCTAssertEqual(recordedVminitDigest(stateRoot: root), second)
+    }
+
+    /// A layout holding some other image is a refusal, and the refusal names
+    /// the option and the path -- the same two things the missing-input and
+    /// unreadable-input refusals name. ArcaDaemon logs and continues here;
+    /// booting sandboxes on an unknown init image is not a warning.
+    func testALayoutHoldingAnotherImageIsRefusedAndNamesTheOptionAndPath() async throws {
+        let root = temporaryRoot()
+        let layout = root.appendingPathComponent("vminit")
+        try OCILayoutFixture.write(
+            at: layout, reference: "vminit:latest", payload: "not the engine's init"
+        )
+        let manager = try imageManager(for: root)
+
+        do {
+            _ = try await loadVminit(
+                from: layout, into: manager, stateRoot: root, logger: logger
+            )
+            XCTFail("an unexpected reference must be refused, not loaded")
+        } catch let error as EngineStartupError {
+            guard case .unexpectedVminitReference(let name, let path, let expected, let actual)
+                = error
+            else {
+                return XCTFail("expected unexpectedVminitReference, got \(error)")
+            }
+            XCTAssertEqual(name, "--vminit-layout")
+            XCTAssertEqual(path, layout.path)
+            XCTAssertEqual(expected, "arca-vminit:latest")
+            XCTAssertEqual(actual, "vminit:latest")
+            XCTAssertTrue(
+                error.description.contains("--vminit-layout")
+                    && error.description.contains(layout.path),
+                "a refusal that does not say what to fix is worse than a crash, got: \(error)"
+            )
+        }
+
+        XCTAssertNil(
+            recordedVminitDigest(stateRoot: root),
+            "a refused load must record nothing, or the next start reads a digest "
+                + "for an image the engine never accepted"
         )
     }
 }

--- a/Tests/ArcaEngineTests/EngineStartupTests.swift
+++ b/Tests/ArcaEngineTests/EngineStartupTests.swift
@@ -326,6 +326,17 @@ final class EngineStartupTests: XCTestCase {
                     && error.description.contains(layout.path),
                 "a refusal that does not say what to fix is worse than a crash, got: \(error)"
             )
+            // The payload assertions above pin what the case carries; this pins
+            // what the user is shown. MEASURED: with `\(actual)` dropped from
+            // `description`, every assertion above still passed and the whole
+            // suite reported `Executed 58 tests, with 0 failures`. `holds ` is
+            // the anchor because `vminit:latest` is a substring of
+            // `arca-vminit:latest`, so an unanchored `contains` for the found
+            // reference is satisfied by the wanted one.
+            XCTAssertTrue(
+                error.description.contains("holds vminit:latest"),
+                "the rendered refusal must name the image actually found, got: \(error)"
+            )
         }
 
         XCTAssertNil(

--- a/Tests/ArcaEngineTests/EngineStartupTests.swift
+++ b/Tests/ArcaEngineTests/EngineStartupTests.swift
@@ -1,0 +1,161 @@
+import Foundation
+import XCTest
+@testable import ArcaEngine
+
+final class EngineStartupTests: XCTestCase {
+    private func temporaryRoot() -> URL {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("arca-startup-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(
+            at: root, withIntermediateDirectories: true
+        )
+        return root
+    }
+
+    /// A missing kernel is a refusal to start, not a degraded engine. An engine
+    /// that starts and answers unsupported_capability for everything that
+    /// matters is the state the C1 review finding was raised against.
+    func testAMissingKernelRefusesAndNamesThePathTried() throws {
+        let root = temporaryRoot()
+        let kernelPath = root.appendingPathComponent("vmlinux")
+        let inputs = EngineInputs(
+            stateRoot: root,
+            kernelPath: kernelPath,
+            vminitLayout: root.appendingPathComponent("vminit")
+        )
+
+        XCTAssertThrowsError(try validateEngineInputs(inputs)) { error in
+            guard let startupError = error as? EngineStartupError,
+                  case .missingInput(let name, let path) = startupError else {
+                return XCTFail("expected missingInput, got \(error)")
+            }
+            XCTAssertEqual(name, "--kernel-path")
+            XCTAssertEqual(path, kernelPath.path)
+        }
+    }
+
+    /// Existing is not the same as being the right kind of thing. A directory
+    /// where the kernel should be passes an existence check and then fails much
+    /// later, inside the VM boot, with a message about the wrong subject.
+    func testADirectoryWhereTheKernelShouldBeIsRefused() throws {
+        let root = temporaryRoot()
+        let kernelPath = root.appendingPathComponent("vmlinux")
+        try FileManager.default.createDirectory(at: kernelPath, withIntermediateDirectories: true)
+        let layout = root.appendingPathComponent("vminit")
+        try FileManager.default.createDirectory(at: layout, withIntermediateDirectories: true)
+
+        XCTAssertThrowsError(
+            try validateEngineInputs(
+                EngineInputs(stateRoot: root, kernelPath: kernelPath, vminitLayout: layout)
+            )
+        ) { error in
+            guard let startupError = error as? EngineStartupError,
+                  case .unreadableInput(let name, let path, _) = startupError else {
+                return XCTFail("expected unreadableInput, got \(error)")
+            }
+            XCTAssertEqual(name, "--kernel-path")
+            XCTAssertEqual(path, kernelPath.path)
+        }
+    }
+
+    /// The mirror of the case above: a file where the OCI layout directory
+    /// should be. `appendingPathComponent` on a file path yields a path that
+    /// simply does not exist, so without this guard the refusal would name a
+    /// missing `oci-layout` rather than the option that was pointed at a file.
+    func testAFileWhereTheVminitLayoutShouldBeIsRefused() throws {
+        let root = temporaryRoot()
+        let kernelPath = root.appendingPathComponent("vmlinux")
+        FileManager.default.createFile(atPath: kernelPath.path, contents: Data("k".utf8))
+        let layout = root.appendingPathComponent("vminit")
+        FileManager.default.createFile(atPath: layout.path, contents: Data("not a layout".utf8))
+
+        XCTAssertThrowsError(
+            try validateEngineInputs(
+                EngineInputs(stateRoot: root, kernelPath: kernelPath, vminitLayout: layout)
+            )
+        ) { error in
+            guard let startupError = error as? EngineStartupError,
+                  case .unreadableInput(let name, let path, let cause) = startupError else {
+                return XCTFail("expected unreadableInput, got \(error)")
+            }
+            XCTAssertEqual(name, "--vminit-layout")
+            XCTAssertEqual(path, layout.path)
+            XCTAssertTrue(
+                cause.contains("is a file"),
+                "the refusal must say what was wrong with it, got \(cause)"
+            )
+        }
+    }
+
+    /// The vminit layout must be a directory holding an OCI layout, not merely
+    /// a path that exists.
+    func testAVminitLayoutWithoutAnOCIMarkerIsRefused() throws {
+        let root = temporaryRoot()
+        let kernelPath = root.appendingPathComponent("vmlinux")
+        FileManager.default.createFile(atPath: kernelPath.path, contents: Data("k".utf8))
+        let layout = root.appendingPathComponent("vminit")
+        try FileManager.default.createDirectory(at: layout, withIntermediateDirectories: true)
+
+        XCTAssertThrowsError(
+            try validateEngineInputs(
+                EngineInputs(stateRoot: root, kernelPath: kernelPath, vminitLayout: layout)
+            )
+        )
+    }
+
+    /// Each marker in the loop is load-bearing on its own. The test above
+    /// creates a layout with neither, so it stays green with `index.json`
+    /// dropped from the list -- `oci-layout` catches the empty directory for it.
+    /// A half-written layout, which is the shape an interrupted export leaves
+    /// behind, is the case only this test refuses.
+    func testAVminitLayoutMissingOnlyItsIndexIsRefused() throws {
+        let root = temporaryRoot()
+        let kernelPath = root.appendingPathComponent("vmlinux")
+        FileManager.default.createFile(atPath: kernelPath.path, contents: Data("k".utf8))
+        let layout = root.appendingPathComponent("vminit")
+        try FileManager.default.createDirectory(at: layout, withIntermediateDirectories: true)
+        FileManager.default.createFile(
+            atPath: layout.appendingPathComponent("oci-layout").path,
+            contents: Data(#"{"imageLayoutVersion":"1.0.0"}"#.utf8)
+        )
+
+        XCTAssertThrowsError(
+            try validateEngineInputs(
+                EngineInputs(stateRoot: root, kernelPath: kernelPath, vminitLayout: layout)
+            )
+        ) { error in
+            guard let startupError = error as? EngineStartupError,
+                  case .unreadableInput(let name, _, let cause) = startupError else {
+                return XCTFail("expected unreadableInput, got \(error)")
+            }
+            XCTAssertEqual(name, "--vminit-layout")
+            XCTAssertTrue(
+                cause.contains("index.json"),
+                "the refusal must name the marker that was missing, got \(cause)"
+            )
+        }
+    }
+
+    /// All three present and well-formed is the only case that proceeds.
+    func testCompleteInputsValidate() throws {
+        let root = temporaryRoot()
+        let kernelPath = root.appendingPathComponent("vmlinux")
+        FileManager.default.createFile(atPath: kernelPath.path, contents: Data("k".utf8))
+        let layout = root.appendingPathComponent("vminit")
+        try FileManager.default.createDirectory(at: layout, withIntermediateDirectories: true)
+        FileManager.default.createFile(
+            atPath: layout.appendingPathComponent("oci-layout").path,
+            contents: Data(#"{"imageLayoutVersion":"1.0.0"}"#.utf8)
+        )
+        FileManager.default.createFile(
+            atPath: layout.appendingPathComponent("index.json").path,
+            contents: Data(#"{"schemaVersion":2,"manifests":[]}"#.utf8)
+        )
+
+        XCTAssertNoThrow(
+            try validateEngineInputs(
+                EngineInputs(stateRoot: root, kernelPath: kernelPath, vminitLayout: layout)
+            )
+        )
+    }
+}

--- a/Tests/ArcaEngineTests/ImageLoadTests.swift
+++ b/Tests/ArcaEngineTests/ImageLoadTests.swift
@@ -1,0 +1,345 @@
+import Foundation
+import Logging
+import XCTest
+@testable import ArcaEngine
+
+/// `arca-engine image load`, at both ends: the loading itself, which lives in
+/// the `ArcaEngine` library so that a test can reach it, and the subcommand
+/// over it, which only a spawned binary can prove is wired at all.
+///
+/// Both ends are needed and neither substitutes for the other. Task 4's review
+/// found six tests that proved `validateEngineInputs` and never that `run()`
+/// called it -- deleting the call left the whole suite green. The last two
+/// tests here are what stops `image load` acquiring the same hole.
+final class ImageLoadTests: XCTestCase {
+    private let logger = Logger(label: "image-load-tests")
+
+    /// The reference the fixture layout carries. A workspace image, not
+    /// `arca-vminit:latest`: this path exists for content a consumer pushes,
+    /// and a test that loaded vminit through it would prove the two are
+    /// interchangeable, which is the merge this subcommand deliberately avoids.
+    private static let workspaceReference = "workspace:latest"
+
+    // MARK: - Loading
+
+    /// Which reference was loaded, not merely that a load returned.
+    ///
+    /// `references` is the only thing that tells loading something from loading
+    /// nothing, so a test that asserted `XCTAssertNoThrow` and stopped would
+    /// pass against a load that reported an empty list.
+    func testALayoutLoadsTheReferenceItNames() async throws {
+        let root = try temporaryEngineRoot()
+
+        let report = try await loadWorkspaceImages(
+            fromOCILayout: try workspaceLayout(in: root),
+            stateRoot: root.appendingPathComponent("state"),
+            logger: logger
+        )
+
+        XCTAssertEqual(
+            report.references, [Self.workspaceReference],
+            "the load must report the reference it put in the store"
+        )
+    }
+
+    /// The row most likely to pass for the wrong reason, and the milestone's
+    /// central property: the images land in the engine's OWN store.
+    ///
+    /// On a machine where Apple's shared store already holds the same image, a
+    /// test that only checked "it loaded" cannot tell the two stores apart, so
+    /// this asserts the resolved path -- read back from the `ImageManager` that
+    /// performed the load, never re-derived here -- and then that bytes really
+    /// arrived under it. ArcaDaemon shares Apple's store and deletes
+    /// `initfs.ext4` out of it on every start; an `image load` that wrote there
+    /// would undo the whole milestone silently.
+    func testTheImagesLandInTheEnginesOwnStoreAndNotApples() async throws {
+        let root = try temporaryEngineRoot()
+        let stateRoot = root.appendingPathComponent("state")
+
+        let report = try await loadWorkspaceImages(
+            fromOCILayout: try workspaceLayout(in: root), stateRoot: stateRoot, logger: logger
+        )
+
+        XCTAssertEqual(
+            report.storeRoot.path, EnginePaths(stateRoot: stateRoot).imageStoreRoot.path,
+            "the load must use the image store this engine derives from its state root"
+        )
+        XCTAssertTrue(
+            report.storeRoot.path.hasPrefix(stateRoot.path + "/"),
+            "the store written to must live under the state root given, got \(report.storeRoot.path)"
+        )
+        XCTAssertFalse(
+            report.storeRoot.path.contains("com.apple.containerization"),
+            "the load must not resolve into Apple's shared store, got \(report.storeRoot.path)"
+        )
+
+        // The path assertions above describe intent; this one is the bytes. A
+        // store root that was named correctly and never written to would satisfy
+        // every assertion above.
+        XCTAssertFalse(
+            try filesUnder(report.storeRoot).isEmpty,
+            "the images must physically land in \(report.storeRoot.path), which is empty"
+        )
+    }
+
+    // MARK: - Refusing
+
+    /// A missing directory is a refusal naming the option and the path tried --
+    /// the posture Task 4 established for the startup options, for the same
+    /// reason: a degraded mode a consumer cannot see is worse than a failure it
+    /// can.
+    func testAMissingLayoutIsRefusedNamingTheOptionAndPath() async throws {
+        let root = try temporaryEngineRoot()
+        let absent = root.appendingPathComponent("no-such-layout")
+
+        guard let error = await refusal(loading: absent, into: root) else { return }
+        guard case .missingInput(let name, let path) = error else {
+            return XCTFail("expected missingInput, got \(error)")
+        }
+        XCTAssertEqual(name, "--oci-layout")
+        XCTAssertEqual(path, absent.path)
+    }
+
+    /// A file where the layout directory should be. Without this guard the
+    /// refusal would name a missing `oci-layout` inside a path that is not a
+    /// directory at all, rather than the option that was pointed at a file.
+    func testAFileWhereTheLayoutShouldBeIsRefused() async throws {
+        let root = try temporaryEngineRoot()
+        let layout = root.appendingPathComponent("layout")
+        try Data("not a layout".utf8).write(to: layout)
+
+        guard let error = await refusal(loading: layout, into: root) else { return }
+        guard case .unreadableInput(let name, let path, let cause) = error else {
+            return XCTFail("expected unreadableInput, got \(error)")
+        }
+        XCTAssertEqual(name, "--oci-layout")
+        XCTAssertEqual(path, layout.path)
+        XCTAssertTrue(
+            cause.contains("is a file"),
+            "the refusal must say what was wrong with it, got \(cause)"
+        )
+    }
+
+    /// A half-written layout -- the shape an interrupted export leaves behind --
+    /// is refused by name of the marker it lacks, before any store is opened.
+    ///
+    /// The cause is asserted on the validation's own phrasing and not on
+    /// `index.json` alone, and that is not fussiness. MEASURED: with
+    /// `"index.json"` dropped from the marker loop, this test still passed --
+    /// validation let the layout through, `ImageStore.load` then failed with
+    /// `notFound: "<path>/index.json"`, and the wrap put that under the same
+    /// case and the same option name. `is not an OCI layout` is the phrase only
+    /// `validateOCILayoutDirectory` produces, so it is what tells the check
+    /// having run from the store having tripped over the same missing file.
+    func testADirectoryMissingOnlyItsIndexIsRefused() async throws {
+        let root = try temporaryEngineRoot()
+        let layout = root.appendingPathComponent("layout")
+        try FileManager.default.createDirectory(at: layout, withIntermediateDirectories: true)
+        try Data(#"{"imageLayoutVersion":"1.0.0"}"#.utf8)
+            .write(to: layout.appendingPathComponent("oci-layout"))
+
+        guard let error = await refusal(loading: layout, into: root) else { return }
+        guard case .unreadableInput(let name, _, let cause) = error else {
+            return XCTFail("expected unreadableInput, got \(error)")
+        }
+        XCTAssertEqual(name, "--oci-layout")
+        XCTAssertTrue(
+            cause.contains("is not an OCI layout") && cause.contains("index.json"),
+            "the refusal must be the marker check's own, naming the marker that was "
+                + "missing, got \(cause)"
+        )
+    }
+
+    /// Loading nothing is not success.
+    ///
+    /// A well-formed layout holding no manifests passes the marker check and
+    /// then imports nothing. `ImageStore.load` does refuse it -- it throws when
+    /// the imported set is empty
+    /// (containerization/.../ImageStore+OCILayout.swift:101-103) -- but with
+    /// `failed to import image`, which names no option and no path. This asserts
+    /// the refusal a user can act on, which is `loadWorkspaceImages`' wrapping:
+    /// the option, the path, and the cause kept verbatim.
+    ///
+    /// There is deliberately no `guard !references.isEmpty` in the production
+    /// path to go with this. The store refuses first, so such a guard could
+    /// never be seen to fail, and a guard no test can drive is not a guard.
+    func testALayoutHoldingNoImagesIsRefusedRatherThanLoadingNothing() async throws {
+        let root = try temporaryEngineRoot()
+        let layout = root.appendingPathComponent("layout")
+        try FileManager.default.createDirectory(at: layout, withIntermediateDirectories: true)
+        try Data(#"{"imageLayoutVersion":"1.0.0"}"#.utf8)
+            .write(to: layout.appendingPathComponent("oci-layout"))
+        try Data(#"{"schemaVersion":2,"manifests":[]}"#.utf8)
+            .write(to: layout.appendingPathComponent("index.json"))
+
+        guard let error = await refusal(loading: layout, into: root) else { return }
+        guard case .unreadableInput(let name, let path, let cause) = error else {
+            return XCTFail("expected unreadableInput, got \(error)")
+        }
+        XCTAssertEqual(name, "--oci-layout")
+        XCTAssertEqual(path, layout.path)
+        // Coupled to the store's own wording, and deliberately: a refusal that
+        // named the option and the path but dropped the cause would satisfy
+        // every other assertion here while telling a user nothing about what
+        // was wrong with their layout. MEASURED against the built binary --
+        // `Error: --oci-layout is unusable at <path>: internalError: "failed to
+        // import image"`.
+        XCTAssertTrue(
+            cause.contains("import"),
+            "the refusal must carry the store's own cause, not swallow it, got \(cause)"
+        )
+    }
+
+    // MARK: - The subcommand over it
+
+    /// The subcommand is wired to the loading, and to this engine's own store.
+    ///
+    /// Only a spawned binary can hold this: a test target cannot import an
+    /// executable, so nothing else can tell an `image load` that calls
+    /// `loadWorkspaceImages` from one that prints a cheerful line and exits 0.
+    ///
+    /// Every assertion below is on something invented microseconds earlier --
+    /// this run's own state root and its layout's reference -- so none of them
+    /// can be satisfied by ArgumentParser's static usage text, which is the trap
+    /// Task 4's review found the second time round.
+    func testTheImageLoadSubcommandLoadsIntoTheStateRootsOwnStore() throws {
+        let root = try temporaryEngineRoot()
+        let stateRoot = root.appendingPathComponent("state")
+        let layout = try workspaceLayout(in: root)
+
+        let run = try runEngine(arguments: [
+            "image", "load",
+            "--state-root", stateRoot.path,
+            "--oci-layout", layout.path,
+        ])
+
+        XCTAssertTrue(
+            run.exitedOnItsOwn,
+            "an image load must load and exit, not serve; stderr: \(run.errorText)"
+        )
+        XCTAssertEqual(
+            run.status, 0,
+            "a valid layout must load; stderr: \(run.errorText)"
+        )
+
+        let storeRoot = EnginePaths(stateRoot: stateRoot).imageStoreRoot
+        XCTAssertTrue(
+            run.outputText.contains(Self.workspaceReference),
+            "the load must report which reference it loaded, got: \(run.outputText)"
+        )
+        XCTAssertTrue(
+            run.outputText.contains(storeRoot.path),
+            "the load must report the store it wrote to, got: \(run.outputText)"
+        )
+        XCTAssertFalse(
+            try filesUnder(storeRoot).isEmpty,
+            "the subcommand must write the image into \(storeRoot.path), which is empty"
+        )
+    }
+
+    /// The subcommand refuses, and leaves nothing behind when it does.
+    ///
+    /// `contains("--oci-layout")` would be satisfied by the subcommand's own
+    /// usage line, which ArgumentParser prints on any parse error before `run()`
+    /// is entered -- Task 4's review found exactly that. The path assertion is
+    /// the one that cannot be: it is a temp path this test invented, so only
+    /// `EngineStartupError`'s own rendering can put it on stderr.
+    ///
+    /// The last assertion carries the ordering. Validation runs before the image
+    /// store is opened, and opening a store creates its directories; if the two
+    /// swapped, everything above still passes and a refused load would have left
+    /// a state root on disk.
+    func testTheImageLoadSubcommandRefusesAMissingLayoutAndCreatesNoState() throws {
+        let root = try temporaryEngineRoot()
+        let stateRoot = root.appendingPathComponent("state")
+        let absent = root.appendingPathComponent("no-such-layout")
+
+        let run = try runEngine(arguments: [
+            "image", "load",
+            "--state-root", stateRoot.path,
+            "--oci-layout", absent.path,
+        ])
+
+        XCTAssertTrue(
+            run.exitedOnItsOwn,
+            "a refused load must exit; stderr: \(run.errorText)"
+        )
+        XCTAssertNotEqual(
+            run.status, 0,
+            "a refusal must be a non-zero exit; stderr: \(run.errorText)"
+        )
+        XCTAssertTrue(
+            run.errorText.contains(absent.path),
+            "stderr must carry the refusal's own message, naming the path tried, "
+                + "and not merely ArgumentParser's usage line; got: \(run.errorText)"
+        )
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: stateRoot.path),
+            "a refused load must create no state, but \(stateRoot.path) exists"
+        )
+    }
+
+    // MARK: - Fixtures
+
+    /// A real OCI layout holding one workspace image.
+    ///
+    /// Real rather than stubbed, for the reason `OCILayoutFixture` records: the
+    /// references and digests under test are the ones the real loader returns,
+    /// and a hand-invented image proves the invention.
+    private func workspaceLayout(in root: URL) throws -> URL {
+        try OCILayoutFixture.write(
+            at: root.appendingPathComponent("workspace"),
+            reference: Self.workspaceReference,
+            payload: "pushed by the consumer, not by startup"
+        )
+    }
+
+    /// Every file below `directory`, or an empty list if it does not exist.
+    ///
+    /// Recursive because the store nests its content under directories of its
+    /// own choosing; what is asserted is that something was written, not the
+    /// shape Containerization writes it in, which is not this engine's to fix.
+    private func filesUnder(_ directory: URL) throws -> [String] {
+        guard let walker = FileManager.default.enumerator(atPath: directory.path) else { return [] }
+        return walker.compactMap { entry in
+            guard let name = entry as? String else { return nil }
+            var isDirectory: ObjCBool = false
+            let path = directory.appendingPathComponent(name).path
+            guard FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory),
+                  !isDirectory.boolValue else { return nil }
+            return name
+        }
+    }
+
+    /// Runs a load that must be refused and hands back the refusal.
+    ///
+    /// A function rather than `XCTAssertThrowsError`, which takes a
+    /// non-`async` autoclosure and so cannot call this at all. Returning nil
+    /// after failing, rather than throwing, lets each caller `guard ... else {
+    /// return }` and read as one case.
+    private func refusal(
+        loading layout: URL,
+        into root: URL,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async -> EngineStartupError? {
+        do {
+            let report = try await loadWorkspaceImages(
+                fromOCILayout: layout,
+                stateRoot: root.appendingPathComponent("state"),
+                logger: logger
+            )
+            XCTFail(
+                "the load must refuse \(layout.path), but reported \(report.references) "
+                    + "in \(report.storeRoot.path)",
+                file: file, line: line
+            )
+            return nil
+        } catch let error as EngineStartupError {
+            return error
+        } catch {
+            XCTFail("expected an EngineStartupError, got \(error)", file: file, line: line)
+            return nil
+        }
+    }
+}

--- a/Tests/ArcaEngineTests/ImageLoadTests.swift
+++ b/Tests/ArcaEngineTests/ImageLoadTests.swift
@@ -323,17 +323,96 @@ final class ImageLoadTests: XCTestCase {
     /// is the shape this project guards against elsewhere: Gas Can's
     /// `build-arca-engine.sh` grew a listing guard because
     /// `swift test --filter <no match>` exits 0 having run nothing.
-    func testTheImageGroupRefusesToDoNothing() throws {
+    ///
+    /// The message half is read out of the refusal's own action list and NOT as
+    /// `errorText.contains("load")`, which is the trap this file already carries
+    /// a comment about and which the fix for the `--help` regression walked
+    /// straight into: the root's `usage:` puts `arca-engine image load
+    /// --state-root <state-root> --oci-layout <oci-layout>` on stderr with every
+    /// `ValidationError`, so `contains("load")` was satisfied by static usage
+    /// text with no contribution from the refusal at all. MEASURED by the
+    /// reviewer: with the message body replaced by the constant `"nope"` and the
+    /// throw kept, the binary printed `Error: nope` and this test passed.
+    ///
+    /// `name an action: ` appears in no usage line, no abstract and no help
+    /// text, so reaching the list at all requires the message to have produced
+    /// it.
+    func testTheImageGroupRefusesToDoNothingAndNamesWhatItCanDo() throws {
         let run = try runEngine(arguments: ["image"])
 
         XCTAssertNotEqual(
             run.status, 0,
             "a group that loaded no image must not report success; stdout: \(run.outputText)"
         )
-        XCTAssertTrue(
-            run.errorText.contains("load"),
-            "the refusal must name the action that was missing, got: \(run.errorText)"
+        XCTAssertEqual(
+            actionsNamed(inRefusal: run.errorText), ["load"],
+            "the refusal must name the actions the group has, got: \(run.errorText)"
         )
+    }
+
+    /// The refusal lists every action the group advertises.
+    ///
+    /// This is the property `ImageCommand.run()`'s derivation off
+    /// `configuration.subcommands` exists for, asserted rather than asserted
+    /// about in a comment. Both sides are the binary's own: the advertised set
+    /// is parsed out of `arca-engine image --help`, which ArgumentParser
+    /// generates from that same array, and the named set is the refusal's list.
+    ///
+    /// **It is a forward guard and cannot bite today.** With `load` the only
+    /// subcommand, replacing the derivation with the literal `"load"` leaves
+    /// both sides equal and this test green. It goes red the moment the two
+    /// disagree, which with one subcommand means only that the message is
+    /// wrong -- and that is what it was proved on. Task 10 adds `prepare`; if it
+    /// reaches `subcommands` and not the message, this is what fails.
+    func testTheRefusalNamesEveryActionTheGroupAdvertises() throws {
+        let help = try runEngine(arguments: ["image", "--help"])
+        XCTAssertEqual(help.status, 0, "image --help must succeed; stderr: \(help.errorText)")
+
+        let advertised = subcommandsAdvertised(inHelp: help.outputText)
+        XCTAssertFalse(
+            advertised.isEmpty,
+            "the group must advertise at least one action, or this test proves nothing "
+                + "by comparing two empty lists; help was: \(help.outputText)"
+        )
+
+        let refusal = try runEngine(arguments: ["image"])
+        XCTAssertEqual(
+            actionsNamed(inRefusal: refusal.errorText), advertised,
+            "every action 'arca-engine image --help' advertises must appear in the refusal, "
+                + "got \(refusal.errorText)"
+        )
+    }
+
+    /// The phrase only `ImageCommand`'s refusal produces. Deliberately long
+    /// enough that no usage line, abstract or help text carries it.
+    private static let actionListMarker = "name an action: "
+
+    /// The actions a refusal named, or an empty list if it named none.
+    private func actionsNamed(inRefusal errorText: String) -> [String] {
+        guard let line = errorText.split(separator: "\n")
+            .first(where: { $0.contains(Self.actionListMarker) }),
+            let marker = line.range(of: Self.actionListMarker) else { return [] }
+        return line[marker.upperBound...]
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+    }
+
+    /// The subcommand names in a help listing's SUBCOMMANDS section.
+    ///
+    /// The section runs from its heading to the first blank line, which is what
+    /// separates the entries from the `See 'arca-engine help …'` footer that is
+    /// indented the same. An entry begins in column three; the continuation
+    /// lines of a wrapped abstract are indented far deeper, so a first token
+    /// taken from a two-space indent is a name and never a stray word.
+    private func subcommandsAdvertised(inHelp helpText: String) -> [String] {
+        let lines = helpText.split(separator: "\n", omittingEmptySubsequences: false)
+        guard let heading = lines.firstIndex(where: { $0.hasPrefix("SUBCOMMANDS:") }) else {
+            return []
+        }
+        return lines[lines.index(after: heading)...]
+            .prefix { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+            .filter { $0.hasPrefix("  ") && !$0.hasPrefix("   ") }
+            .compactMap { $0.split(separator: " ").first.map(String.init) }
     }
 
     // MARK: - Fixtures

--- a/Tests/ArcaEngineTests/ImageLoadTests.swift
+++ b/Tests/ArcaEngineTests/ImageLoadTests.swift
@@ -279,6 +279,63 @@ final class ImageLoadTests: XCTestCase {
         )
     }
 
+    // MARK: - What the command line itself promises
+
+    /// `arca-engine --help` documents how to start the engine.
+    ///
+    /// The subcommand split cost this and nothing noticed, because nothing in
+    /// this suite read help output at all. A root command with no options of
+    /// its own generates `USAGE: arca-engine <subcommand>` and an OPTIONS list
+    /// holding only `-h`, so the four options the engine cannot start without
+    /// became reachable only by first knowing to type `arca-engine serve
+    /// --help`. Milestone 4 writes a launchd plist against this binary; whoever
+    /// writes it, or debugs a start that failed, reads `--help`.
+    ///
+    /// Asserted against the `--help` invocation's own STDOUT at exit 0, which
+    /// is what keeps it out of reach of the usage line ArgumentParser prints on
+    /// every parse error -- that goes to stderr, with exit 64. Task 4's review
+    /// found assertions satisfied by exactly that text.
+    func testHelpDocumentsTheOptionsTheEngineCannotStartWithout() throws {
+        let run = try runEngine(arguments: ["--help"])
+
+        XCTAssertEqual(
+            run.status, 0,
+            "--help must succeed; stderr: \(run.errorText)"
+        )
+        for option in ["--socket-path", "--state-root", "--kernel-path", "--vminit-layout"] {
+            XCTAssertTrue(
+                run.outputText.contains(option),
+                "arca-engine --help must document \(option), which the engine cannot "
+                    + "start without; got: \(run.outputText)"
+            )
+        }
+        XCTAssertTrue(
+            run.outputText.contains("serve --help"),
+            "arca-engine --help must point at where the options are described; "
+                + "got: \(run.outputText)"
+        )
+    }
+
+    /// `arca-engine image` does not exit 0 having done nothing.
+    ///
+    /// ArgumentParser's default for a bare group is help and exit 0, so
+    /// `arca-engine image && echo ok` printed `ok` having loaded no image. That
+    /// is the shape this project guards against elsewhere: Gas Can's
+    /// `build-arca-engine.sh` grew a listing guard because
+    /// `swift test --filter <no match>` exits 0 having run nothing.
+    func testTheImageGroupRefusesToDoNothing() throws {
+        let run = try runEngine(arguments: ["image"])
+
+        XCTAssertNotEqual(
+            run.status, 0,
+            "a group that loaded no image must not report success; stdout: \(run.outputText)"
+        )
+        XCTAssertTrue(
+            run.errorText.contains("load"),
+            "the refusal must name the action that was missing, got: \(run.errorText)"
+        )
+    }
+
     // MARK: - Fixtures
 
     /// A real OCI layout holding one workspace image.

--- a/Tests/ArcaEngineTests/ImageLoadTests.swift
+++ b/Tests/ArcaEngineTests/ImageLoadTests.swift
@@ -362,8 +362,15 @@ final class ImageLoadTests: XCTestCase {
     /// subcommand, replacing the derivation with the literal `"load"` leaves
     /// both sides equal and this test green. It goes red the moment the two
     /// disagree, which with one subcommand means only that the message is
-    /// wrong -- and that is what it was proved on. Task 10 adds `prepare`; if it
-    /// reaches `subcommands` and not the message, this is what fails.
+    /// wrong -- and that is what it was proved on.
+    ///
+    /// What it is waiting for is a second action reaching `subcommands` without
+    /// reaching the message. **Nothing in this milestone schedules one**: the
+    /// remaining work is the engine's gRPC methods, `PrepareImage` among them
+    /// (`proto/arca/engine/v1/engine.proto:41`), which are served over the
+    /// socket and add no subcommand here. So this guards a hazard that is real
+    /// and unscheduled, which is the only reason its cost is two spawned runs
+    /// and not more.
     func testTheRefusalNamesEveryActionTheGroupAdvertises() throws {
         let help = try runEngine(arguments: ["image", "--help"])
         XCTAssertEqual(help.status, 0, "image --help must succeed; stderr: \(help.errorText)")

--- a/Tests/ArcaEngineTests/ImageResolutionTests.swift
+++ b/Tests/ArcaEngineTests/ImageResolutionTests.swift
@@ -317,25 +317,20 @@ final class ImageResolutionTests: XCTestCase {
         }
     }
 
-    /// Resolution is decided by what the store holds, not by how it enumerates.
+    /// A row the caller named beats a row that merely holds the content, on
+    /// every read.
     ///
-    /// The companion to the test above, on the read side and without the delete:
-    /// one unchanged store, asked the same question repeatedly, must answer
-    /// identically. This is **Minor 6** from the round-1 review -- recorded there
-    /// as an unpinned assumption -- closed by the same ordering change rather
-    /// than by a separate guard, and pinned here.
-    ///
-    /// The third row exists to give a tie-break something to trip on: it holds
-    /// the same content under a digest-form name that sorts before the one being
-    /// asked for.
-    func testResolutionIsAFunctionOfStoreContentsAndNotEnumerationOrder() async throws {
+    /// **This tests arm PRECEDENCE and -- corrected -- it does not test the
+    /// tie-break.** Its first version claimed a third row "gives a tie-break
+    /// something to trip on"; the re-review showed the tie-break never runs
+    /// here, because the store holds a row named exactly what is being asked
+    /// for, so the name arm answers and the digest pass is never reached. The
+    /// tie-break has its own test below. This one goes RED under the interleaved
+    /// mutation, which is what it is for.
+    func testANamedRowBeatsAContentMatchOnEveryRead() async throws {
         let store = try await preparedStore()
         let named = "workspace@sha256:\(store.hex)"
         try await store.manager.tagImage(source: "workspace:latest", target: named)
-        try await store.manager.tagImage(
-            source: "workspace:latest",
-            target: "workspace@sha256:\(String(repeating: "0", count: 64))"
-        )
 
         var answers: Set<String> = []
         for _ in 1...25 {
@@ -345,6 +340,77 @@ final class ImageResolutionTests: XCTestCase {
             answers, [named],
             "twenty-five reads of one unchanged store must give exactly one answer, and it "
                 + "must be the row the caller named"
+        )
+    }
+
+    /// The digest pass's tie-break is fixed, not incidental.
+    ///
+    /// **The store is built so the digest pass is the only arm that can
+    /// answer**: no row is named `workspace@sha256:<hex>`, and two rows hold that
+    /// content under the same repository. Both are equally valid answers, so
+    /// something must choose -- and if that something is `imageStore.list()`'s
+    /// order, the resolver is nondeterministic again.
+    ///
+    /// Pinned to `workspace:alpha`, the lexicographically smaller reference. The
+    /// direction is arbitrary; that it is *fixed* is not. Both mutations the
+    /// re-review ran against the first version of this fix -- reversing the sort
+    /// and deleting it -- survived all 137 tests, which is what a tie-break with
+    /// no test looks like. This is **Minor 6** from round 1, finally pinned.
+    ///
+    /// Twenty independent stores, because the failure is per-process.
+    func testTheDigestPassPicksTheSameCandidateEveryTime() async throws {
+        for iteration in 1...20 {
+            let store = try await preparedStore()
+            try await store.manager.tagImage(source: "workspace:latest", target: "workspace:alpha")
+            try await store.manager.tagImage(source: "workspace:latest", target: "workspace:zulu")
+            // Leaves exactly two rows, both holding this content under
+            // `workspace`, and neither named by the digest reference below.
+            _ = try await store.manager.deleteImage(nameOrId: "workspace:latest")
+
+            let resolved = try await store.manager.getImage(
+                nameOrId: "workspace@sha256:\(store.hex)"
+            )
+            XCTAssertEqual(
+                resolved.reference, "workspace:alpha",
+                "run \(iteration): with two equally-valid candidates the digest pass must "
+                    + "choose by a fixed rule, not by the store's enumeration order"
+            )
+        }
+    }
+
+    /// The ID arms are order-independent too.
+    ///
+    /// **The re-review measured these still unstable after the first ordering
+    /// fix**: five reads of one unchanged store, inside one process, gave two
+    /// different answers for a short ID and for a long ID. Both arms can match
+    /// more than one row -- two references to one content share a digest -- and
+    /// both were still returning whichever row the loop reached first.
+    ///
+    /// So "resolution is a function of what the store holds, not how it
+    /// enumerates" was false for half the arms while being written in three
+    /// places. Every arm now collects, sorts and takes the first, and this says
+    /// so rather than the comment saying it.
+    func testTheShortAndLongIdArmsAlsoAnswerTheSameWayEveryTime() async throws {
+        let store = try await preparedStore()
+        try await store.manager.tagImage(source: "workspace:latest", target: "workspace:alpha")
+        try await store.manager.tagImage(source: "workspace:latest", target: "workspace:zulu")
+
+        var shortIdAnswers: Set<String> = []
+        var longIdAnswers: Set<String> = []
+        for _ in 1...25 {
+            shortIdAnswers.insert(
+                try await store.manager.getImage(nameOrId: String(store.hex.prefix(12))).reference
+            )
+            longIdAnswers.insert(
+                try await store.manager.getImage(nameOrId: "sha256:\(store.hex)").reference
+            )
+        }
+        XCTAssertEqual(
+            shortIdAnswers, ["workspace:alpha"],
+            "a short ID matching three rows must resolve to one of them by a fixed rule"
+        )
+        XCTAssertEqual(
+            longIdAnswers, ["workspace:alpha"], "and so must a long ID"
         )
     }
 

--- a/Tests/ArcaEngineTests/ImageResolutionTests.swift
+++ b/Tests/ArcaEngineTests/ImageResolutionTests.swift
@@ -281,9 +281,15 @@ final class ImageResolutionTests: XCTestCase {
     /// match always beats a content match and the answer is a function of what
     /// the store holds rather than of how it enumerates.
     ///
-    /// **Twenty independent stores, because one green run is exactly what the
-    /// broken version produced three times out of five.** Each iteration builds a
-    /// fresh store and so gets its own enumeration order.
+    /// **Twenty stores, and they are independent only because `preparedStore()`
+    /// gives each one its own content.** A fresh store is not by itself a fresh
+    /// enumeration order -- see that fixture's comment. MEASURED against the
+    /// interleaved resolver this test exists to catch (`de8c880`'s
+    /// `ImageManager.swift`, restored whole), 20 runs each: with every store
+    /// holding identical content this test caught it **5 times in 20**; with the
+    /// content varied per store, **19 times in 20**. The re-review's "39 of 40"
+    /// for that mutation was the whole suite going RED, which it did on the
+    /// strength of the three other tests here, not this one.
     func testDeletingALiterallyNamedDigestRowSucceedsOnEveryRun() async throws {
         for iteration in 1...20 {
             let store = try await preparedStore()
@@ -351,18 +357,35 @@ final class ImageResolutionTests: XCTestCase {
     /// something must choose -- and if that something is `imageStore.list()`'s
     /// order, the resolver is nondeterministic again.
     ///
-    /// Pinned to `workspace:alpha`, the lexicographically smaller reference. The
+    /// Pinned to the `alpha` row, the lexicographically smaller reference. The
     /// direction is arbitrary; that it is *fixed* is not. Both mutations the
-    /// re-review ran against the first version of this fix -- reversing the sort
-    /// and deleting it -- survived all 137 tests, which is what a tie-break with
-    /// no test looks like. This is **Minor 6** from round 1, finally pinned.
+    /// re-review ran against the first version of this fix -- reversing the
+    /// tie-break and deleting it -- survived all 131 tests, which is what a
+    /// tie-break with no test looks like. This is **Minor 6** from round 1,
+    /// finally pinned.
     ///
-    /// Twenty independent stores, because the failure is per-process.
+    /// Twenty stores, with the tag names salted per iteration for the reason
+    /// `testTheShortAndLongIdArmsAlsoAnswerTheSameWayEveryTime` records: twenty
+    /// stores holding the same names enumerate alike inside one process, so
+    /// without the salt the loop is worth far fewer than twenty samples.
+    /// MEASURED on the tree this ships as, three mutations, each applied to a
+    /// clean tree:
+    ///
+    /// - this arm reverted to `images.first(where:)`: RED **15 of 15**, 6 to 14
+    ///   of the twenty iterations failing per run.
+    /// - the tie-break deleted (`candidates.first`): RED **10 of 10**.
+    /// - the tie-break reversed: RED **5 of 5**, and it cannot depend on
+    ///   enumeration at all -- it answers the `zulu` row from any order.
     func testTheDigestPassPicksTheSameCandidateEveryTime() async throws {
         for iteration in 1...20 {
             let store = try await preparedStore()
-            try await store.manager.tagImage(source: "workspace:latest", target: "workspace:alpha")
-            try await store.manager.tagImage(source: "workspace:latest", target: "workspace:zulu")
+            let salt = String(format: "%02d", iteration)
+            try await store.manager.tagImage(
+                source: "workspace:latest", target: "workspace:alpha\(salt)"
+            )
+            try await store.manager.tagImage(
+                source: "workspace:latest", target: "workspace:zulu\(salt)"
+            )
             // Leaves exactly two rows, both holding this content under
             // `workspace`, and neither named by the digest reference below.
             _ = try await store.manager.deleteImage(nameOrId: "workspace:latest")
@@ -371,7 +394,7 @@ final class ImageResolutionTests: XCTestCase {
                 nameOrId: "workspace@sha256:\(store.hex)"
             )
             XCTAssertEqual(
-                resolved.reference, "workspace:alpha",
+                resolved.reference, "workspace:alpha\(salt)",
                 "run \(iteration): with two equally-valid candidates the digest pass must "
                     + "choose by a fixed rule, not by the store's enumeration order"
             )
@@ -388,30 +411,57 @@ final class ImageResolutionTests: XCTestCase {
     ///
     /// So "resolution is a function of what the store holds, not how it
     /// enumerates" was false for half the arms while being written in three
-    /// places. Every arm now collects, sorts and takes the first, and this says
-    /// so rather than the comment saying it.
+    /// places. Every arm now collects and takes the minimum, and this says so
+    /// rather than the comment saying it.
+    ///
+    /// **Twenty stores, and the tag names are salted per iteration, because the
+    /// salt is what makes the twenty samples independent.** The first version of
+    /// this test read one store 25 times, and the re-review measured it catching
+    /// a revert of the short-ID arm in 10 runs of 15. Twenty *unsalted* stores
+    /// did not help -- MEASURED at 9 of 15, and every one of those runs failed
+    /// either all 100 assertions or none of them, so twenty stores carrying the
+    /// same three names are one sample and not twenty. Salting the names
+    /// resamples the store's enumeration per iteration, and on the tree this
+    /// ships as:
+    ///
+    /// - short-ID arm reverted to `images.first(where:)`: RED **15 of 15**,
+    ///   failing 40 to 100 of the 100 short-ID assertions per run.
+    /// - long-ID arm reverted the same way: RED **15 of 15**, 30 to 96 per run.
+    ///
+    /// Not proven deterministic, and this comment will not say it is. What is
+    /// measured is 30 of 30 runs RED off a per-iteration miss rate near half,
+    /// which is the difference between one chance to catch a later edit and
+    /// twenty.
     func testTheShortAndLongIdArmsAlsoAnswerTheSameWayEveryTime() async throws {
-        let store = try await preparedStore()
-        try await store.manager.tagImage(source: "workspace:latest", target: "workspace:alpha")
-        try await store.manager.tagImage(source: "workspace:latest", target: "workspace:zulu")
+        for iteration in 1...20 {
+            let store = try await preparedStore()
+            let salt = String(format: "%02d", iteration)
+            try await store.manager.tagImage(
+                source: "workspace:latest", target: "workspace:alpha\(salt)"
+            )
+            try await store.manager.tagImage(
+                source: "workspace:latest", target: "workspace:zulu\(salt)"
+            )
+            // `alpha…` sorts before `latest`, which sorts before `zulu…`, so the
+            // rule's answer is known without recomputing the rule.
+            let expected = "workspace:alpha\(salt)"
 
-        var shortIdAnswers: Set<String> = []
-        var longIdAnswers: Set<String> = []
-        for _ in 1...25 {
-            shortIdAnswers.insert(
-                try await store.manager.getImage(nameOrId: String(store.hex.prefix(12))).reference
-            )
-            longIdAnswers.insert(
-                try await store.manager.getImage(nameOrId: "sha256:\(store.hex)").reference
-            )
+            for read in 1...5 {
+                let shortId = try await store.manager
+                    .getImage(nameOrId: String(store.hex.prefix(12))).reference
+                XCTAssertEqual(
+                    shortId, expected,
+                    "store \(iteration), read \(read): a short ID matching three rows must "
+                        + "resolve to one of them by a fixed rule"
+                )
+                let longId = try await store.manager
+                    .getImage(nameOrId: "sha256:\(store.hex)").reference
+                XCTAssertEqual(
+                    longId, expected,
+                    "store \(iteration), read \(read): and so must a long ID"
+                )
+            }
         }
-        XCTAssertEqual(
-            shortIdAnswers, ["workspace:alpha"],
-            "a short ID matching three rows must resolve to one of them by a fixed rule"
-        )
-        XCTAssertEqual(
-            longIdAnswers, ["workspace:alpha"], "and so must a long ID"
-        )
     }
 
     // MARK: - The parser the arm is built on
@@ -476,15 +526,32 @@ final class ImageResolutionTests: XCTestCase {
         let hex: String
     }
 
+    /// Every store gets its own content, and that is load-bearing for the loop
+    /// tests above.
+    ///
+    /// A store's enumeration order is fixed for the life of a *process* given a
+    /// fixed set of references: MEASURED, by reverting the short-ID arm to
+    /// `images.first(where:)` against twenty stores that all carried the same
+    /// three names -- every run failed either all 100 assertions or none of
+    /// them, and the revert still escaped 6 runs in 15. Twenty such stores are
+    /// one sample and not twenty.
+    ///
+    /// A unique payload gives a unique digest, and so a unique spelling for
+    /// every reference that carries one. That is what makes
+    /// `testDeletingALiterallyNamedDigestRowSucceedsOnEveryRun`'s twenty stores
+    /// twenty samples -- its rows are named `workspace@sha256:<hex>` -- and it
+    /// took that test from 5 catches in 20 to 19 in 20. The two loop tests whose
+    /// rows are plain tags salt the tag names themselves, for the same reason.
     private func preparedStore() async throws -> PreparedStore {
+        let identity = UUID().uuidString
         let root = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("arca-image-resolution-tests-\(UUID().uuidString)")
+            .appendingPathComponent("arca-image-resolution-tests-\(identity)")
         let stateRoot = root.appendingPathComponent("state")
         _ = try await loadWorkspaceImages(
             fromOCILayout: try OCILayoutFixture.write(
                 at: root.appendingPathComponent("workspace"),
                 reference: "workspace:latest",
-                payload: "pushed by the consumer, not by startup"
+                payload: "pushed by the consumer, not by startup, \(identity)"
             ),
             stateRoot: stateRoot,
             logger: logger

--- a/Tests/ArcaEngineTests/ImageResolutionTests.swift
+++ b/Tests/ArcaEngineTests/ImageResolutionTests.swift
@@ -261,6 +261,93 @@ final class ImageResolutionTests: XCTestCase {
         XCTAssertNotNil(untouched, "and must not take the other reference with it")
     }
 
+    /// A legitimate `rmi` by digest reference succeeds every time, not most
+    /// times.
+    ///
+    /// **This pins a nondeterminism the round-2 fix introduced and the re-review
+    /// caught.** With both a tag row and a row literally named
+    /// `repository@sha256:<hex>` in the store, two arms can answer one input: the
+    /// name arm matches the literal row, the digest arm matches the content. The
+    /// arms used to be interleaved inside one loop over `imageStore.list()`,
+    /// whose order is the store's own, so whichever ROW came first decided which
+    /// ARM answered -- and `deleteImage`'s guard, which compares the resolved
+    /// row's reference against the input, then refused a legitimate delete
+    /// whenever the tag row happened to come first. MEASURED by the re-review
+    /// over five runs: two threw, three succeeded, and in one run `getImage` and
+    /// `deleteImage` resolved the same string to different rows inside one
+    /// process.
+    ///
+    /// The loop is now one pass per arm rather than one pass per row, so a name
+    /// match always beats a content match and the answer is a function of what
+    /// the store holds rather than of how it enumerates.
+    ///
+    /// **Twenty independent stores, because one green run is exactly what the
+    /// broken version produced three times out of five.** Each iteration builds a
+    /// fresh store and so gets its own enumeration order.
+    func testDeletingALiterallyNamedDigestRowSucceedsOnEveryRun() async throws {
+        for iteration in 1...20 {
+            let store = try await preparedStore()
+            let named = "workspace@sha256:\(store.hex)"
+            // The store now holds `workspace:latest` AND a row literally named
+            // by the digest reference. Both can answer; only one is right.
+            try await store.manager.tagImage(source: "workspace:latest", target: named)
+
+            let resolved = try await store.manager.getImage(nameOrId: named)
+            XCTAssertEqual(
+                resolved.reference, named,
+                "run \(iteration): the row the caller named must win over the row that "
+                    + "merely holds the same content"
+            )
+
+            _ = try await store.manager.deleteImage(nameOrId: named)
+
+            // Asserted on the store's ROWS, not on whether the reference still
+            // resolves. It still does, and correctly: the surviving
+            // `workspace:latest` holds the same content under the same
+            // repository, so `workspace@sha256:<hex>` remains a true statement
+            // about what the store has. The question this test asks is which row
+            // was removed.
+            let rows = try await store.manager.listImages()
+                .flatMap(\.repoTags).sorted()
+            XCTAssertEqual(
+                rows, ["workspace:latest"],
+                "run \(iteration): the named row must be the one deleted, and the tag must "
+                    + "survive its sibling's deletion"
+            )
+        }
+    }
+
+    /// Resolution is decided by what the store holds, not by how it enumerates.
+    ///
+    /// The companion to the test above, on the read side and without the delete:
+    /// one unchanged store, asked the same question repeatedly, must answer
+    /// identically. This is **Minor 6** from the round-1 review -- recorded there
+    /// as an unpinned assumption -- closed by the same ordering change rather
+    /// than by a separate guard, and pinned here.
+    ///
+    /// The third row exists to give a tie-break something to trip on: it holds
+    /// the same content under a digest-form name that sorts before the one being
+    /// asked for.
+    func testResolutionIsAFunctionOfStoreContentsAndNotEnumerationOrder() async throws {
+        let store = try await preparedStore()
+        let named = "workspace@sha256:\(store.hex)"
+        try await store.manager.tagImage(source: "workspace:latest", target: named)
+        try await store.manager.tagImage(
+            source: "workspace:latest",
+            target: "workspace@sha256:\(String(repeating: "0", count: 64))"
+        )
+
+        var answers: Set<String> = []
+        for _ in 1...25 {
+            answers.insert(try await store.manager.getImage(nameOrId: named).reference)
+        }
+        XCTAssertEqual(
+            answers, [named],
+            "twenty-five reads of one unchanged store must give exactly one answer, and it "
+                + "must be the row the caller named"
+        )
+    }
+
     // MARK: - The parser the arm is built on
 
     /// `ImageIdentity.exactDigest` recognises the form and nothing near it.

--- a/Tests/ArcaEngineTests/ImageResolutionTests.swift
+++ b/Tests/ArcaEngineTests/ImageResolutionTests.swift
@@ -175,6 +175,92 @@ final class ImageResolutionTests: XCTestCase {
         )
     }
 
+    // MARK: - The other callers the widened resolver reaches
+
+    /// `inspectImage` must accept the digest form too, and this pins why the arm
+    /// cannot be scoped to `getImage` alone.
+    ///
+    /// **`createContainer` calls both with the SAME string**, one line apart:
+    /// `getImage(nameOrId: image)` at `ContainerManager.swift:1698` and
+    /// `inspectImage(nameOrId: image)` at `:1701`. `inspectImage` swallows a
+    /// resolution failure with `try?` and returns nil, and the call site takes
+    /// `imageDetails?.id ?? "sha256:" + String(repeating: "0", count: 64)`
+    /// (`:1702`). So narrowing the arm to `getImage` would raise no error -- it
+    /// would silently record an all-zero image ID on every sandbox this engine
+    /// creates.
+    ///
+    /// Task 11's review preferred narrowing, precisely so the Docker-surface
+    /// change would disappear, and asked for this to be traced rather than
+    /// guessed. This test is the trace, and it fails if the arm is narrowed.
+    func testInspectImageResolvesTheDigestFormBecauseTheCreatePathAsksItTo() async throws {
+        let store = try await preparedStore()
+
+        let details = try await store.manager.inspectImage(
+            nameOrId: "workspace@sha256:\(store.hex)"
+        )
+        let found = try XCTUnwrap(
+            details,
+            "inspectImage must resolve the digest form: createContainer passes it the same "
+                + "string it passes getImage, and swallows a nil into an all-zero image ID"
+        )
+        XCTAssertEqual(found.repoTags, ["workspace:latest"])
+        XCTAssertNotEqual(
+            found.id, "sha256:" + String(repeating: "0", count: 64),
+            "the all-zero fallback is what a narrowed arm would record instead"
+        )
+    }
+
+    /// `rmi` by digest reference does not delete a row it did not name.
+    ///
+    /// **This is the destructive consequence the widening introduced**, found by
+    /// Task 11's review and measured there: over a store whose only row was
+    /// `alpha:latest`, `deleteImage("alpha@sha256:<digest>")` untagged
+    /// `alpha:latest` and cleaned up the content behind it. Before the resolver
+    /// arm the same call threw `No such image`, so the widening turned an error
+    /// into an unforced destructive success on the Docker socket.
+    ///
+    /// `deleteImage` deletes by the RESOLVED row's reference
+    /// (`ImageManager.swift:441`), not by the string it was given, which is why
+    /// resolving more inputs makes it delete more things.
+    ///
+    /// The second half is the pair that keeps the refusal honest: a digest
+    /// reference that names an actual stored row still deletes exactly that row,
+    /// and only that row. A guard that refused every digest form would pass the
+    /// first half on its own.
+    func testDeletingByDigestRefusesToRemoveARowItDidNotName() async throws {
+        let store = try await preparedStore()
+
+        do {
+            let removed = try await store.manager.deleteImage(
+                nameOrId: "workspace@sha256:\(store.hex)"
+            )
+            XCTFail("must refuse to untag workspace:latest, removed \(removed)")
+        } catch {
+            XCTAssertTrue(
+                "\(error)".contains("which is a different reference"),
+                "the refusal must say the resolved row was not the one named, got \(error)"
+            )
+        }
+
+        let survived = try await store.manager.inspectImage(nameOrId: "workspace:latest")
+        XCTAssertNotNil(
+            survived, "the tag the caller never typed must still be there after the refusal"
+        )
+
+        // A row that really is named by the digest form deletes normally.
+        let notTheDigest = String(repeating: "c", count: 64)
+        try await store.manager.tagImage(
+            source: "workspace:latest", target: "legacy@sha256:\(notTheDigest)"
+        )
+        _ = try await store.manager.deleteImage(nameOrId: "legacy@sha256:\(notTheDigest)")
+        let deleted = try await store.manager.inspectImage(
+            nameOrId: "legacy@sha256:\(notTheDigest)"
+        )
+        XCTAssertNil(deleted, "a digest reference naming a real row must still delete that row")
+        let untouched = try await store.manager.inspectImage(nameOrId: "workspace:latest")
+        XCTAssertNotNil(untouched, "and must not take the other reference with it")
+    }
+
     // MARK: - The parser the arm is built on
 
     /// `ImageIdentity.exactDigest` recognises the form and nothing near it.

--- a/Tests/ArcaEngineTests/ImageResolutionTests.swift
+++ b/Tests/ArcaEngineTests/ImageResolutionTests.swift
@@ -1,0 +1,264 @@
+import ContainerBridge
+import Foundation
+import Logging
+import XCTest
+@testable import ArcaEngine
+
+/// The store resolves the reference `Create` hands it.
+///
+/// **This is Problem 1, and it is the one part of `Create` that a VM cannot
+/// stand in for.** `ContainerManager.createContainer` uses a single string for
+/// two jobs -- it resolves the image with it (`ContainerManager.swift:1698`) and
+/// records it as `ContainerInfo.image` (`:1901`) -- and `startContainer`
+/// resolves that recorded string again when it rebuilds a container after a
+/// restart (`:2218`). Meanwhile `Inspect` requires the recorded string to be an
+/// exact digest reference, or it answers `invalid_output`
+/// (`SandboxEngineService.swift:196`, `imageDigest(fromReference:)`).
+///
+/// So one string must satisfy three constraints, and the only form that can is
+/// `repository@sha256:<hex>` -- which is exactly the form gascan sends
+/// (`immutable_image_reference`, `crates/gascan-core/src/runtime.rs:677-686`)
+/// and exactly the form the resolver did not accept.
+///
+/// These tests drive `ImageManager` directly rather than through `Create`,
+/// because `createContainer`'s uninitialised-manager guard (`:1659`) throws
+/// before the resolution ever happens: a test that went through `Create` could
+/// not tell a resolver that works from one that is never reached.
+final class ImageResolutionTests: XCTestCase {
+    private let logger = Logger(label: "image-resolution-tests")
+
+    /// The immutable reference resolves, and the tag it is stored under still
+    /// resolves too.
+    ///
+    /// The store holds one row, referenced `workspace:latest` -- a tag. Nothing
+    /// in it is spelt `workspace@sha256:...`, so this cannot pass by an exact
+    /// string match against a stored reference; the digest arm has to actually
+    /// compare the digest.
+    ///
+    /// The tag half is not decoration. It is the whole Docker surface of this
+    /// codebase in one assertion: `docker run nginx:alpine` resolves through
+    /// this same function, and a digest arm written so that it swallowed every
+    /// input would take the tag path away without anything else noticing.
+    func testTheImmutableReferenceGasCanSendsResolvesAndSoDoesTheStoredTag() async throws {
+        let store = try await preparedStore()
+
+        let byDigest = try await store.manager.getImage(
+            nameOrId: "workspace@sha256:\(store.hex)"
+        )
+        XCTAssertEqual(
+            byDigest.reference, "workspace:latest",
+            "the immutable reference must resolve to the row the store really holds"
+        )
+
+        let byTag = try await store.manager.getImage(nameOrId: "workspace:latest")
+        XCTAssertEqual(byTag.reference, "workspace:latest")
+    }
+
+    /// The repository half is compared, not ignored.
+    ///
+    /// A digest arm that resolved on the digest alone would return this store's
+    /// only image for `anything-at-all@sha256:<hex>`, which is a create running
+    /// content under a name the caller did not ask for. The comparison is exact
+    /// and normalizes no registry, the same direction `PrepareImage` chose: a
+    /// false "not found" is visible and recoverable, a false match is neither.
+    func testADigestHeldUnderAnotherRepositoryDoesNotResolve() async throws {
+        let store = try await preparedStore()
+
+        do {
+            let wrong = try await store.manager.getImage(
+                nameOrId: "not-the-workspace@sha256:\(store.hex)"
+            )
+            XCTFail("a foreign repository must not resolve, got \(wrong.reference)")
+        } catch {
+            // `imageNotFound` is what the resolver throws when nothing matches;
+            // any other error would mean the lookup broke rather than declined.
+            XCTAssertTrue(
+                "\(error)".contains("not-the-workspace"),
+                "the refusal must name what was asked for, got \(error)"
+            )
+        }
+    }
+
+    /// And a digest the store does not hold does not resolve under a repository
+    /// it does.
+    ///
+    /// The pair to the test above, on the other axis: together they say the arm
+    /// requires both halves to match rather than either one.
+    func testAnAbsentDigestDoesNotResolveUnderAHeldRepository() async throws {
+        let store = try await preparedStore()
+        let flipped = store.hex.first == "0"
+            ? "1" + store.hex.dropFirst()
+            : "0" + store.hex.dropFirst()
+
+        do {
+            let wrong = try await store.manager.getImage(
+                nameOrId: "workspace@sha256:\(flipped)"
+            )
+            XCTFail("an absent digest must not resolve, got \(wrong.reference)")
+        } catch {
+            XCTAssertTrue(
+                "\(error)".contains(String(flipped)),
+                "the refusal must name what was asked for, got \(error)"
+            )
+        }
+    }
+
+    // MARK: - The additive claim, proved rather than asserted
+
+    /// Every form that resolved before the exact-digest arm existed still
+    /// resolves, and to the same image.
+    ///
+    /// **This is the whole safety argument for touching a resolver shared with
+    /// Arca's Docker surface, so it is a test and not a sentence in a comment.**
+    /// The three arms that were already here -- short ID, long ID and the
+    /// reference matcher -- are each driven against the one row this store holds,
+    /// and each must come back with it.
+    ///
+    /// The short ID is twelve characters because that is the width `resolveImage`
+    /// documents and `^[a-f0-9]{12,64}$` enforces; the long ID carries the
+    /// `sha256:` prefix that is what distinguishes it from the short one.
+    func testEveryFormThatResolvedBeforeStillResolvesToTheSameImage() async throws {
+        let store = try await preparedStore()
+
+        let byTag = try await store.manager.getImage(nameOrId: "workspace:latest")
+        XCTAssertEqual(byTag.reference, "workspace:latest", "the tag arm")
+
+        let byShortID = try await store.manager.getImage(nameOrId: String(store.hex.prefix(12)))
+        XCTAssertEqual(byShortID.reference, "workspace:latest", "the short-ID arm")
+
+        let byLongID = try await store.manager.getImage(nameOrId: "sha256:\(store.hex)")
+        XCTAssertEqual(byLongID.reference, "workspace:latest", "the long-ID arm")
+    }
+
+    /// A store row whose reference literally *is* `repo@sha256:<hex>` still
+    /// resolves by exact string match, through `matchesReference`.
+    ///
+    /// **This is the arm the new one could most easily have taken away**, and the
+    /// fixture is built so that only `matchesReference` can satisfy it: the tag's
+    /// digest half is sixty-four `b`s, which is *not* the digest this store
+    /// records for the image, so the exact-digest arm can match neither half of
+    /// it. Had the new arm been written by making the reference arm unreachable
+    /// for digest-shaped input -- the obvious way to write it -- this fails.
+    ///
+    /// The second half is the pair that makes the first mean something: the same
+    /// row's real digest, under its real repository, resolves through the *new*
+    /// arm. One store answers both ways, so the two arms are shown to coexist
+    /// rather than one having replaced the other.
+    func testAStoredReferenceThatIsItselfADigestReferenceStillResolvesByName() async throws {
+        let store = try await preparedStore()
+        let notTheDigest = String(repeating: "b", count: 64)
+
+        try await store.manager.tagImage(
+            source: "workspace:latest", target: "legacy@sha256:\(notTheDigest)"
+        )
+
+        let byStoredName = try await store.manager.getImage(
+            nameOrId: "legacy@sha256:\(notTheDigest)"
+        )
+        // Asserted on the REFERENCE, not the digest. Both rows carry the same
+        // content and therefore the same digest -- `tagImage` adds a name to
+        // bytes that are already there -- so a digest assertion here would pass
+        // whichever row came back and could not tell which arm answered.
+        XCTAssertEqual(
+            byStoredName.reference, "legacy@sha256:\(notTheDigest)",
+            "a row stored under a digest-shaped reference must still resolve by exact name, "
+                + "through matchesReference, even though that name names a digest the store "
+                + "does not hold"
+        )
+
+        let byRealDigest = try await store.manager.getImage(
+            nameOrId: "workspace@sha256:\(store.hex)"
+        )
+        XCTAssertEqual(
+            byRealDigest.digest, "sha256:\(store.hex)",
+            "and the same store must still answer the new arm"
+        )
+    }
+
+    // MARK: - The parser the arm is built on
+
+    /// `ImageIdentity.exactDigest` recognises the form and nothing near it.
+    ///
+    /// Tested directly, because these refusals are invisible through
+    /// `getImage`: a malformed digest that the parser wrongly accepted would
+    /// engage the exact-digest arm, match no stored digest, and throw "No such
+    /// image" -- which is what a *correctly* refused one does too. The two paths
+    /// are indistinguishable from outside, so the only place the guard can be
+    /// held is here. A mutation that dropped the length check survived the whole
+    /// suite until this existed.
+    ///
+    /// The uppercase row is the one that would bite in practice: the store
+    /// records digests lowercase, so accepting `SHA256` hex would parse a
+    /// reference that then matches nothing, reporting content absent that the
+    /// engine holds.
+    func testTheExactDigestParserRecognisesTheFormAndNothingNearIt() {
+        let hex = String(repeating: "a", count: 64)
+
+        let parsed = ImageIdentity.exactDigest(of: "workspace@sha256:\(hex)")
+        XCTAssertEqual(parsed?.repository, "workspace")
+        XCTAssertEqual(parsed?.digest, "sha256:\(hex)")
+
+        // A tag before the digest names the same repository.
+        XCTAssertEqual(
+            ImageIdentity.exactDigest(of: "workspace:latest@sha256:\(hex)")?.repository,
+            "workspace"
+        )
+        // And a registry port is not a tag.
+        XCTAssertEqual(
+            ImageIdentity.exactDigest(of: "registry.example:5000/repo@sha256:\(hex)")?.repository,
+            "registry.example:5000/repo"
+        )
+
+        XCTAssertNil(ImageIdentity.exactDigest(of: "workspace:latest"), "no digest at all")
+        XCTAssertNil(ImageIdentity.exactDigest(of: "sha256:\(hex)"), "a bare long ID is not one")
+        XCTAssertNil(
+            ImageIdentity.exactDigest(of: "workspace@sha256:\(hex.dropLast())"), "63 characters"
+        )
+        XCTAssertNil(
+            ImageIdentity.exactDigest(of: "workspace@sha256:\(hex)a"), "65 characters"
+        )
+        XCTAssertNil(
+            ImageIdentity.exactDigest(of: "workspace@sha256:\(hex.uppercased())"), "uppercase hex"
+        )
+        XCTAssertNil(
+            ImageIdentity.exactDigest(of: "workspace@sha256:\(String(repeating: "g", count: 64))"),
+            "64 characters that are not hex"
+        )
+        XCTAssertNil(ImageIdentity.exactDigest(of: "@sha256:\(hex)"), "no repository")
+    }
+
+    // MARK: - Fixtures
+
+    private struct PreparedStore {
+        let manager: ImageManager
+        /// Read back from the store: Containerization synthesizes an index for a
+        /// single-manifest layout during import, so the digest the store records
+        /// is not one this test could state in advance.
+        let hex: String
+    }
+
+    private func preparedStore() async throws -> PreparedStore {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("arca-image-resolution-tests-\(UUID().uuidString)")
+        let stateRoot = root.appendingPathComponent("state")
+        _ = try await loadWorkspaceImages(
+            fromOCILayout: try OCILayoutFixture.write(
+                at: root.appendingPathComponent("workspace"),
+                reference: "workspace:latest",
+                payload: "pushed by the consumer, not by startup"
+            ),
+            stateRoot: stateRoot,
+            logger: logger
+        )
+        let manager = try EngineManagers.makeImageManager(
+            paths: EnginePaths(stateRoot: stateRoot), logger: logger
+        )
+        let details = try await manager.inspectImage(nameOrId: "workspace:latest")
+        let digest = try XCTUnwrap(
+            details?.repoDigests.first, "the store must report a digest for the image it loaded"
+        )
+        return PreparedStore(
+            manager: manager, hex: digest.replacingOccurrences(of: "sha256:", with: "")
+        )
+    }
+}

--- a/Tests/ArcaEngineTests/InspectTests.swift
+++ b/Tests/ArcaEngineTests/InspectTests.swift
@@ -1,4 +1,7 @@
+import ContainerBridge
+import Foundation
 import GRPC
+import Logging
 import SandboxEngineProto
 import XCTest
 @testable import ArcaEngine
@@ -34,34 +37,520 @@ final class InspectTests: XCTestCase {
         XCTAssertEqual(sandboxState(fromStatus: "restarting"), .unspecified)
     }
 
-    /// Three arms, not two: "it is not there" and "I could not tell" demand
-    /// opposite behaviour from a reconciler (engine.proto:354-357). This build
-    /// is in the second position and must say so.
+    // MARK: - The sandbox arm
+
+    /// The whole `Sandbox`, asserted as one value.
     ///
-    /// The assertion that matters is the negative one. An earlier version of
-    /// this test asserted `.absent` and passed -- against a service whose
-    /// backing state is empty under every input, so `.absent` was the only
-    /// answer it could produce. It would have passed identically against
-    /// `{ .with { $0.absent = .init() } }` with ContainerBridge deleted, which
-    /// is to say it distinguished nothing. `absent` is the arm a reconciler
-    /// reads as "create it", so answering it without having looked is how a
-    /// running sandbox acquires a duplicate.
+    /// Field by field, an assertion per field passes over a method that fills in
+    /// the two fields the test names and leaves the rest at their proto
+    /// defaults, and every one of those defaults is a lie a reconciler acts on:
+    /// an unset `state` is `UNSPECIFIED`, an unset `owner` is "not gascan's",
+    /// and an empty `ports` is "publishes nothing". Comparing the built message
+    /// against a message written out in full is the only form that fails when a
+    /// field is dropped rather than mis-set.
     ///
-    /// Calls the context-free `inspect(request:)` overload rather than the
-    /// protocol-conforming `inspect(request:context:)`: grpc-swift's
-    /// `GRPCAsyncServerCallContext` has no public initialiser, so a test
-    /// target cannot construct one. See SandboxEngineService.swift.
-    func testInspectRefusesToReportAbsenceItCannotObserve() async throws {
-        let response = await SandboxEngineService.forTesting().inspect(
-            request: Arca_Engine_V1_InspectRequest.with { $0.sandboxID = "absent-a1b2c3d4e5f6" }
+    /// Seeded as `created`, not `exited`, so the expected state is `.creating`
+    /// -- a non-zero enum case. Against `exited` an implementation that never
+    /// assigned `state` at all would still have to be caught by the raw value,
+    /// and `.stopped` is not the proto default either, but `created` also
+    /// exercises the one status `loadPersistedState()` leaves untouched without
+    /// going through crash recovery.
+    func testAnOwnedSandboxRoundTripsWithItsDigestOwnerStateAndPorts() async throws {
+        let managers = try Self.managers()
+        try await Self.seed(
+            into: managers.stateStore,
+            id: Self.ownedContainerID,
+            name: Self.ownedSandboxID,
+            image: Self.workspaceRepository + "@sha256:" + Self.ownedDigestHex,
+            status: "created",
+            labels: SandboxIdentity.labels(from: Self.ownerLabels),
+            portBindings: ["80/tcp": [PortBinding(hostPort: "8080")]]
+        )
+        try await managers.containerManager.loadPersistedState()
+
+        let response = await managers.makeService().inspect(
+            request: Arca_Engine_V1_InspectRequest.with { $0.sandboxID = Self.ownedSandboxID }
         )
 
-        if case .absent = response.outcome {
-            return XCTFail("a build that loads no state must not answer Absent")
+        guard case .sandbox(let sandbox) = response.outcome else {
+            return XCTFail("a seeded, labelled sandbox must answer the sandbox arm: "
+                + "\(String(describing: response.outcome))")
         }
+        XCTAssertEqual(
+            sandbox,
+            Arca_Engine_V1_Sandbox.with {
+                $0.sandboxID = Self.ownedSandboxID
+                $0.image = Arca_Engine_V1_ImageDigest.with {
+                    $0.repository = Self.workspaceRepository
+                    $0.sha256Hex = Self.ownedDigestHex
+                }
+                $0.state = .creating
+                $0.owner = Self.ownerLabels
+                $0.ports = [
+                    Arca_Engine_V1_PortMapping.with {
+                        $0.hostPort = 8080
+                        $0.guestPort = 80
+                    }
+                ]
+            },
+            "every field of the reported sandbox comes from the seeded row"
+        )
+    }
+
+    /// I4, at the seam where it was found: the removed body assigned
+    /// `sandbox.ports = []` unconditionally.
+    ///
+    /// The assertion is the full mapping list, not `count == 1` and not
+    /// `contains`. gascan reads this list as complete
+    /// (crates/gascan-arca/src/translate.rs:353-389) and compares it for port
+    /// drift, so a count is satisfied by one mapping with the two numbers
+    /// transposed -- which is a different published port and a different
+    /// reconciliation.
+    func testASandboxPublishingEightyEightyToEightyReportsThatOneMapping() async throws {
+        let managers = try Self.managers()
+        try await Self.seed(
+            into: managers.stateStore,
+            id: Self.ownedContainerID,
+            name: Self.ownedSandboxID,
+            image: Self.workspaceRepository + "@sha256:" + Self.ownedDigestHex,
+            status: "exited",
+            labels: SandboxIdentity.labels(from: Self.ownerLabels),
+            portBindings: ["80/tcp": [PortBinding(hostPort: "8080")]]
+        )
+        try await managers.containerManager.loadPersistedState()
+
+        let sandbox = try await Self.inspectedSandbox(managers, Self.ownedSandboxID)
+        XCTAssertEqual(
+            sandbox.ports,
+            [
+                Arca_Engine_V1_PortMapping.with {
+                    $0.hostPort = 8080
+                    $0.guestPort = 80
+                }
+            ],
+            "the stored binding 8080->80 is one mapping; an empty list reads as "
+                + "'publishes nothing' and a transposed one reads as a different port"
+        )
+    }
+
+    /// `repeated` is ordered on the wire, and the bindings come out of a
+    /// Dictionary whose iteration order is seeded per process
+    /// (`ContainerManager.swift:959`). Unsorted, two Inspects of one unchanged
+    /// sandbox can report its ports in different orders.
+    ///
+    /// Sorted by guest port, then host port, so both seeds below are pinned by a
+    /// single expected list rather than by a set comparison -- a set comparison
+    /// is exactly the assertion that cannot see the nondeterminism.
+    func testPortsAreReportedInAStableOrderRatherThanDictionaryOrder() async throws {
+        let managers = try Self.managers()
+        try await Self.seed(
+            into: managers.stateStore,
+            id: Self.ownedContainerID,
+            name: Self.ownedSandboxID,
+            image: Self.workspaceRepository + "@sha256:" + Self.ownedDigestHex,
+            status: "exited",
+            labels: SandboxIdentity.labels(from: Self.ownerLabels),
+            portBindings: [
+                "443/tcp": [PortBinding(hostPort: "8443")],
+                "80/tcp": [PortBinding(hostPort: "8080")],
+            ]
+        )
+        try await managers.containerManager.loadPersistedState()
+
+        let sandbox = try await Self.inspectedSandbox(managers, Self.ownedSandboxID)
+        XCTAssertEqual(
+            sandbox.ports,
+            [
+                Arca_Engine_V1_PortMapping.with {
+                    $0.hostPort = 8080
+                    $0.guestPort = 80
+                },
+                Arca_Engine_V1_PortMapping.with {
+                    $0.hostPort = 8443
+                    $0.guestPort = 443
+                },
+            ],
+            "ports must come back in guest-port order every time, not in whatever "
+                + "order this process's Dictionary seed produced"
+        )
+    }
+
+    // MARK: - The foreign arm, and the order that produces it
+
+    /// I5, first half: an unlabelled container is refused, not returned.
+    ///
+    /// Returning a `Sandbox` with no owner -- what the removed body's
+    /// `if let owner` did -- reaches gascan as
+    /// `invalid_output("sandbox {id} carries no owner labels")`
+    /// (crates/gascan-arca/src/translate.rs:412-414), the code reserved for "the
+    /// engine sent me something I cannot interpret". That reports a broken
+    /// engine when the truth is a foreign resource.
+    ///
+    /// The image here is a valid digest reference on purpose: this test must
+    /// fail when the label guard goes, and must NOT depend on which of the two
+    /// guards runs first. The ordering is the next test's job.
+    func testAnUnlabelledContainerIsRefusedAsForeignRatherThanReturnedWithoutAnOwner() async throws {
+        let managers = try Self.managers()
+        try await Self.seed(
+            into: managers.stateStore,
+            id: Self.foreignContainerID,
+            name: Self.foreignSandboxID,
+            image: Self.workspaceRepository + "@sha256:" + Self.foreignDigestHex,
+            status: "exited",
+            labels: [:],
+            portBindings: [:]
+        )
+        try await managers.containerManager.loadPersistedState()
+
+        let response = await managers.makeService().inspect(
+            request: Arca_Engine_V1_InspectRequest.with { $0.sandboxID = Self.foreignSandboxID }
+        )
+
         guard case .error(let error) = response.outcome else {
-            return XCTFail("Inspect must answer: \(String(describing: response.outcome))")
+            return XCTFail("an unlabelled container must be refused, not reported: "
+                + "\(String(describing: response.outcome))")
         }
-        XCTAssertEqual(error.code, "unsupported_capability")
+        XCTAssertEqual(error.code, "foreign_resource_refused")
+        XCTAssertEqual(error.resource, Self.foreignSandboxID)
+        XCTAssertEqual(
+            error.message,
+            "container \(Self.foreignSandboxID) carries no gascan owner labels, so this "
+                + "engine cannot assert it is the sandbox that was asked for"
+        )
+    }
+
+    /// I5, and the reason the label read comes first.
+    ///
+    /// A container this engine did not create is very likely created from a tag,
+    /// and `imageDigest(fromReference:)` refuses a tag. With the digest check in
+    /// front of the label read -- which is what the removed body did -- this
+    /// container answers `invalid_output`, and gascan reads that as a broken
+    /// engine rather than as a name collision with something that is not a
+    /// sandbox.
+    ///
+    /// **This test is the ordering, and nothing else.** It differs from the one
+    /// above only in the image: unlabelled and tagged, so it takes the label arm
+    /// only when the label read runs first. Moving the digest guard back in
+    /// front leaves the previous test green and this one red.
+    func testAContainerFromATagUnderACollidingNameTakesTheForeignArmNotInvalidOutput() async throws {
+        let managers = try Self.managers()
+        try await Self.seed(
+            into: managers.stateStore,
+            id: Self.taggedContainerID,
+            name: Self.taggedSandboxID,
+            image: "ubuntu:latest",
+            status: "exited",
+            labels: [:],
+            portBindings: [:]
+        )
+        try await managers.containerManager.loadPersistedState()
+
+        let response = await managers.makeService().inspect(
+            request: Arca_Engine_V1_InspectRequest.with { $0.sandboxID = Self.taggedSandboxID }
+        )
+
+        guard case .error(let error) = response.outcome else {
+            return XCTFail("a foreign container must be refused, not reported: "
+                + "\(String(describing: response.outcome))")
+        }
+        XCTAssertEqual(
+            error.code, "foreign_resource_refused",
+            "a container with no gascan labels is foreign whatever its image is; "
+                + "invalid_output here would tell the consumer this engine is broken"
+        )
+        XCTAssertEqual(error.resource, Self.taggedSandboxID)
+        XCTAssertEqual(
+            error.message,
+            "container \(Self.taggedSandboxID) carries no gascan owner labels, so this "
+                + "engine cannot assert it is the sandbox that was asked for"
+        )
+    }
+
+    // MARK: - The three arms, told apart
+
+    /// `absent`, proved against a service that demonstrably sees state.
+    ///
+    /// Asserting `.absent` alone is what the version this replaces did, against
+    /// a build whose backing state was empty under every input -- so `.absent`
+    /// was the only answer it could give and the assertion distinguished
+    /// nothing. Here the same service, over the same loaded state, answers all
+    /// three arms in one test: a seeded labelled row is the sandbox arm, a
+    /// seeded unlabelled row is the error arm, and only the id that was never
+    /// seeded is `absent`.
+    ///
+    /// `absent` is the arm a reconciler reads as "create it", so the error and
+    /// absent answers being different messages is the property that keeps a
+    /// running sandbox from acquiring a duplicate.
+    func testAbsentIsAnsweredOnlyForAnIdTheLoadedStateDoesNotHold() async throws {
+        let managers = try Self.managers()
+        try await Self.seed(
+            into: managers.stateStore,
+            id: Self.ownedContainerID,
+            name: Self.ownedSandboxID,
+            image: Self.workspaceRepository + "@sha256:" + Self.ownedDigestHex,
+            status: "exited",
+            labels: SandboxIdentity.labels(from: Self.ownerLabels),
+            portBindings: [:]
+        )
+        try await Self.seed(
+            into: managers.stateStore,
+            id: Self.foreignContainerID,
+            name: Self.foreignSandboxID,
+            image: Self.workspaceRepository + "@sha256:" + Self.foreignDigestHex,
+            status: "exited",
+            labels: [:],
+            portBindings: [:]
+        )
+        try await managers.containerManager.loadPersistedState()
+        let service = managers.makeService()
+
+        let present = await service.inspect(
+            request: Arca_Engine_V1_InspectRequest.with { $0.sandboxID = Self.ownedSandboxID }
+        )
+        guard case .sandbox(let sandbox) = present.outcome else {
+            return XCTFail("this service can see loaded state, or the absent assertion "
+                + "below proves nothing: \(String(describing: present.outcome))")
+        }
+        XCTAssertEqual(sandbox.sandboxID, Self.ownedSandboxID)
+
+        let foreign = await service.inspect(
+            request: Arca_Engine_V1_InspectRequest.with { $0.sandboxID = Self.foreignSandboxID }
+        )
+        guard case .error(let error) = foreign.outcome else {
+            return XCTFail("the error arm must be reachable, or 'absent is not the error "
+                + "arm' is untested: \(String(describing: foreign.outcome))")
+        }
+        XCTAssertEqual(error.code, "foreign_resource_refused")
+
+        let missing = await service.inspect(
+            request: Arca_Engine_V1_InspectRequest.with { $0.sandboxID = Self.absentSandboxID }
+        )
+        guard case .absent = missing.outcome else {
+            return XCTFail("an id the loaded state does not hold is absent, not an error "
+                + "and not a sandbox: \(String(describing: missing.outcome))")
+        }
+    }
+
+    // MARK: - Bindings the contract cannot carry
+
+    /// A stored binding with no host port is refused, not reported as port 0 and
+    /// not dropped.
+    ///
+    /// `docker run -p 80` records `HostPort: ""`, which
+    /// `convertPortBindingsToMappings` parses to a nil `publicPort`. `hostPort =
+    /// 0` fabricates a value the store never held, and gascan rejects it as
+    /// `port 0 is not a mapping` (crates/gascan-arca/src/translate.rs:370-375)
+    /// while blaming the engine's output. Dropping the entry is the other
+    /// fabrication: the list gascan compares for drift would then say this
+    /// sandbox publishes nothing at all.
+    func testAStoredBindingWithNoHostPortIsRefusedRatherThanReportedAsPortZero() async throws {
+        let managers = try Self.managers()
+        try await Self.seed(
+            into: managers.stateStore,
+            id: Self.ownedContainerID,
+            name: Self.ownedSandboxID,
+            image: Self.workspaceRepository + "@sha256:" + Self.ownedDigestHex,
+            status: "exited",
+            labels: SandboxIdentity.labels(from: Self.ownerLabels),
+            portBindings: ["80/tcp": [PortBinding(hostIp: "", hostPort: "")]]
+        )
+        try await managers.containerManager.loadPersistedState()
+
+        let response = await managers.makeService().inspect(
+            request: Arca_Engine_V1_InspectRequest.with { $0.sandboxID = Self.ownedSandboxID }
+        )
+
+        guard case .error(let error) = response.outcome else {
+            return XCTFail("a binding with no host port has no representation and must be "
+                + "refused: \(String(describing: response.outcome))")
+        }
+        XCTAssertEqual(error.code, "invalid_output")
+        XCTAssertEqual(error.resource, Self.ownedSandboxID)
+        XCTAssertEqual(
+            error.message,
+            "port binding <none>:80/tcp is stored with no host port, and the contract "
+                + "has no way to report a binding that has none"
+        )
+    }
+
+    /// A udp binding is refused, not emitted as a tcp publication.
+    ///
+    /// `PortMapping` is two numbers and no protocol field
+    /// (engine.proto:211-217), so a udp binding put on the wire reads as a tcp
+    /// publication that does not exist -- and a tcp and a udp binding on the
+    /// same two numbers arrive as a duplicate gascan rejects outright
+    /// (crates/gascan-arca/src/translate.rs:376-381).
+    func testAUdpBindingIsRefusedRatherThanReportedAsATcpPublication() async throws {
+        let managers = try Self.managers()
+        try await Self.seed(
+            into: managers.stateStore,
+            id: Self.ownedContainerID,
+            name: Self.ownedSandboxID,
+            image: Self.workspaceRepository + "@sha256:" + Self.ownedDigestHex,
+            status: "exited",
+            labels: SandboxIdentity.labels(from: Self.ownerLabels),
+            portBindings: ["53/udp": [PortBinding(hostPort: "5353")]]
+        )
+        try await managers.containerManager.loadPersistedState()
+
+        let response = await managers.makeService().inspect(
+            request: Arca_Engine_V1_InspectRequest.with { $0.sandboxID = Self.ownedSandboxID }
+        )
+
+        guard case .error(let error) = response.outcome else {
+            return XCTFail("a udp binding has no representation and must be refused: "
+                + "\(String(describing: response.outcome))")
+        }
+        XCTAssertEqual(error.code, "invalid_output")
+        XCTAssertEqual(error.resource, Self.ownedSandboxID)
+        XCTAssertEqual(
+            error.message,
+            "port binding 5353:53/udp is not tcp, and the contract's PortMapping "
+                + "carries no protocol field to say otherwise"
+        )
+    }
+
+    /// Three stored numbers that are not ports, none of which may reach the wire.
+    ///
+    /// 70000 and 0 both convert to `UInt32` without complaint, which is why a
+    /// bare `UInt32(exactly:)` is not the guard: 0 arrives at gascan as `port 0
+    /// is not a mapping` and 70000 as `host port 70000 is out of range`
+    /// (crates/gascan-arca/src/translate.rs:358-375), both blaming the engine's
+    /// output. -1 is the one that wraps, to 4294967295, under
+    /// `UInt32(truncatingIfNeeded:)`.
+    ///
+    /// Driven against the helper directly because the three cases differ only in
+    /// one integer; the path from a stored row to this helper is what the two
+    /// tests above prove.
+    func testAPortNumberOutsideOneToSixtyFiveThousandFiveHundredAndThirtyFiveIsRefused() {
+        XCTAssertEqual(
+            sandboxPorts(fromBindings: [PortMapping(privatePort: 70000, publicPort: 8080)]),
+            .failure(UnrepresentablePortBinding(
+                reason: "port binding 8080:70000/tcp names a number that is not a port"
+            ))
+        )
+        XCTAssertEqual(
+            sandboxPorts(fromBindings: [PortMapping(privatePort: 80, publicPort: 0)]),
+            .failure(UnrepresentablePortBinding(
+                reason: "port binding 0:80/tcp names a number that is not a port"
+            ))
+        )
+        XCTAssertEqual(
+            sandboxPorts(fromBindings: [PortMapping(privatePort: -1, publicPort: 8080)]),
+            .failure(UnrepresentablePortBinding(
+                reason: "port binding 8080:-1/tcp names a number that is not a port"
+            ))
+        )
+    }
+
+    // MARK: - Fixtures
+
+    /// Container ids are 64 characters and must not share their first 32:
+    /// `loadPersistedState()` derives the native id from `String(id.prefix(32))`
+    /// and keys `reverseMapping` on it, so a collision makes one seed vanish.
+    private static let ownedContainerID = String(repeating: "a", count: 64)
+    private static let foreignContainerID = String(repeating: "b", count: 64)
+    private static let taggedContainerID = String(repeating: "c", count: 64)
+
+    /// `SandboxIdentity.containerName(forSandboxId:)` is the identity function,
+    /// so these are both the sandbox ids and the seeded container names. Each
+    /// contains a hyphen, which keeps `resolveContainerID` from reading it as a
+    /// hex short id (`ContainerManager.swift:2005-2023`).
+    private static let ownedSandboxID = "web-a1b2c3d4e5f6"
+    private static let foreignSandboxID = "foreign-b1c2d3e4f5a6"
+    private static let taggedSandboxID = "tagged-c1d2e3f4a5b6"
+    private static let absentSandboxID = "missing-d1e2f3a4b5c6"
+
+    private static let workspaceRepository = "ghcr.io/liquescent-development/gascan/workspace"
+    private static let ownedDigestHex = String(repeating: "1", count: 64)
+    private static let foreignDigestHex = String(repeating: "2", count: 64)
+
+    private static let ownerLabels = Arca_Engine_V1_OwnerLabels.with {
+        $0.managedBy = "gascan"
+        $0.sandboxID = ownedSandboxID
+    }
+
+    /// The engine's own managers over a throwaway state root -- the production
+    /// factory, so what these tests inspect is what `arca-engine` serves.
+    ///
+    /// `wireCollaborators()` is deliberately not called: `Inspect` reads no
+    /// field these tests assert on that needs either collaborator, and leaving
+    /// them unset keeps this fixture free of `NetworkManager`. What the network
+    /// collaborator costs when unset is asserted in `EngineManagerWiringTests`.
+    private static func managers() throws -> EngineManagers {
+        try EngineManagers(
+            stateRoot: URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("arca-inspect-tests-\(UUID().uuidString)"),
+            kernelPath: URL(fileURLWithPath: "/opt/arca/vmlinux"),
+            logLevel: "info",
+            logger: Logger(label: "arca-engine-tests")
+        )
+    }
+
+    /// One container row, through `StateStore` and then `loadPersistedState()`
+    /// -- the restore path the engine itself runs -- rather than through a
+    /// double. `initialize()` is the normal caller and constructs a real
+    /// `VmnetNetwork`, which no test in this target may do.
+    ///
+    /// Labels ride in the config JSON and bindings in the host config JSON,
+    /// because those are the two columns the restore path decodes them out of
+    /// (`ContainerManager.swift:329-344`).
+    private static func seed(
+        into store: StateStore,
+        id: String,
+        name: String,
+        image: String,
+        status: String,
+        labels: [String: String],
+        portBindings: [String: [PortBinding]]
+    ) async throws {
+        let encoder = JSONEncoder()
+        try await store.saveContainer(
+            id: id,
+            name: name,
+            image: image,
+            imageID: "sha256:probe",
+            createdAt: Date(),
+            status: status,
+            running: false,
+            paused: false,
+            restarting: false,
+            pid: 0,
+            exitCode: 0,
+            startedAt: nil,
+            finishedAt: Date(),
+            stoppedByUser: false,
+            entrypoint: nil,
+            configJSON: String(
+                decoding: try encoder.encode(
+                    ContainerConfiguration(image: image, labels: labels)
+                ),
+                as: UTF8.self
+            ),
+            hostConfigJSON: String(
+                decoding: try encoder.encode(HostConfig(portBindings: portBindings)),
+                as: UTF8.self
+            )
+        )
+    }
+
+    /// The sandbox arm, or a failure naming the arm that came back instead.
+    private static func inspectedSandbox(
+        _ managers: EngineManagers,
+        _ sandboxID: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws -> Arca_Engine_V1_Sandbox {
+        let response = await managers.makeService().inspect(
+            request: Arca_Engine_V1_InspectRequest.with { $0.sandboxID = sandboxID }
+        )
+        guard case .sandbox(let sandbox) = response.outcome else {
+            XCTFail(
+                "expected the sandbox arm: \(String(describing: response.outcome))",
+                file: file, line: line
+            )
+            throw XCTSkip("no sandbox arm to assert on")
+        }
+        return sandbox
     }
 }

--- a/Tests/ArcaEngineTests/InspectTests.swift
+++ b/Tests/ArcaEngineTests/InspectTests.swift
@@ -106,6 +106,18 @@ final class InspectTests: XCTestCase {
     /// drift, so a count is satisfied by one mapping with the two numbers
     /// transposed -- which is a different published port and a different
     /// reconciliation.
+    ///
+    /// The `state` assertion is not decoration and does not belong to the ports
+    /// finding. It is the SECOND status this file pins: the round-trip test
+    /// above seeds `created` and expects `.creating`, this row seeds `exited`
+    /// and expects `.stopped`. One asserted status is satisfied by a hardcoded
+    /// constant -- MEASURED, `sandbox.state = .creating` in place of the
+    /// `sandboxState(fromStatus:)` call left `Executed 71 tests, with 0
+    /// failures`, so nothing proved the call site called it. Two statuses
+    /// mapping to two cases cannot be met by any constant. The consumer
+    /// switches on this field directly
+    /// (crates/gascan-arca/src/translate.rs:399-409), so a wrong case sends a
+    /// reconciler at the wrong action.
     func testASandboxPublishingEightyEightyToEightyReportsThatOneMapping() async throws {
         let managers = try Self.managers()
         try await Self.seed(
@@ -131,6 +143,11 @@ final class InspectTests: XCTestCase {
             "the stored binding 8080->80 is one mapping; an empty list reads as "
                 + "'publishes nothing' and a transposed one reads as a different port"
         )
+        XCTAssertEqual(
+            sandbox.state, .stopped,
+            "this row is seeded exited, and the round-trip test seeds created; a "
+                + "hardcoded state satisfies one of the two and cannot satisfy both"
+        )
     }
 
     /// `repeated` is ordered on the wire, and the bindings come out of a
@@ -138,9 +155,19 @@ final class InspectTests: XCTestCase {
     /// (`ContainerManager.swift:959`). Unsorted, two Inspects of one unchanged
     /// sandbox can report its ports in different orders.
     ///
-    /// Sorted by guest port, then host port, so both seeds below are pinned by a
-    /// single expected list rather than by a set comparison -- a set comparison
-    /// is exactly the assertion that cannot see the nondeterminism.
+    /// **Six bindings, not two, and the count is the guard.** A random order
+    /// matches the sorted one with probability 1/N!, so a two-binding fixture
+    /// catches a missing sort only about half the time. MEASURED with the sort
+    /// removed, `swift test --filter …/testPortsAreReportedInAStableOrder…`:
+    /// two bindings gave **3 RED / 10 runs**, six bindings gave **10 RED / 10**.
+    /// With the sort restored, six bindings gave **10 GREEN / 10**. The earlier
+    /// two-binding form of this test was a guard that missed 70% of the time.
+    ///
+    /// The host ports deliberately do not ascend with the guest ports
+    /// (62222, 8080, 8443, 13000, 25432, 19090 against 22, 80, 443, 3000, 5432,
+    /// 9090), so a sort keyed on the host port produces a different list and
+    /// fails. Sorting by `(guestPort, hostPort)` is the ordering asserted, not
+    /// merely "some deterministic ordering".
     func testPortsAreReportedInAStableOrderRatherThanDictionaryOrder() async throws {
         let managers = try Self.managers()
         try await Self.seed(
@@ -151,8 +178,12 @@ final class InspectTests: XCTestCase {
             status: "exited",
             labels: SandboxIdentity.labels(from: Self.ownerLabels),
             portBindings: [
-                "443/tcp": [PortBinding(hostPort: "8443")],
+                "5432/tcp": [PortBinding(hostPort: "25432")],
                 "80/tcp": [PortBinding(hostPort: "8080")],
+                "9090/tcp": [PortBinding(hostPort: "19090")],
+                "22/tcp": [PortBinding(hostPort: "62222")],
+                "443/tcp": [PortBinding(hostPort: "8443")],
+                "3000/tcp": [PortBinding(hostPort: "13000")],
             ]
         )
         try await managers.containerManager.loadPersistedState()
@@ -162,12 +193,28 @@ final class InspectTests: XCTestCase {
             sandbox.ports,
             [
                 Arca_Engine_V1_PortMapping.with {
+                    $0.hostPort = 62222
+                    $0.guestPort = 22
+                },
+                Arca_Engine_V1_PortMapping.with {
                     $0.hostPort = 8080
                     $0.guestPort = 80
                 },
                 Arca_Engine_V1_PortMapping.with {
                     $0.hostPort = 8443
                     $0.guestPort = 443
+                },
+                Arca_Engine_V1_PortMapping.with {
+                    $0.hostPort = 13000
+                    $0.guestPort = 3000
+                },
+                Arca_Engine_V1_PortMapping.with {
+                    $0.hostPort = 25432
+                    $0.guestPort = 5432
+                },
+                Arca_Engine_V1_PortMapping.with {
+                    $0.hostPort = 19090
+                    $0.guestPort = 9090
                 },
             ],
             "ports must come back in guest-port order every time, not in whatever "
@@ -263,6 +310,66 @@ final class InspectTests: XCTestCase {
             error.message,
             "container \(Self.taggedSandboxID) carries no gascan owner labels, so this "
                 + "engine cannot assert it is the sandbox that was asked for"
+        )
+    }
+
+    /// I5's other half: the labels that ARE present are echoed, not invented.
+    ///
+    /// The brief's ruling is "labels present -> return the Sandbox with them and
+    /// let the consumer judge", and `inspect`'s doc comment states it as a
+    /// behavioural claim. Nothing pinned it: every other fixture reaching the
+    /// sandbox arm carries `gascan` / `ownedSandboxID` and is inspected under
+    /// `ownedSandboxID`, so stored labels and labels fabricated from the request
+    /// were indistinguishable. MEASURED -- replacing the echo with
+    /// `managedBy = "gascan"; sandboxID = sandboxId` left `Executed 71 tests,
+    /// with 0 failures`.
+    ///
+    /// What that fabrication costs is worse than either finding this task fixed.
+    /// A container labelled for sandbox B, inspected as sandbox A, would report
+    /// `owner.sandbox_id = A`; the consumer's `sandbox_id != id` check
+    /// (crates/gascan-arca/src/translate.rs:421-425) never fires, and it adopts
+    /// and reconciles another sandbox's container.
+    ///
+    /// **Both label fields differ from any plausible fabrication, deliberately.**
+    /// `managed_by` is a tool this engine has never heard of, because the
+    /// contract says the engine stores labels verbatim and NEVER INTERPRETS THEM
+    /// (engine.proto:143-148) -- and because the consumer classifies a
+    /// `managed_by` that is not `gascan` as `Foreign` on its own
+    /// (crates/gascan-core/src/runtime.rs:100). An engine that hardcoded
+    /// `"gascan"` would report another tool's container as gascan's and delete
+    /// that classification before the consumer could make it.
+    ///
+    /// The two ids asserted here are `web-a1b2c3d4e5f6` (the envelope, which is
+    /// the REQUEST's) and `other-e1f2a3b4c5d6` (the label, which is the STORE's).
+    /// Neither is a substring of the other, and the test's whole point is that
+    /// they must not be equal.
+    func testAContainerLabelledForAnotherSandboxIsReturnedWithTheLabelsTheStoreHolds() async throws {
+        let managers = try Self.managers()
+        try await Self.seed(
+            into: managers.stateStore,
+            id: Self.mismatchedContainerID,
+            // The NAME is the sandbox id that will be asked for; the LABEL below
+            // names a different one. That is the collision under test.
+            name: Self.ownedSandboxID,
+            image: Self.workspaceRepository + "@sha256:" + Self.ownedDigestHex,
+            status: "exited",
+            labels: SandboxIdentity.labels(from: Self.mismatchedOwnerLabels),
+            portBindings: [:]
+        )
+        try await managers.containerManager.loadPersistedState()
+
+        let sandbox = try await Self.inspectedSandbox(managers, Self.ownedSandboxID)
+        XCTAssertEqual(
+            sandbox.owner, Self.mismatchedOwnerLabels,
+            "the owner must be the labels the store holds, verbatim; labels built "
+                + "from the request would make an ownership mismatch invisible to "
+                + "the only component allowed to judge it"
+        )
+        XCTAssertEqual(
+            sandbox.sandboxID, Self.ownedSandboxID,
+            "the envelope still answers the id that was asked for -- it is the "
+                + "owner labels that disagree with it, and that disagreement is "
+                + "the whole signal the consumer acts on"
         )
     }
 
@@ -451,6 +558,7 @@ final class InspectTests: XCTestCase {
     private static let ownedContainerID = String(repeating: "a", count: 64)
     private static let foreignContainerID = String(repeating: "b", count: 64)
     private static let taggedContainerID = String(repeating: "c", count: 64)
+    private static let mismatchedContainerID = String(repeating: "d", count: 64)
 
     /// `SandboxIdentity.containerName(forSandboxId:)` is the identity function,
     /// so these are both the sandbox ids and the seeded container names. Each
@@ -468,6 +576,14 @@ final class InspectTests: XCTestCase {
     private static let ownerLabels = Arca_Engine_V1_OwnerLabels.with {
         $0.managedBy = "gascan"
         $0.sandboxID = ownedSandboxID
+    }
+
+    /// Labels that agree with nothing the engine could invent: a `managed_by`
+    /// this engine has never heard of, and a `sandbox_id` naming a sandbox other
+    /// than the one the request asks for.
+    private static let mismatchedOwnerLabels = Arca_Engine_V1_OwnerLabels.with {
+        $0.managedBy = "another-tool"
+        $0.sandboxID = "other-e1f2a3b4c5d6"
     }
 
     /// The engine's own managers over a throwaway state root -- the production

--- a/Tests/ArcaEngineTests/LayerCacheRoleTests.swift
+++ b/Tests/ArcaEngineTests/LayerCacheRoleTests.swift
@@ -1,0 +1,122 @@
+import Containerization
+import ContainerizationEXT4
+import Foundation
+import SystemPackage
+import XCTest
+
+/// That an ext4 image formatted before roles existed is not mistaken for one that carries a
+/// role.
+///
+/// **This is the shape of a defect that shipped, and the reason it is worth a test of its
+/// own.** `ca47c87` made the guest classify virtio-blk devices by the role in their ext4
+/// volume label, and `OverlayFSUnpacker` writes that label only where it FORMATS a layer --
+/// which happens only on a cache miss. Every `layer.ext4` written before the label existed
+/// therefore came back from the cache-hit branch unlabelled, reached the guest, and was
+/// dropped by the classifier with `is not an Arca role, leaving it alone`: a rootfs built from
+/// a subset of its own image, or from none of it, with no error on either side.
+///
+/// **What makes it silent is that a stale image is not broken.** It is a valid ext4
+/// filesystem, so nothing throws, nothing is corrupt, and no existing check has any reason to
+/// object. The only thing wrong with it is an absence, and an absence is exactly what a
+/// classifier that trusts the cache never looks for.
+///
+/// So the fix is a positive test for the role on every cache hit
+/// (`OverlayFSUnpacker.unpackLayerToCache`), and these are the two answers that decision rests
+/// on, driven against real formatted images rather than against a fixture that stands in for
+/// one.
+final class LayerCacheRoleTests: XCTestCase {
+    private var scratch: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        scratch = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("arca-layer-cache-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let scratch { try? FileManager.default.removeItem(at: scratch) }
+        try super.tearDownWithError()
+    }
+
+    /// Formats an ext4 image, with `label` or without one, and returns its path.
+    ///
+    /// `volumeLabel: nil` is the **exact** pre-change call, not an imitation of it: the
+    /// parameter was added by the same commit that introduced roles, so omitting it reproduces
+    /// what every cached layer on disk before that commit actually is.
+    private func image(named name: String, label: String?) throws -> FilePath {
+        let path = FilePath(scratch.appendingPathComponent(name).path)
+        let formatter = try EXT4.Formatter(path, minDiskSize: 2 * 1024 * 1024, volumeLabel: label)
+        try formatter.close()
+        return path
+    }
+
+    /// The load-bearing half: an unlabelled image must not answer with a role.
+    ///
+    /// It is asserted through `role(ofImageAt:)` rather than through the raw label because
+    /// that is the function the cache-hit branch calls, and a test of the label alone would
+    /// leave the mapping from "no label" to "not a layer" unpinned -- which is where the
+    /// silence came from.
+    func testAnImageFormattedWithoutALabelHasNoRole() throws {
+        let stale = try image(named: "stale.ext4", label: nil)
+
+        XCTAssertNil(
+            try EXT4.volumeLabel(ofBlockDevice: stale),
+            "an image formatted with no volumeLabel must carry no label"
+        )
+        XCTAssertNil(
+            ArcaBlockDeviceRole.role(ofImageAt: stale),
+            "an unlabelled layer image must not be accepted as a role-carrying one; "
+                + "accepting it is what let the guest drop a layer silently"
+        )
+    }
+
+    /// The control, and it is not optional.
+    ///
+    /// Without it `role(ofImageAt:)` returning `nil` for everything would pass the assertion
+    /// above -- the one-sided-assertion shape this project has shipped before. This pins that
+    /// the function can say yes, and to the right role.
+    func testAnImageFormattedForALayerReportsThatRole() throws {
+        let fresh = try image(
+            named: "fresh.ext4",
+            label: ArcaBlockDeviceRole.overlayLayer.volumeLabel
+        )
+
+        XCTAssertEqual(
+            ArcaBlockDeviceRole.role(ofImageAt: fresh),
+            .overlayLayer,
+            "an image formatted for the layer role must report it"
+        )
+    }
+
+    /// A role the caller did not ask about must not be mistaken for the one it did.
+    ///
+    /// The cache-hit branch tests `== .overlayLayer` rather than "has some role", and this is
+    /// what makes that specific. A writable image in a layer's cache slot is a wrong rootfs,
+    /// not a usable layer.
+    func testTheWritableRoleIsNotMistakenForALayer() throws {
+        let writable = try image(
+            named: "writable.ext4",
+            label: ArcaBlockDeviceRole.overlayWritable.volumeLabel
+        )
+
+        XCTAssertEqual(ArcaBlockDeviceRole.role(ofImageAt: writable), .overlayWritable)
+        XCTAssertNotEqual(
+            ArcaBlockDeviceRole.role(ofImageAt: writable),
+            .overlayLayer,
+            "the cache-hit check accepts only .overlayLayer, and this is why it must"
+        )
+    }
+
+    /// A path holding no filesystem at all answers `nil` rather than throwing.
+    ///
+    /// The caller is classifying, not validating: it has to reach "reformat this" from a
+    /// truncated or garbage file the same way it reaches it from an unlabelled one. A throw
+    /// here would propagate out of an image unpack instead.
+    func testAPathThatIsNotAFilesystemHasNoRole() throws {
+        let garbage = scratch.appendingPathComponent("garbage.ext4")
+        try Data(repeating: 0x5A, count: 8192).write(to: garbage)
+
+        XCTAssertNil(ArcaBlockDeviceRole.role(ofImageAt: FilePath(garbage.path)))
+    }
+}

--- a/Tests/ArcaEngineTests/LayerCacheRoleTests.swift
+++ b/Tests/ArcaEngineTests/LayerCacheRoleTests.swift
@@ -108,6 +108,66 @@ final class LayerCacheRoleTests: XCTestCase {
         )
     }
 
+    /// The decision the cache actually makes, over a real cache layout.
+    ///
+    /// **The three tests above pin the PREDICATE, and a reviewer showed that is not the same
+    /// thing.** Bypassing the check at its call site -- `if true || cachedRole == .overlayLayer`,
+    /// which is the pre-fix behaviour exactly -- left `swift test --filter ArcaEngineTests` at
+    /// 155 passing. `OverlayFSUnpacker.cachedLayerIsReusable` exists so that the decision has a
+    /// name a test can reach; this drives it over `{cache}/{digest}/layer.ext4` rather than over
+    /// a bare temp file, so the fixture is the shape the unpacker meets.
+    func testAStaleCacheEntryIsNotReusableAndAFreshOneIs() throws {
+        let cache = scratch.appendingPathComponent("layers")
+        let stale = try cachedLayer(in: cache, digest: "sha256:stale", label: nil)
+        let fresh = try cachedLayer(
+            in: cache,
+            digest: "sha256:fresh",
+            label: ArcaBlockDeviceRole.overlayLayer.volumeLabel
+        )
+
+        XCTAssertTrue(OverlayFSUnpacker.cachedLayerExists(at: stale))
+        XCTAssertFalse(
+            OverlayFSUnpacker.cachedLayerIsReusable(at: stale),
+            "a cache entry written before role labels existed must be reformatted, not reused"
+        )
+        XCTAssertTrue(
+            OverlayFSUnpacker.cachedLayerIsReusable(at: fresh),
+            "a labelled entry must still be a hit; without this the check would reformat forever"
+        )
+    }
+
+    /// Discarding an entry twice is not an error, and a failure that is not "already gone" is.
+    ///
+    /// The unpacker is re-entrant across `await` and two `Create`s can share a layer digest, so
+    /// both can reach the discard. The loser must not fail the RPC over work the winner already
+    /// did -- but nothing else may be swallowed, because an entry that survives is handed to the
+    /// guest unlabelled, which is the defect this whole change exists to prevent.
+    func testDiscardingAnAlreadyDiscardedEntryIsNotAnError() throws {
+        let cache = scratch.appendingPathComponent("layers")
+        let entry = try cachedLayer(in: cache, digest: "sha256:raced", label: nil)
+
+        XCTAssertNoThrow(try OverlayFSUnpacker.discardCachedLayer(at: entry))
+        XCTAssertFalse(OverlayFSUnpacker.cachedLayerExists(at: entry))
+        XCTAssertNoThrow(
+            try OverlayFSUnpacker.discardCachedLayer(at: entry),
+            "a second discard races the first and must be the outcome it wanted, not a failure"
+        )
+    }
+
+    /// `{cache}/{digest}/layer.ext4`, which is the layout `unpackLayerToCache` builds.
+    private func cachedLayer(in cache: URL, digest: String, label: String?) throws -> URL {
+        let directory = cache.appendingPathComponent(digest)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let path = directory.appendingPathComponent("layer.ext4")
+        let formatter = try EXT4.Formatter(
+            FilePath(path.path),
+            minDiskSize: 2 * 1024 * 1024,
+            volumeLabel: label
+        )
+        try formatter.close()
+        return path
+    }
+
     /// A path holding no filesystem at all answers `nil` rather than throwing.
     ///
     /// The caller is classifying, not validating: it has to reach "reformat this" from a

--- a/Tests/ArcaEngineTests/LifecycleTests.swift
+++ b/Tests/ArcaEngineTests/LifecycleTests.swift
@@ -1,0 +1,667 @@
+import ContainerBridge
+import Foundation
+import Logging
+import SandboxEngineProto
+import XCTest
+@testable import ArcaEngine
+
+/// `Start`, `Stop` and `Remove` driven through the engine's own managers.
+///
+/// **What is reachable without a VM, established before these tests were
+/// written rather than assumed while writing them. Each claim below names the
+/// test that holds it, so none of them is only prose:**
+///
+/// - **`startContainer` is NOT.** It resolves the name at
+///   `ContainerManager.swift:2071` and then guards on `nativeManager` at
+///   `:2080`, which is assigned only inside an `initialize()` that constructs a
+///   live `Containerization.VmnetNetwork`. So **nothing here proves a sandbox
+///   starts**, and the one test that drives `Start` all the way to the call says
+///   so in its own name and asserts the `notInitialized` it stops at. Proving a
+///   start is Task 13's live tier.
+/// - **`stopContainer` IS**, for a container that is `created`, `exited` or
+///   `dead`: it returns without acting (`:2701-2707`). So `Stop`'s success arm
+///   is a real success over production code --
+///   `testStopOfAnOwnedSandboxSucceedsAndLeavesTheContainerInPlace` -- and every
+///   refusal below it is a refusal of something that would otherwise have been
+///   `Ack`ed.
+/// - **`removeContainer` IS**, in full, for a container with no native object --
+///   which is every container `loadPersistedState()` restores. It takes the
+///   database-only branch at `:3050`, clears the store, and calls
+///   `cleanupVolumesForContainer` (`:3170`). So `Remove` is measured end to end
+///   here, deletion included and asserted on the host.
+/// - **A container in state `running` is NOT reachable at all.**
+///   `loadPersistedState()` recovers every persisted `running` row as exited 137
+///   before anything can read it (`:371-393`) -- which is exactly what
+///   `CrashRecoveryTests` pins -- and only `startContainer` sets the state
+///   otherwise. So `removeContainer`'s `containerRunning` refusal
+///   (`:3011-3013`) has no VM-free fixture, is not asserted here, and belongs to
+///   Task 13. Seeding a row as `running` does **not** produce one: it produces an
+///   exited container, and a test written that way would prove nothing while
+///   reading as though it proved the refusal.
+///
+/// Every fixture is seeded through `StateStore` and `loadPersistedState()`, the
+/// restore path the engine itself runs, and never through a double.
+final class LifecycleTests: XCTestCase {
+
+    // MARK: - Start
+
+    /// `Start` will not boot a container it cannot establish is gascan's.
+    ///
+    /// Container names are a flat namespace this engine does not own, so a
+    /// sandbox id can resolve to something the consumer never created. `Inspect`
+    /// declines to *report* such a container as the sandbox; this declines to
+    /// *run* it, which is the same refusal over a much larger consequence -- a VM
+    /// the consumer did not ask for, running work it cannot see.
+    ///
+    /// The code is asserted, not just the failure arm: `foreign_resource_refused`
+    /// tells the consumer something else holds the name, while the `not_found`
+    /// one refusal up tells it to create a sandbox. Answering the second here
+    /// would have a reconciler create a duplicate.
+    func testStartRefusesAnUnlabelledContainerRatherThanBootingIt() async throws {
+        let managers = try Self.managers()
+        try await Self.seed(
+            into: managers.stateStore, id: Self.ownedContainerID,
+            name: Self.sandboxID, status: "created", labels: [:]
+        )
+        try await managers.containerManager.loadPersistedState()
+
+        let response = await managers.makeService().start(
+            request: Arca_Engine_V1_StartRequest.with { $0.sandboxID = Self.sandboxID }
+        )
+        Self.assertRefused(
+            response, code: .foreignResourceRefused, resource: Self.sandboxID,
+            "an unlabelled container under the sandbox's name is not the sandbox"
+        )
+    }
+
+    /// A sandbox the engine does not hold is `not_found`, which is what has a
+    /// reconciler create it. `command_failed` would have it retry forever.
+    func testStartOfASandboxTheEngineDoesNotHoldIsNotFound() async throws {
+        let managers = try Self.managers()
+        let response = await managers.makeService().start(
+            request: Arca_Engine_V1_StartRequest.with { $0.sandboxID = Self.sandboxID }
+        )
+        Self.assertRefused(
+            response, code: .notFound, resource: Self.sandboxID,
+            "nothing is seeded, so the engine holds no such container"
+        )
+    }
+
+    /// **This test does NOT prove a sandbox starts, and is named so it cannot be
+    /// read as if it does.**
+    ///
+    /// What it proves is that an owned, correctly named container passes all
+    /// three gates and that `startContainer` is really called -- the failure it
+    /// asserts on is `nativeManager`'s, raised *inside* the call, and no gate in
+    /// this method can produce it. A `start` that returned early for any reason
+    /// would answer one of the other three codes instead.
+    ///
+    /// The message is asserted as well as the code because `command_failed` is
+    /// also what a broken call would answer; "not initialized" is the specific
+    /// thing that says the call happened and stopped at the VM.
+    func testStartOfAnOwnedSandboxReachesStartContainerAndStopsOnlyForWantOfAVM() async throws {
+        let managers = try Self.managers()
+        try await Self.seed(
+            into: managers.stateStore, id: Self.ownedContainerID,
+            name: Self.sandboxID, status: "created", labels: Self.ownedLabels
+        )
+        try await managers.containerManager.loadPersistedState()
+
+        let response = await managers.makeService().start(
+            request: Arca_Engine_V1_StartRequest.with { $0.sandboxID = Self.sandboxID }
+        )
+        guard case .error(let error) = response.outcome else {
+            return XCTFail("no VM is reachable here, so this cannot succeed: "
+                + "\(String(describing: response.outcome))")
+        }
+        XCTAssertEqual(error.code, EngineErrorCode.commandFailed.rawValue)
+        XCTAssertEqual(error.resource, Self.sandboxID)
+        XCTAssertTrue(
+            error.message.contains("not initialized"),
+            "the gates must have passed and startContainer must have been entered; "
+                + "its nativeManager guard is the only thing that can say this. Got: "
+                + error.message
+        )
+    }
+
+    // MARK: - Stop
+
+    /// The one lifecycle success this target can measure, and it is a real one:
+    /// `stopContainer` returns without acting for a container that is already
+    /// `created`, so `Stop` completes over production code.
+    ///
+    /// The container is asserted still present afterwards, which is not
+    /// decoration: `Stop` and `Remove` are one line apart in this file and both
+    /// answer `Ack`, so an implementation that stopped by removing would pass any
+    /// test that only checked the outcome arm.
+    func testStopOfAnOwnedSandboxSucceedsAndLeavesTheContainerInPlace() async throws {
+        let managers = try Self.managers()
+        try await Self.seed(
+            into: managers.stateStore, id: Self.ownedContainerID,
+            name: Self.sandboxID, status: "created", labels: Self.ownedLabels
+        )
+        try await managers.containerManager.loadPersistedState()
+
+        let response = await managers.makeService().stop(
+            request: Arca_Engine_V1_StopRequest.with { $0.sandboxID = Self.sandboxID }
+        )
+        guard case .ok = response.outcome else {
+            return XCTFail("stopping an already-created container is a no-op that succeeds: "
+                + "\(String(describing: response.outcome))")
+        }
+        let after = try await managers.containerManager.getContainer(id: Self.sandboxID)
+        XCTAssertNotNil(after, "Stop must not remove the container it stopped")
+    }
+
+    /// The refusal, measured against what the engine would otherwise have done.
+    ///
+    /// This fixture is the success test's fixture with the labels taken off, and
+    /// that is what makes it sharp: without the ownership gate `stopContainer`
+    /// runs, returns its idempotent no-op, and the engine answers `Ack` for a
+    /// container it has no reason to believe is the caller's. The two outcomes
+    /// differ by the gate alone.
+    func testStopRefusesAnUnlabelledContainerItWouldOtherwiseHaveAcked() async throws {
+        let managers = try Self.managers()
+        try await Self.seed(
+            into: managers.stateStore, id: Self.ownedContainerID,
+            name: Self.sandboxID, status: "created", labels: [:]
+        )
+        try await managers.containerManager.loadPersistedState()
+
+        let response = await managers.makeService().stop(
+            request: Arca_Engine_V1_StopRequest.with { $0.sandboxID = Self.sandboxID }
+        )
+        Self.assertRefused(
+            response, code: .foreignResourceRefused, resource: Self.sandboxID,
+            "an unlabelled container is not the sandbox, and stopping it would Ack"
+        )
+    }
+
+    /// **The resolver hazard, on the read-modify verb.**
+    ///
+    /// `resolveContainerID` prefix-matches any pure-hex name of four or more
+    /// characters against Docker ids *before* it tries the name lookup
+    /// (`ContainerManager.swift:2005-2023`). The container seeded here is named
+    /// `unrelated-container` and has nothing to do with the request; only its
+    /// Docker id happens to begin `beef`.
+    ///
+    /// Without the gate the engine resolves `beef` to it and answers `Ack` for
+    /// having stopped a sandbox it never touched. With the gate the request never
+    /// reaches the resolver.
+    func testStopRefusesAHexSandboxIdItWouldOtherwiseHaveAckedForAnUnrelatedContainer() async throws {
+        let managers = try Self.managers()
+        try await Self.seed(
+            into: managers.stateStore, id: Self.hexPrefixedContainerID,
+            name: Self.unrelatedContainerName, status: "created", labels: Self.ownedLabels
+        )
+        try await managers.containerManager.loadPersistedState()
+
+        let response = await managers.makeService().stop(
+            request: Arca_Engine_V1_StopRequest.with { $0.sandboxID = "beef" }
+        )
+        Self.assertRefused(
+            response, code: .invalidResourceIdentity, resource: "beef",
+            "a pure-hex sandbox id is a Docker id prefix to the resolver, and a gascan "
+                + "sandbox id always contains a hyphen"
+        )
+    }
+
+    // MARK: - Remove
+
+    /// **The resolver hazard, on the verb that destroys.**
+    ///
+    /// MEASURED with `containerNameRefusal`'s call deleted from `removableKind`:
+    /// `swift test --filter ArcaEngineTests` reports this test as its only
+    /// failure, and it fails on the survival assertion below -- the engine
+    /// resolved `beef` to the Docker id `beef111…`, found a container it was
+    /// authorised to delete, and deleted it. That is the whole reason Task 7's
+    /// Minor 4 was routed to this task: harmless while every method was
+    /// read-only, and a deletion the moment one was not.
+    ///
+    /// The container's labels are the caller's own, deliberately, so that the
+    /// ownership gate cannot be what saves it -- without the identity gate this
+    /// request is authorised and the deletion goes through.
+    ///
+    /// The second assertion is the one that matters. A refusal that arrived after
+    /// the deletion would satisfy the first.
+    func testARemoveNamingAHexPrefixRefusesAndDeletesNothing() async throws {
+        let managers = try Self.managers()
+        try await Self.seed(
+            into: managers.stateStore, id: Self.hexPrefixedContainerID,
+            name: Self.unrelatedContainerName, status: "exited", labels: Self.ownedLabels
+        )
+        await managers.wireCollaborators()
+        try await managers.containerManager.loadPersistedState()
+
+        let response = await managers.makeService().remove(
+            request: Self.removeRequest([(.container, "beef")])
+        )
+        Self.assertRefused(
+            response, code: .invalidResourceIdentity, resource: "beef",
+            "a pure-hex resource name is a Docker id prefix to the resolver"
+        )
+        let survivor = try await managers.containerManager.getContainer(
+            id: Self.unrelatedContainerName
+        )
+        XCTAssertNotNil(
+            survivor,
+            "the unrelated container must still be on the host; measured without this "
+                + "gate, `removeContainer(id: \"beef\")` deleted it"
+        )
+    }
+
+    /// A container, the volume it mounts and its network, deleted in one call --
+    /// and the request lists them in the order that cannot work.
+    ///
+    /// **The wire order is volume, network, container on purpose.**
+    /// `deleteVolume` refuses a volume a container still mounts
+    /// (`VolumeManager.swift:317-327`, `VolumeError.inUse`), and the
+    /// `volume_mounts` row that makes it "in use" is cleared by CASCADE when the
+    /// container row goes (`ContainerManager.swift:3173`). So an implementation
+    /// that honoured the request's order, or sorted the other way, answers
+    /// `invalid_state` here instead of `Ack`. MEASURED with the sort deleted from
+    /// `remove(request:)`: `swift test --filter ArcaEngineTests` reports this
+    /// test as its only failure.
+    ///
+    /// All three deletions are asserted on the host, by exact contents rather
+    /// than by count: an `Ack` is what a `Remove` that deleted nothing would also
+    /// return.
+    func testRemoveDeletesAContainerTheVolumeItMountsAndItsNetworkInOneCall() async throws {
+        let managers = try Self.managers()
+        try await managers.volumeManager.initialize()
+        _ = try await managers.volumeManager.createVolume(
+            name: Self.mountedVolume, driver: "local", driverOpts: nil, labels: Self.ownedLabels
+        )
+        let networkID = try await managers.networkManager.createNetwork(
+            name: Self.networkName, driver: "null", subnet: nil, gateway: nil,
+            ipRange: nil, options: [:], labels: Self.ownedLabels
+        )
+        try await Self.seed(
+            into: managers.stateStore, id: Self.ownedContainerID,
+            name: Self.sandboxID, status: "exited", labels: Self.ownedLabels
+        )
+        try await managers.stateStore.saveVolumeMount(
+            containerID: Self.ownedContainerID, volumeName: Self.mountedVolume,
+            containerPath: "/home/workspace/.cache", isAnonymous: false
+        )
+        await managers.wireCollaborators()
+        try await managers.containerManager.loadPersistedState()
+
+        let response = await managers.makeService().remove(
+            request: Self.removeRequest([
+                (.volume, Self.mountedVolume),
+                (.network, Self.networkName),
+                (.container, Self.sandboxID),
+            ])
+        )
+        guard case .ok = response.outcome else {
+            return XCTFail("all three are the caller's and all three can be deleted here: "
+                + "\(String(describing: response.outcome))")
+        }
+        let container = try await managers.containerManager.getContainer(id: Self.sandboxID)
+        XCTAssertNil(container, "the container must be gone from the host")
+        let volumes = try await managers.volumeManager.listVolumes().map(\.name).sorted()
+        XCTAssertEqual(volumes, [], "the volume must be gone from the host")
+        let networks = try await managers.networkManager.listNetworks().map(\.name).sorted()
+        XCTAssertEqual(networks, [], "the network must be gone from the host")
+        XCTAssertNotNil(networkID, "the fixture really created a network to delete")
+    }
+
+    /// **Nothing is deleted until everything is authorised.**
+    ///
+    /// The container is the caller's and would be deleted; the volume carries no
+    /// labels and must be refused. `AckResponse` has no field in which a partial
+    /// teardown could report what it destroyed (engine.proto:76-82), so an
+    /// implementation that authorised and deleted in one pass would answer this
+    /// exact error having already removed the sandbox -- an error the consumer
+    /// reads as "nothing happened".
+    ///
+    /// The container's survival is therefore the assertion; the code is the
+    /// lesser half. Deletion order puts the container first, so a merged pass
+    /// really would take it.
+    func testRemoveRefusesAnUnlabelledResourceBeforeDeletingTheAuthorisedOne() async throws {
+        let managers = try Self.managers()
+        try await managers.volumeManager.initialize()
+        _ = try await managers.volumeManager.createVolume(
+            name: Self.mountedVolume, driver: "local", driverOpts: nil, labels: [:]
+        )
+        try await Self.seed(
+            into: managers.stateStore, id: Self.ownedContainerID,
+            name: Self.sandboxID, status: "exited", labels: Self.ownedLabels
+        )
+        await managers.wireCollaborators()
+        try await managers.containerManager.loadPersistedState()
+
+        let response = await managers.makeService().remove(
+            request: Self.removeRequest([
+                (.container, Self.sandboxID),
+                (.volume, Self.mountedVolume),
+            ])
+        )
+        Self.assertRefused(
+            response, code: .foreignResourceRefused, resource: Self.mountedVolume,
+            "a volume carrying no gascan labels is not one this engine may delete"
+        )
+        let container = try await managers.containerManager.getContainer(id: Self.sandboxID)
+        XCTAssertNotNil(
+            container,
+            "the authorised container must survive a call that was refused: an Ack-less "
+                + "response with the sandbox already gone is unreportable"
+        )
+        let volumes = try await managers.volumeManager.listVolumes().map(\.name)
+        XCTAssertEqual(volumes, [Self.mountedVolume], "and the refused volume must survive")
+    }
+
+    /// Both owner labels are compared, and each half is load-bearing on its own.
+    ///
+    /// Two volumes, two calls. The first disagrees on `managed_by` only: a
+    /// comparison that looked at `sandbox_id` alone would delete another tool's
+    /// volume that happened to carry a colliding id. The second disagrees on
+    /// `sandbox_id` only: a comparison that looked at `managed_by` alone would let
+    /// every gascan sandbox delete every other gascan sandbox's resources, which
+    /// is precisely what `engine.proto:381-383` says this field exists to stop.
+    /// Either half dropped leaves one of these two green and the other red.
+    func testRemoveRefusesAResourceThatDisagreesOnEitherOwnerLabel() async throws {
+        let managers = try Self.managers()
+        try await managers.volumeManager.initialize()
+        _ = try await managers.volumeManager.createVolume(
+            name: "other-tool-vol", driver: "local", driverOpts: nil,
+            labels: SandboxIdentity.labels(from: Arca_Engine_V1_OwnerLabels.with {
+                $0.managedBy = "another-tool"
+                $0.sandboxID = Self.sandboxID
+            })
+        )
+        _ = try await managers.volumeManager.createVolume(
+            name: "other-sandbox-vol", driver: "local", driverOpts: nil,
+            labels: SandboxIdentity.labels(from: Arca_Engine_V1_OwnerLabels.with {
+                $0.managedBy = "gascan"
+                $0.sandboxID = "other-e1f2a3b4c5d6"
+            })
+        )
+        let service = managers.makeService()
+
+        Self.assertRefused(
+            await service.remove(request: Self.removeRequest([(.volume, "other-tool-vol")])),
+            code: .ownershipMismatch, resource: "other-tool-vol",
+            "same sandbox_id, different managed_by: still not the caller's"
+        )
+        Self.assertRefused(
+            await service.remove(request: Self.removeRequest([(.volume, "other-sandbox-vol")])),
+            code: .ownershipMismatch, resource: "other-sandbox-vol",
+            "same managed_by, different sandbox_id: another sandbox's resource"
+        )
+        let volumes = try await managers.volumeManager.listVolumes().map(\.name).sorted()
+        XCTAssertEqual(
+            volumes, ["other-sandbox-vol", "other-tool-vol"],
+            "neither refused volume may have been deleted"
+        )
+    }
+
+    /// A resource the engine does not hold is `not_found`, and the resources
+    /// named beside it are untouched.
+    ///
+    /// `not_found` rather than a silent `Ack`: the consumer removes exactly what
+    /// it recorded, so "you named something I do not have" is a disagreement
+    /// about state worth surfacing, and an `Ack` over it would hide a resource
+    /// that was deleted by something else.
+    func testRemoveOfAResourceTheEngineDoesNotHoldIsNotFoundAndDeletesNothing() async throws {
+        let managers = try Self.managers()
+        try await Self.seed(
+            into: managers.stateStore, id: Self.ownedContainerID,
+            name: Self.sandboxID, status: "exited", labels: Self.ownedLabels
+        )
+        await managers.wireCollaborators()
+        try await managers.containerManager.loadPersistedState()
+
+        let response = await managers.makeService().remove(
+            request: Self.removeRequest([
+                (.container, Self.sandboxID),
+                (.volume, "never-created-vol"),
+            ])
+        )
+        Self.assertRefused(
+            response, code: .notFound, resource: "never-created-vol",
+            "the engine holds no such volume"
+        )
+        let container = try await managers.containerManager.getContainer(id: Self.sandboxID)
+        XCTAssertNotNil(container, "the container named beside it must survive")
+    }
+
+    /// **The volume-manager wiring, driven through the RPC rather than asserted
+    /// as a wiring.**
+    ///
+    /// `cleanupVolumesForContainer` (`ContainerManager.swift:4140-4143`) is
+    /// `guard let volumeManager = volumeManager else { return }`. Unwired, it
+    /// deletes nothing, `removeContainer` succeeds anyway, CASCADE takes the
+    /// `volume_mounts` row with the container, and the anonymous volume is left on
+    /// disk with nothing pointing at it -- a leak underneath an `Ack`.
+    /// `EngineManagerWiringTests` proves the same thing one layer down, over
+    /// `ContainerManager` directly; this proves that `Remove` itself reaches it.
+    ///
+    /// **The remove names only the container.** The anonymous volume is one no
+    /// `ResourceIdentity` can name -- that is what makes it anonymous -- so if it
+    /// is not deleted here it is not deleted at all.
+    ///
+    /// The named volume is the second half and is not decoration: it is mounted
+    /// too, and a cleanup that deleted every mounted volume would pass a
+    /// one-volume form of this test while destroying data the consumer never
+    /// asked to lose.
+    func testRemovingAContainerThroughTheRPCDeletesItsAnonymousVolumeAndSparesTheNamedOne() async throws {
+        let managers = try Self.managers()
+        try await managers.volumeManager.initialize()
+        _ = try await managers.volumeManager.createVolume(
+            name: "anon-vol", driver: "local", driverOpts: nil, labels: Self.ownedLabels
+        )
+        _ = try await managers.volumeManager.createVolume(
+            name: "named-vol", driver: "local", driverOpts: nil, labels: Self.ownedLabels
+        )
+        try await Self.seed(
+            into: managers.stateStore, id: Self.ownedContainerID,
+            name: Self.sandboxID, status: "exited", labels: Self.ownedLabels
+        )
+        try await managers.stateStore.saveVolumeMount(
+            containerID: Self.ownedContainerID, volumeName: "anon-vol",
+            containerPath: "/scratch", isAnonymous: true
+        )
+        try await managers.stateStore.saveVolumeMount(
+            containerID: Self.ownedContainerID, volumeName: "named-vol",
+            containerPath: "/named", isAnonymous: false
+        )
+        await managers.wireCollaborators()
+        try await managers.containerManager.loadPersistedState()
+
+        let response = await managers.makeService().remove(
+            request: Self.removeRequest([(.container, Self.sandboxID)])
+        )
+        guard case .ok = response.outcome else {
+            return XCTFail("removing an owned, exited container succeeds here: "
+                + "\(String(describing: response.outcome))")
+        }
+        let remaining = try await managers.volumeManager.listVolumes().map(\.name).sorted()
+        XCTAssertEqual(
+            remaining, ["named-vol"],
+            "Remove must delete the container's anonymous volume and keep the named one"
+        )
+    }
+
+    /// A remove that names nothing is refused rather than `Ack`ed.
+    ///
+    /// The `Ack` would be true -- everything named was deleted -- and it is the
+    /// answer a caller that dropped its list reads as a completed teardown. The
+    /// consumer refuses to build one itself
+    /// (`crates/gascan-arca/src/translate.rs:255-256`), so this refuses nothing it
+    /// sends.
+    func testARemoveThatNamesNoResourcesIsRefused() async throws {
+        let response = await (try Self.managers()).makeService().remove(
+            request: Arca_Engine_V1_RemoveRequest.with { $0.owner = Self.ownerLabels }
+        )
+        Self.assertRefused(
+            response, code: .invalidState, resource: "",
+            "an empty remove is a caller that lost its list"
+        )
+    }
+
+    /// A remove under half-set owner labels is refused before any comparison.
+    ///
+    /// Compared as-is, a half-set owner matches only resources labelled equally
+    /// half-set, so every resource in the call would come back
+    /// `ownership_mismatch` -- "these are not yours", when the truth is "you did
+    /// not say who you are". The two demand different fixes.
+    func testARemoveUnderHalfSetOwnerLabelsIsRefusedBeforeAnyComparison() async throws {
+        let managers = try Self.managers()
+        try await Self.seed(
+            into: managers.stateStore, id: Self.ownedContainerID,
+            name: Self.sandboxID, status: "exited", labels: Self.ownedLabels
+        )
+        await managers.wireCollaborators()
+        try await managers.containerManager.loadPersistedState()
+
+        let response = await managers.makeService().remove(
+            request: Arca_Engine_V1_RemoveRequest.with {
+                $0.owner = Arca_Engine_V1_OwnerLabels.with { $0.sandboxID = Self.sandboxID }
+                $0.resources = [Arca_Engine_V1_ResourceIdentity.with {
+                    $0.kind = .container
+                    $0.name = Self.sandboxID
+                }]
+            }
+        )
+        Self.assertRefused(
+            response, code: .invalidResourceIdentity, resource: "",
+            "managed_by is empty, so there is nothing to compare against"
+        )
+        let container = try await managers.containerManager.getContainer(id: Self.sandboxID)
+        XCTAssertNotNil(container, "and the resource it named must survive")
+    }
+
+    /// An unset `kind` is a request to delete "a resource" without saying from
+    /// which of three namespaces, and the engine will not guess.
+    ///
+    /// The container seeded here shares the requested name, so a guess of
+    /// `container` would find something and delete it.
+    func testARemoveNamingAResourceOfUnspecifiedKindIsRefused() async throws {
+        let managers = try Self.managers()
+        try await Self.seed(
+            into: managers.stateStore, id: Self.ownedContainerID,
+            name: Self.sandboxID, status: "exited", labels: Self.ownedLabels
+        )
+        await managers.wireCollaborators()
+        try await managers.containerManager.loadPersistedState()
+
+        let response = await managers.makeService().remove(
+            request: Self.removeRequest([(.unspecified, Self.sandboxID)])
+        )
+        Self.assertRefused(
+            response, code: .invalidResourceIdentity, resource: Self.sandboxID,
+            "kind is unset, and container, volume and network are three namespaces"
+        )
+        let container = try await managers.containerManager.getContainer(id: Self.sandboxID)
+        XCTAssertNotNil(container, "the container that shares the name must survive")
+    }
+
+    // MARK: - Fixtures
+
+    /// 64 characters, and the two must not share their first 32:
+    /// `loadPersistedState()` derives the native id from `String(id.prefix(32))`
+    /// and keys `reverseMapping` on it, so a collision makes one seed vanish.
+    private static let ownedContainerID = String(repeating: "a", count: 64)
+
+    /// A Docker id that begins with a hex string a caller could send as a name.
+    /// The container it belongs to is named something else entirely.
+    private static let hexPrefixedContainerID = "beef" + String(repeating: "1", count: 60)
+    private static let unrelatedContainerName = "unrelated-container"
+
+    /// `SandboxIdentity.containerName(forSandboxId:)` is the identity function, so
+    /// this is both the sandbox id and the seeded container name. It contains a
+    /// hyphen, which is what keeps a well-formed id away from the hex arm of
+    /// `resolveContainerID`.
+    private static let sandboxID = "web-a1b2c3d4e5f6"
+    private static let mountedVolume = "gascan-cache-web-a1b2c3d4e5f6"
+    private static let networkName = "sbx-net-web-a1b2c3d4e5f6"
+
+    private static let ownerLabels = Arca_Engine_V1_OwnerLabels.with {
+        $0.managedBy = "gascan"
+        $0.sandboxID = sandboxID
+    }
+    private static let ownedLabels = SandboxIdentity.labels(from: ownerLabels)
+
+    /// The engine's own managers over a throwaway state root -- the production
+    /// factory, so what these tests drive is what `arca-engine` serves.
+    private static func managers() throws -> EngineManagers {
+        try EngineManagers(
+            stateRoot: URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("arca-lifecycle-tests-\(UUID().uuidString)"),
+            kernelPath: URL(fileURLWithPath: "/opt/arca/vmlinux"),
+            logLevel: "info",
+            logger: Logger(label: "arca-engine-tests")
+        )
+    }
+
+    /// One container row, through `StateStore` and then `loadPersistedState()` --
+    /// the restore path the engine itself runs -- rather than through a double.
+    /// `initialize()` is the normal caller and constructs a real `VmnetNetwork`,
+    /// which no test in this target may do.
+    private static func seed(
+        into store: StateStore,
+        id: String,
+        name: String,
+        status: String,
+        labels: [String: String]
+    ) async throws {
+        let encoder = JSONEncoder()
+        let image = "arca/probe@sha256:" + String(repeating: "1", count: 64)
+        try await store.saveContainer(
+            id: id, name: name, image: image, imageID: "sha256:probe",
+            createdAt: Date(), status: status, running: false, paused: false,
+            restarting: false, pid: 0, exitCode: 0, startedAt: nil,
+            finishedAt: Date(), stoppedByUser: false, entrypoint: nil,
+            configJSON: String(
+                decoding: try encoder.encode(
+                    ContainerConfiguration(image: image, labels: labels)
+                ),
+                as: UTF8.self
+            ),
+            hostConfigJSON: String(decoding: try encoder.encode(HostConfig()), as: UTF8.self)
+        )
+    }
+
+    /// A remove under `ownerLabels`, naming exactly what it is given and in the
+    /// order it is given -- the wire order, so a test can put it deliberately
+    /// wrong.
+    private static func removeRequest(
+        _ resources: [(Arca_Engine_V1_ResourceKind, String)]
+    ) -> Arca_Engine_V1_RemoveRequest {
+        Arca_Engine_V1_RemoveRequest.with { request in
+            request.owner = ownerLabels
+            request.resources = resources.map { kind, name in
+                Arca_Engine_V1_ResourceIdentity.with {
+                    $0.kind = kind
+                    $0.name = name
+                }
+            }
+        }
+    }
+
+    /// The error arm with its code and the resource it names, both asserted.
+    ///
+    /// `resource` as well as `code` because they are not interchangeable
+    /// (`EngineErrors.swift:32-35`) and because in a multi-resource remove the
+    /// resource is what says *which* one was refused -- a call that refused the
+    /// wrong member would carry the right code.
+    private static func assertRefused(
+        _ response: Arca_Engine_V1_AckResponse,
+        code: EngineErrorCode,
+        resource: String,
+        _ why: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard case .error(let error) = response.outcome else {
+            return XCTFail(
+                "expected a refusal -- \(why): \(String(describing: response.outcome))",
+                file: file, line: line
+            )
+        }
+        XCTAssertEqual(error.code, code.rawValue, why, file: file, line: line)
+        XCTAssertEqual(error.resource, resource, why, file: file, line: line)
+    }
+}

--- a/Tests/ArcaEngineTests/ListFilterTests.swift
+++ b/Tests/ArcaEngineTests/ListFilterTests.swift
@@ -178,6 +178,210 @@ final class ListFilterTests: XCTestCase {
         )
     }
 
+    /// The production derivation behind `getNetworkAttachments`, with nothing
+    /// installed.
+    ///
+    /// This is the test the stub-driven one below cannot replace. A stub proves
+    /// the seam carries a failure; it says nothing about whether the source
+    /// production actually reads is wired up. MEASURED, mutating the production
+    /// default and leaving the seam intact -- `attachmentSource` reduced to
+    ///
+    ///     private var attachmentSource: any NetworkAttachmentSource {
+    ///         installedAttachmentSource ?? EmptyAttachments()
+    ///     }
+    ///
+    /// with `EmptyAttachments` answering `[:]` and `[]`:
+    /// `swift test --filter ArcaEngineTests` -> `Executed 43 tests, with 4
+    /// failures`, this test on `("[]") is not equal to
+    /// ("["ffff…ffff"]") - getNetworkAttachments must read the attachment out
+    /// of the StateStore` and `testContainerNetworksAreReadFromTheStore` on
+    /// `("[]") is not equal to ("["probe-attached"]")` -- two failing tests,
+    /// two assertions each. Both stub-driven tests below stayed green through
+    /// it (`testGetNetworkAttachmentsReportsAStoreFailureRatherThanNoAttachments
+    /// … passed`, `testGetContainerNetworksReportsAStoreFailureRatherThanNoNetworks
+    /// … passed`), and so did `NetworkPruneGateTests`, whose 2 tests still
+    /// reported `Test run with 2 tests in 1 suite passed`. This is the mutation
+    /// a seam-only test cannot see.
+    func testNetworkAttachmentsAreReadFromTheStore() async throws {
+        let fixture = try await Self.attachmentFixture()
+
+        let attachments = try await fixture.manager.getNetworkAttachments(
+            networkID: Self.attachedNetworkID
+        )
+
+        XCTAssertEqual(
+            attachments.keys.sorted(),
+            [Self.attachedContainerID],
+            "getNetworkAttachments must read the attachment out of the StateStore"
+        )
+        XCTAssertEqual(
+            attachments[Self.attachedContainerID]?.ip,
+            "172.18.0.2",
+            "the attachment must carry the stored address, not a placeholder"
+        )
+    }
+
+    /// The failure half for the same method, and the one that gates a deletion.
+    ///
+    /// `[:]` is what "nothing is attached" looks like, so a swallowed store
+    /// failure told `docker network prune` every network was unused.
+    /// `NetworkPruneGateTests` in `ArcaTests` asserts on the deletion itself;
+    /// this asserts the read that gate depends on reports rather than returns
+    /// empty.
+    ///
+    /// MEASURED, restoring the swallow -- `getNetworkAttachments`' body
+    /// returned to `if let attachments = try? await
+    /// attachmentSource.getNetworkAttachments(networkID: networkID) { return
+    /// attachments }; return [:]`: `swift test --filter ArcaEngineTests` ->
+    /// `Executed 43 tests, with 1 failure`, this test on `getNetworkAttachments
+    /// returned 0 attachments instead of reporting the store failure`. The
+    /// three other tests added here stayed green through it, including
+    /// `testGetContainerNetworksReportsAStoreFailureRatherThanNoNetworks` --
+    /// which is why that one exists separately.
+    func testGetNetworkAttachmentsReportsAStoreFailureRatherThanNoAttachments() async throws {
+        let manager = SandboxEngineService.forTesting().networkManager
+        await manager.setNetworkAttachmentSource(StubNetworkAttachmentSource.failing)
+
+        do {
+            let swallowed = try await manager.getNetworkAttachments(
+                networkID: Self.attachedNetworkID
+            )
+            XCTFail(
+                "getNetworkAttachments returned \(swallowed.count) attachments instead of "
+                    + "reporting the store failure"
+            )
+        } catch is NetworkAttachmentsUnreachable {
+            // The store's failure reached the caller, which is the point.
+        }
+    }
+
+    /// The production derivation behind `getContainerNetworks`, with nothing
+    /// installed. The other half of the mutation measured above: proving one of
+    /// these two methods leaves the other unproven, because each reads its own
+    /// direction of the attachment table.
+    func testContainerNetworksAreReadFromTheStore() async throws {
+        let fixture = try await Self.attachmentFixture()
+
+        let networks = try await fixture.manager.getContainerNetworks(
+            containerID: Self.attachedContainerID
+        )
+
+        XCTAssertEqual(
+            networks.map(\.name),
+            ["probe-attached"],
+            "getContainerNetworks must read the container's networks out of the StateStore"
+        )
+        XCTAssertEqual(
+            networks.first?.containers,
+            [Self.attachedContainerID],
+            "the network must carry its attached containers, as the backend's copy did"
+        )
+    }
+
+    /// The failure half for `getContainerNetworks`, proved separately from
+    /// `getNetworkAttachments` above.
+    ///
+    /// An empty answer here reads to `getWireGuardClient` as "not attached to
+    /// any WireGuard network", and its caller publishes no port mappings on the
+    /// strength of that -- a container that comes up with its ports silently
+    /// unmapped.
+    ///
+    /// MEASURED, restoring the swallow to this method alone -- `return (try?
+    /// await attachmentSource.getContainerNetworks(containerID: containerID))
+    /// ?? []`: `swift test --filter ArcaEngineTests` -> `Executed 43 tests,
+    /// with 1 failure`, this test on `getContainerNetworks returned 0 networks
+    /// instead of reporting the store failure`.
+    /// `testGetNetworkAttachmentsReportsAStoreFailureRatherThanNoAttachments`
+    /// stayed green through it (`… passed (0.009 seconds)`), which is why both
+    /// exist.
+    func testGetContainerNetworksReportsAStoreFailureRatherThanNoNetworks() async throws {
+        let manager = SandboxEngineService.forTesting().networkManager
+        await manager.setNetworkAttachmentSource(StubNetworkAttachmentSource.failing)
+
+        do {
+            let swallowed = try await manager.getContainerNetworks(
+                containerID: Self.attachedContainerID
+            )
+            XCTFail(
+                "getContainerNetworks returned \(swallowed.count) networks instead of "
+                    + "reporting the store failure"
+            )
+        } catch is NetworkAttachmentsUnreachable {
+            // The store's failure reached the caller rather than an empty list.
+        }
+    }
+
+    private static let attachedNetworkID = String(repeating: "e", count: 64)
+    private static let attachedContainerID = String(repeating: "f", count: 64)
+
+    /// A manager over a throwaway state root holding one network, one
+    /// container, and the attachment joining them.
+    ///
+    /// The rows go in through `StateStore`'s own writers -- the ones
+    /// `createNetwork` and `attachContainerToNetwork` call -- so what the two
+    /// tests above exercise is the real read path over real rows. The
+    /// `StateStore` is returned alongside the manager so it stays alive for the
+    /// test's duration.
+    private static func attachmentFixture() async throws -> (
+        manager: NetworkManager, store: StateStore
+    ) {
+        let stateRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("arca-attachment-tests-\(UUID().uuidString)")
+        let paths = EnginePaths(stateRoot: stateRoot)
+        let logger = Logger(label: "arca-engine-tests")
+
+        let seedStore = try StateStore(path: paths.stateDatabase.path, logger: logger)
+        try await seedStore.saveNetwork(
+            id: attachedNetworkID,
+            name: "probe-attached",
+            driver: "bridge",
+            scope: "local",
+            createdAt: Date(),
+            subnet: "172.18.0.0/16",
+            gateway: "172.18.0.1",
+            ipRange: nil,
+            optionsJSON: nil,
+            labelsJSON: nil,
+            isDefault: false
+        )
+
+        // The attachment row carries foreign keys to both tables, so the
+        // container has to exist before it can be attached.
+        let encoder = JSONEncoder()
+        try await seedStore.saveContainer(
+            id: attachedContainerID,
+            name: "attached-probe",
+            image: "arca/probe:latest",
+            imageID: "sha256:probe",
+            createdAt: Date(),
+            status: "running",
+            running: true,
+            paused: false,
+            restarting: false,
+            pid: 0,
+            exitCode: 0,
+            startedAt: Date(),
+            finishedAt: nil,
+            stoppedByUser: false,
+            entrypoint: nil,
+            configJSON: String(
+                decoding: try encoder.encode(ContainerConfiguration(image: "arca/probe:latest")),
+                as: UTF8.self
+            ),
+            hostConfigJSON: String(decoding: try encoder.encode(HostConfig()), as: UTF8.self)
+        )
+
+        try await seedStore.saveNetworkAttachment(
+            containerID: attachedContainerID,
+            networkID: attachedNetworkID,
+            ipAddress: "172.18.0.2",
+            macAddress: "02:42:ac:12:00:02",
+            aliases: ["attached-probe"]
+        )
+
+        return (SandboxEngineService.forTesting(stateRoot: stateRoot).networkManager, seedStore)
+    }
+
     /// The one bridge network the succeeding half of the first test expects
     /// back, so the assertion is an equality rather than a non-emptiness check.
     private static let probeNetwork = NetworkMetadata(
@@ -306,5 +510,28 @@ struct StubNetworkLister: NetworkLister {
 
     func listNetworks() async throws -> [NetworkMetadata] {
         try result.get()
+    }
+}
+
+/// The error a failing attachment source reports. At file scope for the reason
+/// `NetworkListerUnreachable` is, and distinct from it so a test cannot pass by
+/// catching the wrong seam's failure.
+struct NetworkAttachmentsUnreachable: Error {}
+
+/// An attachment source that cannot reach the store.
+///
+/// Only the failing direction is offered: the answering direction is what the
+/// production `StoredNetworkAttachments` already does over a real StateStore,
+/// and the tests that need it install nothing rather than stand a stub in its
+/// place. A stub that answers would only prove the stub answers.
+struct StubNetworkAttachmentSource: NetworkAttachmentSource {
+    static let failing = StubNetworkAttachmentSource()
+
+    func getNetworkAttachments(networkID: String) async throws -> [String: NetworkAttachment] {
+        throw NetworkAttachmentsUnreachable()
+    }
+
+    func getContainerNetworks(containerID: String) async throws -> [NetworkMetadata] {
+        throw NetworkAttachmentsUnreachable()
     }
 }

--- a/Tests/ArcaEngineTests/ListFilterTests.swift
+++ b/Tests/ArcaEngineTests/ListFilterTests.swift
@@ -512,9 +512,13 @@ struct NetworkListerUnreachable: Error, CustomStringConvertible {
     /// `ListResourcesTests.testANetworkBackendFailureIsTheErrorArmRatherThanAShortList`
     /// pins that message by exact equality -- which is what distinguishes
     /// "carried the source's own failure out" from "substituted engine prose",
-    /// and what `contains` would not. Left to the default `String(describing:)`
-    /// the asserted string was this type's *name*, so renaming the type would
-    /// have silently changed what that assertion meant.
+    /// and what `contains` would not.
+    ///
+    /// Before this conformance existed that assertion pinned the default
+    /// `String(describing:)` output, which is this type's *name*: renaming the
+    /// type would have changed what the assertion meant with nothing failing.
+    /// Stated here, the two are the right way round -- changing this
+    /// `description` fails that assertion, and renaming the type does not.
     var description: String { "the bridge network source could not be reached" }
 }
 

--- a/Tests/ArcaEngineTests/ListFilterTests.swift
+++ b/Tests/ArcaEngineTests/ListFilterTests.swift
@@ -5,6 +5,12 @@ import XCTest
 @testable import ArcaEngine
 
 final class ListFilterTests: XCTestCase {
+    /// A kernel path for services whose sandboxes are never booted. Nothing in
+    /// this suite starts a VM, so the value is never read; it is named rather
+    /// than derived from the state root so that no test here quietly reasserts
+    /// the derivation `--kernel-path` replaced.
+    private static let unbootedKernel = URL(fileURLWithPath: "/opt/arca/vmlinux")
+
     /// gascan's drift and leak detection reads ListResources. A container that
     /// exists but is not listed is a leak the consumer can never see, so the
     /// engine asks for everything explicitly.
@@ -168,7 +174,9 @@ final class ListFilterTests: XCTestCase {
             isDefault: true
         )
 
-        let manager = SandboxEngineService.forTesting(stateRoot: stateRoot).networkManager
+        let manager = SandboxEngineService
+            .forTesting(stateRoot: stateRoot, kernelPath: Self.unbootedKernel)
+            .networkManager
 
         let networks = try await manager.listNetworks()
         XCTAssertEqual(
@@ -379,7 +387,12 @@ final class ListFilterTests: XCTestCase {
             aliases: ["attached-probe"]
         )
 
-        return (SandboxEngineService.forTesting(stateRoot: stateRoot).networkManager, seedStore)
+        return (
+            SandboxEngineService
+                .forTesting(stateRoot: stateRoot, kernelPath: unbootedKernel)
+                .networkManager,
+            seedStore
+        )
     }
 
     /// The one bridge network the succeeding half of the first test expects
@@ -472,7 +485,7 @@ final class ListFilterTests: XCTestCase {
 
         return ContainerManager(
             imageManager: try ImageManager(logger: logger, imageStorePath: paths.imageStoreRoot),
-            kernelPath: paths.kernel.path,
+            kernelPath: unbootedKernel.path,
             imageStoreRoot: paths.imageStoreRoot,
             layerCachePath: paths.layerCache,
             stateStore: stateStore,

--- a/Tests/ArcaEngineTests/ListFilterTests.swift
+++ b/Tests/ArcaEngineTests/ListFilterTests.swift
@@ -1,0 +1,105 @@
+import ContainerBridge
+import Foundation
+import Logging
+import XCTest
+@testable import ArcaEngine
+
+final class ListFilterTests: XCTestCase {
+    /// gascan's drift and leak detection reads ListResources. A container that
+    /// exists but is not listed is a leak the consumer can never see, so the
+    /// engine asks for everything explicitly.
+    func testInternalContainersAreRequestedByAnExplicitFlagNotASubstring() {
+        XCTAssertFalse(ContainerManager.internalContainersRequested(in: [:]))
+        XCTAssertFalse(
+            ContainerManager.internalContainersRequested(in: ["label": ["com.example.other"]])
+        )
+        XCTAssertTrue(
+            ContainerManager.internalContainersRequested(in: ["label": ["com.arca.internal"]])
+        )
+    }
+
+    /// The assertion the helper test above cannot make. Asserting on
+    /// `internalContainersRequested(in:)` alone proves the rule computes the
+    /// right answer, not that `listContainers` obeys the answer it is handed:
+    /// with the `includeInternal` guard reverted to the old filter-derived
+    /// `showInternal`, the helper test and the whole suite stayed green
+    /// (`swift test --filter ArcaEngineTests` -> `Executed 35 tests, with 0
+    /// failures`). This drives a real container through the real restore loop
+    /// and asks for it both ways.
+    func testListContainersShowsAnInternalContainerOnlyWhenAskedTo() async throws {
+        let manager = try await Self.managerWithInternalContainer(named: "arca-internal-probe")
+        try await manager.loadPersistedState()
+
+        let shown = try await manager.listContainers(all: true, includeInternal: true)
+        XCTAssertEqual(
+            shown.map(\.names),
+            [["/arca-internal-probe"]],
+            "includeInternal: true must list a container labelled com.arca.internal=true"
+        )
+
+        let hidden = try await manager.listContainers(all: true, includeInternal: false)
+        XCTAssertTrue(
+            hidden.isEmpty,
+            "includeInternal: false must hide it; got \(hidden.map(\.names))"
+        )
+    }
+
+    /// A `ContainerManager` over a throwaway state root whose StateStore already
+    /// holds one container labelled `com.arca.internal=true`.
+    ///
+    /// The container is seeded through `StateStore.saveContainer` and read back
+    /// by `loadPersistedState()` -- the same pair the daemon uses across a
+    /// restart -- rather than by writing into `containers` through a test-only
+    /// setter, so what the test exercises is the restore path itself.
+    ///
+    /// Paths come from `EnginePaths`, the derivation `arca-engine` calls, for
+    /// the reason `TestSupport` gives: a copy of those `appendingPathComponent`
+    /// lines makes the test a replica of the wiring rather than the wiring.
+    private static func managerWithInternalContainer(named name: String) async throws -> ContainerManager {
+        let logger = Logger(label: "arca-engine-tests")
+        let paths = EnginePaths(
+            stateRoot: URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("arca-list-filter-tests-\(UUID().uuidString)")
+        )
+
+        let stateStore = try StateStore(path: paths.stateDatabase.path, logger: logger)
+
+        // Docker IDs are 64 characters; loadPersistedState() derives the native
+        // ID from the first 32, and listContainers drops any container whose
+        // reverse mapping is missing, so the length matters.
+        let dockerID = String(repeating: "a", count: 64)
+        let config = ContainerConfiguration(
+            image: "arca/probe:latest",
+            labels: ["com.arca.internal": "true"]
+        )
+        let encoder = JSONEncoder()
+        try await stateStore.saveContainer(
+            id: dockerID,
+            name: name,
+            image: "arca/probe:latest",
+            imageID: "sha256:probe",
+            createdAt: Date(),
+            status: "exited",
+            running: false,
+            paused: false,
+            restarting: false,
+            pid: 0,
+            exitCode: 0,
+            startedAt: nil,
+            finishedAt: nil,
+            stoppedByUser: false,
+            entrypoint: nil,
+            configJSON: String(decoding: try encoder.encode(config), as: UTF8.self),
+            hostConfigJSON: String(decoding: try encoder.encode(HostConfig()), as: UTF8.self)
+        )
+
+        return ContainerManager(
+            imageManager: try ImageManager(logger: logger, imageStorePath: paths.imageStoreRoot),
+            kernelPath: paths.kernel.path,
+            imageStoreRoot: paths.imageStoreRoot,
+            layerCachePath: paths.layerCache,
+            stateStore: stateStore,
+            logger: logger
+        )
+    }
+}

--- a/Tests/ArcaEngineTests/ListFilterTests.swift
+++ b/Tests/ArcaEngineTests/ListFilterTests.swift
@@ -64,19 +64,19 @@ final class ListFilterTests: XCTestCase {
     /// that the signature says `throws` would pass against the unfixed body the
     /// moment someone wrote `throws` without deleting the `try?`, and asserting
     /// only that the failing lister throws would pass against a `listNetworks()`
-    /// that threw no matter what. Both mutations were run against this test, and
-    /// `swift test --filter ArcaEngineTests` reported `Executed 37 tests, with 1
-    /// failure` for each:
+    /// that threw no matter what. Both mutations were run against this test:
     ///
-    /// - the append put back to `if let wgNetworks = try? await
-    ///   lister.listNetworks()` -> `listNetworks() returned 0 networks instead
-    ///   of reporting the backend failure`
+    /// - the source loop swallowing again, `if let listed = try? await
+    ///   lister.listNetworks()` -> `Executed 39 tests, with 2 failures`, this
+    ///   one on `listNetworks() returned 0 networks instead of reporting the
+    ///   backend failure` (the null-driver test below is the other)
     /// - `throw NetworkManagerError.networkNotFound(...)` as the first statement
-    ///   of `listNetworks()` -> `caught error: "network guard-proving mutation
-    ///   not found"`
+    ///   of `listNetworks()` -> `Executed 37 tests, with 1 failure`, `caught
+    ///   error: "network guard-proving mutation not found"` (measured when the
+    ///   suite stood at 37, before the null-driver tests below existed)
     func testListNetworksReportsABackendFailureRatherThanAShortList() async throws {
         let failing = SandboxEngineService.forTesting().networkManager
-        await failing.setBridgeNetworkLister(StubBridgeLister.failing)
+        await failing.setBridgeNetworkLister(StubNetworkLister.failing)
 
         do {
             let swallowed = try await failing.listNetworks()
@@ -84,14 +84,14 @@ final class ListFilterTests: XCTestCase {
                 "listNetworks() returned \(swallowed.count) networks instead of "
                     + "reporting the backend failure"
             )
-        } catch is BridgeBackendUnreachable {
+        } catch is NetworkListerUnreachable {
             // The backend's own error reached the caller, which is the point.
         }
 
         // The other side: the same seam, a lister that answers. Without this,
         // a `listNetworks()` that threw no matter what would pass the half above.
         let working = SandboxEngineService.forTesting().networkManager
-        await working.setBridgeNetworkLister(StubBridgeLister.listing([Self.probeNetwork]))
+        await working.setBridgeNetworkLister(StubNetworkLister.listing([Self.probeNetwork]))
 
         let networks = try await working.listNetworks()
         XCTAssertEqual(
@@ -101,7 +101,84 @@ final class ListFilterTests: XCTestCase {
         )
     }
 
-    /// The one bridge network the succeeding half of the test above expects
+    /// The same rule for the other source `listNetworks()` reads. The
+    /// null-driver networks used to be read back one at a time through
+    /// `getNetwork(id:)`, whose `catch` logs and returns `nil`, so a StateStore
+    /// failure dropped every `--driver null` network from the answer and still
+    /// reported success -- the same short list one branch over.
+    ///
+    /// Failing the null source specifically, not "some source", is what makes
+    /// this test able to see that regression: it is why the two sources have
+    /// separate setters. MEASURED: with `NullDriverNetworks` dropped from
+    /// `networkListers` and the old branch restored to
+    ///
+    ///     let nullNetworkIDs = networkDrivers.filter { $0.value == "null" }.keys
+    ///     for networkID in nullNetworkIDs {
+    ///         if let network = await getNetwork(id: networkID) { ... }
+    ///     }
+    ///
+    /// `swift test --filter ArcaEngineTests` reported `Executed 39 tests, with 2
+    /// failures`, this test on `listNetworks() returned 0 networks instead of
+    /// reporting the null-driver store failure` and
+    /// `testNullDriverNetworksAreListedFromTheStore` on `("[]") is not equal to
+    /// ("["probe-none"]")`. Dropping only the source from `networkListers`, with
+    /// the old branch left out, reported the same two failures.
+    func testListNetworksReportsANullDriverStoreFailureRatherThanAShortList() async throws {
+        let failing = SandboxEngineService.forTesting().networkManager
+        await failing.setNullNetworkLister(StubNetworkLister.failing)
+
+        do {
+            let swallowed = try await failing.listNetworks()
+            XCTFail(
+                "listNetworks() returned \(swallowed.count) networks instead of "
+                    + "reporting the null-driver store failure"
+            )
+        } catch is NetworkListerUnreachable {
+            // The store's failure reached the caller rather than a short list.
+        }
+    }
+
+    /// The half the stub cannot prove: that the source `listNetworks()` derives
+    /// for null-driver networks really is the StateStore, and really is read.
+    ///
+    /// Nothing is installed here -- the manager runs its own
+    /// `NullDriverNetworks` over the real store the seed was written to, so
+    /// dropping that source from the derivation makes this go red while the
+    /// stub-driven test above stays green. The network is seeded through
+    /// `StateStore.saveNetwork`, the call `createNetwork` itself makes for
+    /// `driver: "null"`, rather than through a test-only setter.
+    func testNullDriverNetworksAreListedFromTheStore() async throws {
+        let stateRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("arca-null-network-tests-\(UUID().uuidString)")
+        let paths = EnginePaths(stateRoot: stateRoot)
+        let logger = Logger(label: "arca-engine-tests")
+
+        let seedStore = try StateStore(path: paths.stateDatabase.path, logger: logger)
+        try await seedStore.saveNetwork(
+            id: String(repeating: "d", count: 64),
+            name: "probe-none",
+            driver: "null",
+            scope: "local",
+            createdAt: Date(),
+            subnet: "",
+            gateway: "",
+            ipRange: nil,
+            optionsJSON: nil,
+            labelsJSON: nil,
+            isDefault: true
+        )
+
+        let manager = SandboxEngineService.forTesting(stateRoot: stateRoot).networkManager
+
+        let networks = try await manager.listNetworks()
+        XCTAssertEqual(
+            networks.map(\.name),
+            ["probe-none"],
+            "listNetworks() must read the null-driver networks out of the StateStore"
+        )
+    }
+
+    /// The one bridge network the succeeding half of the first test expects
     /// back, so the assertion is an equality rather than a non-emptiness check.
     private static let probeNetwork = NetworkMetadata(
         id: String(repeating: "c", count: 64),
@@ -200,10 +277,10 @@ final class ListFilterTests: XCTestCase {
     }
 }
 
-/// The error a failing bridge backend reports.
+/// The error a failing network source reports.
 ///
 /// At file scope, not nested inside `ListFilterTests`, and not nested inside
-/// `StubBridgeLister` either. MEASURED: nested, `catch is
+/// `StubNetworkLister` either. MEASURED: nested, `catch is
 /// StubBridgeLister.BackendUnreachable` crashed the test binary --
 /// `swift test --filter ArcaEngineTests` reported `exited with unexpected
 /// signal code 11`, and driving the one test straight through `xctest` exited
@@ -211,19 +288,20 @@ final class ListFilterTests: XCTestCase {
 /// reached from that `catch` (`ListFilterTests.swift:82:17` in the backtrace).
 /// Moving these two declarations out, with nothing else changed, made the same
 /// test pass.
-struct BridgeBackendUnreachable: Error {}
+struct NetworkListerUnreachable: Error {}
 
-/// A bridge-network source that either fails or answers. This is the seam the
-/// network test needs and the container tests did not: `NetworkManager`
-/// populates its real backend only inside `initialize()`, which also creates the
-/// default `host` network over vmnet and so cannot run in a unit test.
-struct StubBridgeLister: BridgeNetworkLister {
-    let result: Result<[NetworkMetadata], BridgeBackendUnreachable>
+/// A network source that either fails or answers. This is the seam the network
+/// tests need and the container tests did not: `NetworkManager` populates its
+/// WireGuard backend only inside `initialize()`, which also creates the default
+/// `host` network over vmnet and so cannot run in a unit test, and `StateStore`
+/// is a concrete actor whose SQLite connection a test cannot break on demand.
+struct StubNetworkLister: NetworkLister {
+    let result: Result<[NetworkMetadata], NetworkListerUnreachable>
 
-    static let failing = StubBridgeLister(result: .failure(BridgeBackendUnreachable()))
+    static let failing = StubNetworkLister(result: .failure(NetworkListerUnreachable()))
 
-    static func listing(_ networks: [NetworkMetadata]) -> StubBridgeLister {
-        StubBridgeLister(result: .success(networks))
+    static func listing(_ networks: [NetworkMetadata]) -> StubNetworkLister {
+        StubNetworkLister(result: .success(networks))
     }
 
     func listNetworks() async throws -> [NetworkMetadata] {

--- a/Tests/ArcaEngineTests/ListFilterTests.swift
+++ b/Tests/ArcaEngineTests/ListFilterTests.swift
@@ -488,6 +488,7 @@ final class ListFilterTests: XCTestCase {
             kernelPath: unbootedKernel.path,
             imageStoreRoot: paths.imageStoreRoot,
             layerCachePath: paths.layerCache,
+            logRoot: paths.logsRoot,
             stateStore: stateStore,
             logger: logger
         )

--- a/Tests/ArcaEngineTests/ListFilterTests.swift
+++ b/Tests/ArcaEngineTests/ListFilterTests.swift
@@ -505,7 +505,18 @@ final class ListFilterTests: XCTestCase {
 /// reached from that `catch` (`ListFilterTests.swift:82:17` in the backtrace).
 /// Moving these two declarations out, with nothing else changed, made the same
 /// test pass.
-struct NetworkListerUnreachable: Error {}
+struct NetworkListerUnreachable: Error, CustomStringConvertible {
+    /// Stated rather than synthesised, because it is asserted verbatim.
+    /// `engineErrorCatching` interpolates the caught error into the
+    /// `EngineError`'s message (`EngineErrors.swift:62`), and
+    /// `ListResourcesTests.testANetworkBackendFailureIsTheErrorArmRatherThanAShortList`
+    /// pins that message by exact equality -- which is what distinguishes
+    /// "carried the source's own failure out" from "substituted engine prose",
+    /// and what `contains` would not. Left to the default `String(describing:)`
+    /// the asserted string was this type's *name*, so renaming the type would
+    /// have silently changed what that assertion meant.
+    var description: String { "the bridge network source could not be reached" }
+}
 
 /// A network source that either fails or answers. This is the seam the network
 /// tests need and the container tests did not: `NetworkManager` populates its

--- a/Tests/ArcaEngineTests/ListFilterTests.swift
+++ b/Tests/ArcaEngineTests/ListFilterTests.swift
@@ -24,38 +24,69 @@ final class ListFilterTests: XCTestCase {
     /// with the `includeInternal` guard reverted to the old filter-derived
     /// `showInternal`, the helper test and the whole suite stayed green
     /// (`swift test --filter ArcaEngineTests` -> `Executed 35 tests, with 0
-    /// failures`). This drives a real container through the real restore loop
-    /// and asks for it both ways.
-    func testListContainersShowsAnInternalContainerOnlyWhenAskedTo() async throws {
-        let manager = try await Self.managerWithInternalContainer(named: "arca-internal-probe")
+    /// failures`, before this test existed).
+    ///
+    /// Two containers are seeded, not one, and the negative case asserts an
+    /// equality rather than `isEmpty`. With a single internal container,
+    /// `hidden.isEmpty` passes just as well when the guard hides *every*
+    /// container as when it hides the right one -- and hiding everything is the
+    /// direction that reaches users, because `includeInternal: false` is what
+    /// three of the four Docker call sites pass, `docker ps` among the paths
+    /// that would go blank. MEASURED: with the guard widened to
+    /// `if !includeInternal { return nil }`, the one-container form of this test
+    /// still reported `Executed 2 tests, with 0 failures`.
+    func testListContainersHidesOnlyTheInternalContainerAndOnlyWhenAsked() async throws {
+        let manager = try await Self.seededManager()
         try await manager.loadPersistedState()
 
         let shown = try await manager.listContainers(all: true, includeInternal: true)
         XCTAssertEqual(
-            shown.map(\.names),
-            [["/arca-internal-probe"]],
-            "includeInternal: true must list a container labelled com.arca.internal=true"
+            Self.names(of: shown),
+            ["/arca-internal-probe", "/plain-probe"],
+            "includeInternal: true must list both containers, the labelled one included"
         )
 
         let hidden = try await manager.listContainers(all: true, includeInternal: false)
-        XCTAssertTrue(
-            hidden.isEmpty,
-            "includeInternal: false must hide it; got \(hidden.map(\.names))"
+        XCTAssertEqual(
+            Self.names(of: hidden),
+            ["/plain-probe"],
+            "includeInternal: false must hide the internal container and keep the plain one"
         )
     }
 
-    /// A `ContainerManager` over a throwaway state root whose StateStore already
-    /// holds one container labelled `com.arca.internal=true`.
+    /// Container names in a stable order. `listContainers` maps over
+    /// `containers.values`, and a Dictionary's iteration order is not
+    /// guaranteed, so an order-sensitive assertion would flake.
+    private static func names(of containers: [ContainerSummary]) -> [String] {
+        containers.flatMap(\.names).sorted()
+    }
+
+    /// One container to seed into the StateStore before the manager restores.
+    private struct Seed {
+        let name: String
+        let labels: [String: String]
+
+        /// The character the 64-character Docker ID is built from. Distinct per
+        /// seed: `loadPersistedState()` derives the native ID from the first 32
+        /// characters, and two containers sharing a native ID would overwrite
+        /// each other in `reverseMapping`.
+        let idCharacter: Character
+    }
+
+    /// A `ContainerManager` over a throwaway state root whose StateStore holds
+    /// one container labelled `com.arca.internal=true` and one with no labels at
+    /// all. The unlabelled one is what makes the negative case meaningful: it is
+    /// the container that must survive `includeInternal: false`.
     ///
-    /// The container is seeded through `StateStore.saveContainer` and read back
-    /// by `loadPersistedState()` -- the same pair the daemon uses across a
-    /// restart -- rather than by writing into `containers` through a test-only
-    /// setter, so what the test exercises is the restore path itself.
+    /// Containers are seeded through `StateStore.saveContainer` and read back by
+    /// `loadPersistedState()` -- the same pair the daemon uses across a restart
+    /// -- rather than by writing into `containers` through a test-only setter,
+    /// so what the test exercises is the restore path itself.
     ///
     /// Paths come from `EnginePaths`, the derivation `arca-engine` calls, for
     /// the reason `TestSupport` gives: a copy of those `appendingPathComponent`
     /// lines makes the test a replica of the wiring rather than the wiring.
-    private static func managerWithInternalContainer(named name: String) async throws -> ContainerManager {
+    private static func seededManager() async throws -> ContainerManager {
         let logger = Logger(label: "arca-engine-tests")
         let paths = EnginePaths(
             stateRoot: URL(fileURLWithPath: NSTemporaryDirectory())
@@ -63,35 +94,43 @@ final class ListFilterTests: XCTestCase {
         )
 
         let stateStore = try StateStore(path: paths.stateDatabase.path, logger: logger)
-
-        // Docker IDs are 64 characters; loadPersistedState() derives the native
-        // ID from the first 32, and listContainers drops any container whose
-        // reverse mapping is missing, so the length matters.
-        let dockerID = String(repeating: "a", count: 64)
-        let config = ContainerConfiguration(
-            image: "arca/probe:latest",
-            labels: ["com.arca.internal": "true"]
-        )
         let encoder = JSONEncoder()
-        try await stateStore.saveContainer(
-            id: dockerID,
-            name: name,
-            image: "arca/probe:latest",
-            imageID: "sha256:probe",
-            createdAt: Date(),
-            status: "exited",
-            running: false,
-            paused: false,
-            restarting: false,
-            pid: 0,
-            exitCode: 0,
-            startedAt: nil,
-            finishedAt: nil,
-            stoppedByUser: false,
-            entrypoint: nil,
-            configJSON: String(decoding: try encoder.encode(config), as: UTF8.self),
-            hostConfigJSON: String(decoding: try encoder.encode(HostConfig()), as: UTF8.self)
-        )
+
+        let seeds = [
+            Seed(
+                name: "arca-internal-probe",
+                labels: ["com.arca.internal": "true"],
+                idCharacter: "a"
+            ),
+            Seed(name: "plain-probe", labels: [:], idCharacter: "b")
+        ]
+
+        for seed in seeds {
+            let config = ContainerConfiguration(image: "arca/probe:latest", labels: seed.labels)
+
+            // Docker IDs are 64 characters. listContainers drops any container
+            // whose reverse mapping is missing, and that mapping is keyed on the
+            // first 32, so the length is load-bearing rather than cosmetic.
+            try await stateStore.saveContainer(
+                id: String(repeating: String(seed.idCharacter), count: 64),
+                name: seed.name,
+                image: "arca/probe:latest",
+                imageID: "sha256:probe",
+                createdAt: Date(),
+                status: "exited",
+                running: false,
+                paused: false,
+                restarting: false,
+                pid: 0,
+                exitCode: 0,
+                startedAt: nil,
+                finishedAt: nil,
+                stoppedByUser: false,
+                entrypoint: nil,
+                configJSON: String(decoding: try encoder.encode(config), as: UTF8.self),
+                hostConfigJSON: String(decoding: try encoder.encode(HostConfig()), as: UTF8.self)
+            )
+        }
 
         return ContainerManager(
             imageManager: try ImageManager(logger: logger, imageStorePath: paths.imageStoreRoot),

--- a/Tests/ArcaEngineTests/ListFilterTests.swift
+++ b/Tests/ArcaEngineTests/ListFilterTests.swift
@@ -54,6 +54,63 @@ final class ListFilterTests: XCTestCase {
         )
     }
 
+    /// The network half of the same rule. `listNetworks()` swallowed a
+    /// WireGuard-backend failure with `try?` and returned the networks it had
+    /// managed to collect, so a backend that could not answer read to gascan as
+    /// a host with no bridge networks -- the answer that hides a leak instead of
+    /// reporting one.
+    ///
+    /// Two-sided for the reason the container test above is. Asserting only
+    /// that the signature says `throws` would pass against the unfixed body the
+    /// moment someone wrote `throws` without deleting the `try?`, and asserting
+    /// only that the failing lister throws would pass against a `listNetworks()`
+    /// that threw no matter what. Both mutations were run against this test, and
+    /// `swift test --filter ArcaEngineTests` reported `Executed 37 tests, with 1
+    /// failure` for each:
+    ///
+    /// - the append put back to `if let wgNetworks = try? await
+    ///   lister.listNetworks()` -> `listNetworks() returned 0 networks instead
+    ///   of reporting the backend failure`
+    /// - `throw NetworkManagerError.networkNotFound(...)` as the first statement
+    ///   of `listNetworks()` -> `caught error: "network guard-proving mutation
+    ///   not found"`
+    func testListNetworksReportsABackendFailureRatherThanAShortList() async throws {
+        let failing = SandboxEngineService.forTesting().networkManager
+        await failing.setBridgeNetworkLister(StubBridgeLister.failing)
+
+        do {
+            let swallowed = try await failing.listNetworks()
+            XCTFail(
+                "listNetworks() returned \(swallowed.count) networks instead of "
+                    + "reporting the backend failure"
+            )
+        } catch is BridgeBackendUnreachable {
+            // The backend's own error reached the caller, which is the point.
+        }
+
+        // The other side: the same seam, a lister that answers. Without this,
+        // a `listNetworks()` that threw no matter what would pass the half above.
+        let working = SandboxEngineService.forTesting().networkManager
+        await working.setBridgeNetworkLister(StubBridgeLister.listing([Self.probeNetwork]))
+
+        let networks = try await working.listNetworks()
+        XCTAssertEqual(
+            networks.map(\.name),
+            ["probe-bridge"],
+            "listNetworks() must return what the bridge lister reports"
+        )
+    }
+
+    /// The one bridge network the succeeding half of the test above expects
+    /// back, so the assertion is an equality rather than a non-emptiness check.
+    private static let probeNetwork = NetworkMetadata(
+        id: String(repeating: "c", count: 64),
+        name: "probe-bridge",
+        driver: "bridge",
+        subnet: "172.18.0.0/16",
+        gateway: "172.18.0.1"
+    )
+
     /// Container names in a stable order. `listContainers` maps over
     /// `containers.values`, and a Dictionary's iteration order is not
     /// guaranteed, so an order-sensitive assertion would flake.
@@ -140,5 +197,36 @@ final class ListFilterTests: XCTestCase {
             stateStore: stateStore,
             logger: logger
         )
+    }
+}
+
+/// The error a failing bridge backend reports.
+///
+/// At file scope, not nested inside `ListFilterTests`, and not nested inside
+/// `StubBridgeLister` either. MEASURED: nested, `catch is
+/// StubBridgeLister.BackendUnreachable` crashed the test binary --
+/// `swift test --filter ArcaEngineTests` reported `exited with unexpected
+/// signal code 11`, and driving the one test straight through `xctest` exited
+/// 139 on three runs out of three, faulting in `lookUpImpOrForward` in libobjc
+/// reached from that `catch` (`ListFilterTests.swift:82:17` in the backtrace).
+/// Moving these two declarations out, with nothing else changed, made the same
+/// test pass.
+struct BridgeBackendUnreachable: Error {}
+
+/// A bridge-network source that either fails or answers. This is the seam the
+/// network test needs and the container tests did not: `NetworkManager`
+/// populates its real backend only inside `initialize()`, which also creates the
+/// default `host` network over vmnet and so cannot run in a unit test.
+struct StubBridgeLister: BridgeNetworkLister {
+    let result: Result<[NetworkMetadata], BridgeBackendUnreachable>
+
+    static let failing = StubBridgeLister(result: .failure(BridgeBackendUnreachable()))
+
+    static func listing(_ networks: [NetworkMetadata]) -> StubBridgeLister {
+        StubBridgeLister(result: .success(networks))
+    }
+
+    func listNetworks() async throws -> [NetworkMetadata] {
+        try result.get()
     }
 }

--- a/Tests/ArcaEngineTests/ListResourcesTests.swift
+++ b/Tests/ArcaEngineTests/ListResourcesTests.swift
@@ -7,8 +7,10 @@ final class ListResourcesTests: XCTestCase {
     /// An empty `ResourceList` is not an error arm -- it is a confident report
     /// of a clean host, and this build cannot earn it.
     ///
-    /// The assertion that matters is the negative one, for the same reason as
-    /// `InspectTests.testInspectRefusesToReportAbsenceItCannotObserve`. The
+    /// The assertion that matters is the negative one, for the reason
+    /// `InspectTests.testAbsentIsAnsweredOnlyForAnIdTheLoadedStateDoesNotHold`
+    /// now states from the other side: an emptiness is only an observation when
+    /// the thing reporting it can be shown to see a non-empty case too. The
     /// version this replaces asserted `list.resources.isEmpty` against a
     /// service whose three managers are empty under every input; it would have
     /// passed against a hardcoded empty list with ContainerBridge deleted.

--- a/Tests/ArcaEngineTests/ListResourcesTests.swift
+++ b/Tests/ArcaEngineTests/ListResourcesTests.swift
@@ -15,15 +15,24 @@ final class ListResourcesTests: XCTestCase {
     ///
     /// **Unfiltered, and that is the point of this test.** Every other
     /// assertion in this file narrows to one kind first, and a per-kind
-    /// assertion cannot see a walk that stops early. MEASURED: with
+    /// assertion cannot see a walk that stops early. The mutation that shows it
+    /// is
     ///
     ///     if resources.count >= 3 { return resources }
     ///
-    /// after the container loop, an engine holding three or more containers
-    /// reports no volumes and no networks at all -- the silently incomplete list
-    /// `listResources`' own doc comment calls worse than no list -- and the
-    /// suite stayed green at `Executed 75 tests, with 0 failures`. Comparing
-    /// against a list holding every kind is what closes that: a walk that stops
+    /// after the container loop, which makes an engine holding three or more
+    /// containers report no volumes and no networks at all -- the silently
+    /// incomplete list `listResources`' own doc comment calls worse than no
+    /// list.
+    ///
+    /// MEASURED twice with `swift test --filter ArcaEngineTests`, and the two
+    /// results are the reason this test has its present shape. Against the
+    /// per-kind assertions this test carried **before it was widened**, that
+    /// mutation left `Executed 75 tests, with 0 failures`: nothing in the suite
+    /// saw it. Against the assertion **below**, the same mutation reports
+    /// `Executed 75 tests, with 1 failure` -- this test, its actual list holding
+    /// the three containers and neither the volume nor the network. Comparing
+    /// against a list holding every kind is what closed that: a walk that stops
     /// after any source fails here, whichever source it was.
     ///
     /// **Five resources, three kinds, mixed ownership.** This is also the
@@ -135,17 +144,19 @@ final class ListResourcesTests: XCTestCase {
     /// The volume and network halves of the same rule, read back through the
     /// real path with **nothing installed**.
     ///
-    /// Two of each kind, one labelled and one not, for the reason the container
-    /// test seeds three: a list that drops the unlabelled resources and a list
-    /// that drops the kind entirely are different regressions and must produce
-    /// different failures.
+    /// Two of each kind, one labelled and one not, for the reason the all-kinds
+    /// test above seeds three containers: a list that drops the unlabelled
+    /// resources and a list that drops the kind entirely are different
+    /// regressions and must produce different failures. That test spans the
+    /// kinds; this one goes deeper within two of them.
     ///
     /// Nothing is installed on `NetworkManager` here, deliberately. Task 3's
     /// review measured that a stub-driven test stays green through the mutation
     /// that matters -- dropping the production default while leaving the
-    /// installed-stub path intact -- so the network half of this method is only
-    /// proved by a test that runs the manager's own `NullDriverNetworks` over
-    /// the store the seed was written to.
+    /// installed-stub path intact -- so the network half of this method is
+    /// proved only by a test that runs the manager's own `NullDriverNetworks`
+    /// over the store the seed was written to. This is one such test; the
+    /// all-kinds test above installs nothing either, and is the other.
     func testALabelledAndAnUnlabelledVolumeAndNetworkAreAllReported() async throws {
         let managers = try Self.managers()
         try await Self.seedVolume(
@@ -226,8 +237,9 @@ final class ListResourcesTests: XCTestCase {
     /// Driven through `setBridgeNetworkLister`, the seam Task 3 built so a
     /// backend can fail without standing in for the rest of
     /// `WireGuardNetworkBackend`. What this seam cannot prove is that the
-    /// production source is wired up at all; that is the previous test's job,
-    /// and the two are guard-proved against different mutations.
+    /// production source is wired up at all; that is the job of the two tests
+    /// above, which install nothing, and all three are guard-proved against
+    /// different mutations.
     func testANetworkBackendFailureIsTheErrorArmRatherThanAShortList() async throws {
         let managers = try Self.managers()
         try await Self.seedContainer(

--- a/Tests/ArcaEngineTests/ListResourcesTests.swift
+++ b/Tests/ArcaEngineTests/ListResourcesTests.swift
@@ -10,21 +10,33 @@ final class ListResourcesTests: XCTestCase {
     // MARK: - Every resource the engine holds
 
     /// The contract is "every resource the engine holds, labelled or not"
-    /// (engine.proto:387-391), asserted against the two kinds of container an
-    /// engine-side filter would drop: one labelled `com.arca.internal=true` and
-    /// one carrying no labels at all.
+    /// (engine.proto:387-391), asserted against **the whole response** -- all
+    /// three kinds in one list, not a projection of it.
     ///
-    /// **Three containers, and the assertion is the whole list.** This is the
+    /// **Unfiltered, and that is the point of this test.** Every other
+    /// assertion in this file narrows to one kind first, and a per-kind
+    /// assertion cannot see a walk that stops early. MEASURED: with
+    ///
+    ///     if resources.count >= 3 { return resources }
+    ///
+    /// after the container loop, an engine holding three or more containers
+    /// reports no volumes and no networks at all -- the silently incomplete list
+    /// `listResources`' own doc comment calls worse than no list -- and the
+    /// suite stayed green at `Executed 75 tests, with 0 failures`. Comparing
+    /// against a list holding every kind is what closes that: a walk that stops
+    /// after any source fails here, whichever source it was.
+    ///
+    /// **Five resources, three kinds, mixed ownership.** This is also the
     /// eighth-finding shape: a membership or non-emptiness assertion cannot tell
     /// "dropped the right one" from "dropped everything", which is the defect
     /// `XCTAssertTrue(hidden.isEmpty)` shipped in Task 2. Comparing the full
     /// sorted list against a list written out in full fails differently for the
-    /// two -- an `includeInternal: false` regression leaves the other two
+    /// two -- an `includeInternal: false` regression leaves the other four
     /// standing, and a walk that collected nothing leaves none.
     ///
-    /// The unlabelled container comes back with `owner` unset, which is how a
-    /// consumer sees a resource it does not own (engine.proto:169-173). That is
-    /// deliberately not `inspect`'s answer for the same row -- there an
+    /// The internal and unlabelled resources come back with `owner` unset, which
+    /// is how a consumer sees a resource it does not own (engine.proto:169-173).
+    /// That is deliberately not `inspect`'s answer for the same row -- there an
     /// unlabelled container is `foreign_resource_refused`
     /// (`InspectTests.testAnUnlabelledContainerIsRefusedAsForeignRatherThanReturnedWithoutAnOwner`).
     /// The two methods answer different questions and the difference is load-bearing.
@@ -34,7 +46,7 @@ final class ListResourcesTests: XCTestCase {
     /// `containerResourceName` is on the call path and not merely unit-tested
     /// below: an unstripped slash makes every owned container look unrelated to
     /// its sandbox and drift detection silently sees nothing.
-    func testEveryContainerIsReportedIncludingTheInternalAndTheUnlabelledOne() async throws {
+    func testTheWholeResponseHoldsEveryKindIncludingInternalAndUnlabelledResources() async throws {
         let managers = try Self.managers()
         try await Self.seedContainer(
             into: managers.stateStore,
@@ -54,12 +66,27 @@ final class ListResourcesTests: XCTestCase {
             name: Self.unlabelledContainerName,
             labels: [:]
         )
+        // One of each remaining kind, so the assertion below spans all three.
+        // Labelled volume, unlabelled network: the owner field is exercised in
+        // both directions across kinds rather than only across containers.
+        try await Self.seedVolume(
+            into: managers.stateStore,
+            name: Self.ownedVolumeName,
+            labels: SandboxIdentity.labels(from: Self.ownerLabels)
+        )
+        try await Self.seedNetwork(
+            into: managers.stateStore,
+            id: Self.foreignNetworkID,
+            name: Self.foreignNetworkName,
+            labels: [:]
+        )
         try await managers.containerManager.loadPersistedState()
+        try await managers.volumeManager.initialize()
 
         let resources = try await Self.listedResources(managers)
 
         XCTAssertEqual(
-            Self.sorted(resources.filter { $0.identity.kind == .container }),
+            Self.sorted(resources),
             Self.sorted([
                 Arca_Engine_V1_Resource.with {
                     $0.identity = Arca_Engine_V1_ResourceIdentity.with {
@@ -83,11 +110,25 @@ final class ListResourcesTests: XCTestCase {
                         $0.name = Self.unlabelledContainerName
                     }
                 },
+                Arca_Engine_V1_Resource.with {
+                    $0.identity = Arca_Engine_V1_ResourceIdentity.with {
+                        $0.kind = .volume
+                        $0.name = Self.ownedVolumeName
+                    }
+                    $0.owner = Self.ownerLabels
+                },
+                Arca_Engine_V1_Resource.with {
+                    $0.identity = Arca_Engine_V1_ResourceIdentity.with {
+                        $0.kind = .network
+                        $0.name = Self.foreignNetworkName
+                    }
+                },
             ]),
-            "all three seeded containers must be reported: the owned one, the "
-                + "internal one, and the unlabelled one. Dropping only the internal "
-                + "row is an includeInternal regression; dropping all three is a "
-                + "walk that reads no containers, and these are not the same defect"
+            "the response must hold all five seeded resources across all three "
+                + "kinds. Dropping only the internal container is an includeInternal "
+                + "regression; dropping every volume and network is a walk that "
+                + "stopped after the containers; dropping all five is a walk that "
+                + "read nothing, and these are three different defects"
         )
     }
 
@@ -232,7 +273,7 @@ final class ListResourcesTests: XCTestCase {
                 + "the consumer looking for a resource that is not the problem"
         )
         XCTAssertEqual(
-            error.message, "NetworkListerUnreachable()",
+            error.message, "the bridge network source could not be reached",
             "the backend's own failure is carried out verbatim rather than replaced "
                 + "with prose that hides which source could not answer"
         )
@@ -493,6 +534,14 @@ final class ListResourcesTests: XCTestCase {
     }
 
     /// The resources arm, or a failure naming the arm that came back instead.
+    ///
+    /// Calls the context-free `listResources(request:)` overload rather than the
+    /// protocol-conforming `listResources(request:context:)`, as every direct
+    /// call in this file does: grpc-swift's `GRPCAsyncServerCallContext` has no
+    /// public initialiser reachable from outside the GRPC module, so a test
+    /// target cannot construct one. See the note on the `create(request:)`
+    /// overload in `SandboxEngineService.swift`. The forwarding overload is
+    /// therefore driven only by gascan's live tier, over a real socket.
     private static func listedResources(
         _ managers: EngineManagers,
         file: StaticString = #filePath,

--- a/Tests/ArcaEngineTests/ListResourcesTests.swift
+++ b/Tests/ArcaEngineTests/ListResourcesTests.swift
@@ -1,38 +1,299 @@
+import ContainerBridge
+import Foundation
 import GRPC
+import Logging
 import SandboxEngineProto
 import XCTest
 @testable import ArcaEngine
 
 final class ListResourcesTests: XCTestCase {
-    /// An empty `ResourceList` is not an error arm -- it is a confident report
-    /// of a clean host, and this build cannot earn it.
-    ///
-    /// The assertion that matters is the negative one, for the reason
-    /// `InspectTests.testAbsentIsAnsweredOnlyForAnIdTheLoadedStateDoesNotHold`
-    /// now states from the other side: an emptiness is only an observation when
-    /// the thing reporting it can be shown to see a non-empty case too. The
-    /// version this replaces asserted `list.resources.isEmpty` against a
-    /// service whose three managers are empty under every input; it would have
-    /// passed against a hardcoded empty list with ContainerBridge deleted.
-    /// gascan's drift and leak detection reads this method, and a clean report
-    /// from a host holding resources is the failure it cannot see.
-    ///
-    /// Calls the context-free `listResources(request:)` overload rather than
-    /// the protocol-conforming `listResources(request:context:)`:
-    /// grpc-swift's `GRPCAsyncServerCallContext` has no public initialiser,
-    /// so a test target cannot construct one. See SandboxEngineService.swift.
-    func testListResourcesRefusesToReportAnEmptinessItCannotObserve() async throws {
-        let response = await SandboxEngineService.forTesting()
-            .listResources(request: .init())
+    // MARK: - Every resource the engine holds
 
-        if case .resources = response.outcome {
-            return XCTFail("a build that loads no state must not report a resource list")
+    /// The contract is "every resource the engine holds, labelled or not"
+    /// (engine.proto:387-391), asserted against the two kinds of container an
+    /// engine-side filter would drop: one labelled `com.arca.internal=true` and
+    /// one carrying no labels at all.
+    ///
+    /// **Three containers, and the assertion is the whole list.** This is the
+    /// eighth-finding shape: a membership or non-emptiness assertion cannot tell
+    /// "dropped the right one" from "dropped everything", which is the defect
+    /// `XCTAssertTrue(hidden.isEmpty)` shipped in Task 2. Comparing the full
+    /// sorted list against a list written out in full fails differently for the
+    /// two -- an `includeInternal: false` regression leaves the other two
+    /// standing, and a walk that collected nothing leaves none.
+    ///
+    /// The unlabelled container comes back with `owner` unset, which is how a
+    /// consumer sees a resource it does not own (engine.proto:169-173). That is
+    /// deliberately not `inspect`'s answer for the same row -- there an
+    /// unlabelled container is `foreign_resource_refused`
+    /// (`InspectTests.testAnUnlabelledContainerIsRefusedAsForeignRatherThanReturnedWithoutAnOwner`).
+    /// The two methods answer different questions and the difference is load-bearing.
+    ///
+    /// Names are asserted bare. ContainerBridge stores them slashed
+    /// (`ContainerManager.swift:788`), so this is also the end-to-end proof that
+    /// `containerResourceName` is on the call path and not merely unit-tested
+    /// below: an unstripped slash makes every owned container look unrelated to
+    /// its sandbox and drift detection silently sees nothing.
+    func testEveryContainerIsReportedIncludingTheInternalAndTheUnlabelledOne() async throws {
+        let managers = try Self.managers()
+        try await Self.seedContainer(
+            into: managers.stateStore,
+            id: Self.ownedContainerID,
+            name: Self.ownedSandboxID,
+            labels: SandboxIdentity.labels(from: Self.ownerLabels)
+        )
+        try await Self.seedContainer(
+            into: managers.stateStore,
+            id: Self.internalContainerID,
+            name: Self.internalContainerName,
+            labels: ["com.arca.internal": "true"]
+        )
+        try await Self.seedContainer(
+            into: managers.stateStore,
+            id: Self.unlabelledContainerID,
+            name: Self.unlabelledContainerName,
+            labels: [:]
+        )
+        try await managers.containerManager.loadPersistedState()
+
+        let resources = try await Self.listedResources(managers)
+
+        XCTAssertEqual(
+            Self.sorted(resources.filter { $0.identity.kind == .container }),
+            Self.sorted([
+                Arca_Engine_V1_Resource.with {
+                    $0.identity = Arca_Engine_V1_ResourceIdentity.with {
+                        $0.kind = .container
+                        $0.name = Self.ownedSandboxID
+                    }
+                    $0.owner = Self.ownerLabels
+                },
+                // No `owner` assigned: an internal container carries no gascan
+                // owner labels, and the consumer must be told that rather than
+                // not told about the container.
+                Arca_Engine_V1_Resource.with {
+                    $0.identity = Arca_Engine_V1_ResourceIdentity.with {
+                        $0.kind = .container
+                        $0.name = Self.internalContainerName
+                    }
+                },
+                Arca_Engine_V1_Resource.with {
+                    $0.identity = Arca_Engine_V1_ResourceIdentity.with {
+                        $0.kind = .container
+                        $0.name = Self.unlabelledContainerName
+                    }
+                },
+            ]),
+            "all three seeded containers must be reported: the owned one, the "
+                + "internal one, and the unlabelled one. Dropping only the internal "
+                + "row is an includeInternal regression; dropping all three is a "
+                + "walk that reads no containers, and these are not the same defect"
+        )
+    }
+
+    /// The volume and network halves of the same rule, read back through the
+    /// real path with **nothing installed**.
+    ///
+    /// Two of each kind, one labelled and one not, for the reason the container
+    /// test seeds three: a list that drops the unlabelled resources and a list
+    /// that drops the kind entirely are different regressions and must produce
+    /// different failures.
+    ///
+    /// Nothing is installed on `NetworkManager` here, deliberately. Task 3's
+    /// review measured that a stub-driven test stays green through the mutation
+    /// that matters -- dropping the production default while leaving the
+    /// installed-stub path intact -- so the network half of this method is only
+    /// proved by a test that runs the manager's own `NullDriverNetworks` over
+    /// the store the seed was written to.
+    func testALabelledAndAnUnlabelledVolumeAndNetworkAreAllReported() async throws {
+        let managers = try Self.managers()
+        try await Self.seedVolume(
+            into: managers.stateStore,
+            name: Self.ownedVolumeName,
+            labels: SandboxIdentity.labels(from: Self.ownerLabels)
+        )
+        try await Self.seedVolume(
+            into: managers.stateStore, name: Self.foreignVolumeName, labels: [:]
+        )
+        try await Self.seedNetwork(
+            into: managers.stateStore,
+            id: Self.ownedNetworkID,
+            name: Self.ownedNetworkName,
+            labels: SandboxIdentity.labels(from: Self.ownerLabels)
+        )
+        try await Self.seedNetwork(
+            into: managers.stateStore,
+            id: Self.foreignNetworkID,
+            name: Self.foreignNetworkName,
+            labels: [:]
+        )
+        try await managers.volumeManager.initialize()
+
+        let resources = try await Self.listedResources(managers)
+
+        XCTAssertEqual(
+            Self.sorted(resources.filter { $0.identity.kind == .volume }),
+            Self.sorted([
+                Arca_Engine_V1_Resource.with {
+                    $0.identity = Arca_Engine_V1_ResourceIdentity.with {
+                        $0.kind = .volume
+                        $0.name = Self.ownedVolumeName
+                    }
+                    $0.owner = Self.ownerLabels
+                },
+                Arca_Engine_V1_Resource.with {
+                    $0.identity = Arca_Engine_V1_ResourceIdentity.with {
+                        $0.kind = .volume
+                        $0.name = Self.foreignVolumeName
+                    }
+                },
+            ]),
+            "both seeded volumes must be reported, the unlabelled one with no owner"
+        )
+        XCTAssertEqual(
+            Self.sorted(resources.filter { $0.identity.kind == .network }),
+            Self.sorted([
+                Arca_Engine_V1_Resource.with {
+                    $0.identity = Arca_Engine_V1_ResourceIdentity.with {
+                        $0.kind = .network
+                        $0.name = Self.ownedNetworkName
+                    }
+                    $0.owner = Self.ownerLabels
+                },
+                Arca_Engine_V1_Resource.with {
+                    $0.identity = Arca_Engine_V1_ResourceIdentity.with {
+                        $0.kind = .network
+                        $0.name = Self.foreignNetworkName
+                    }
+                },
+            ]),
+            "both seeded networks must be reported, read through the manager's own "
+                + "source over the real store rather than through an installed stub"
+        )
+    }
+
+    // MARK: - The error arm, and the empty arm it must not be confused with
+
+    /// A network-backend failure is the error arm, not a shorter list.
+    ///
+    /// Containers and volumes are seeded and **would** have been collected, so
+    /// the answer this refuses is not "nothing found" -- it is the partial
+    /// answer, the one that reports a host holding two containers and two
+    /// volumes and no networks at all. gascan has no way to see a silently short
+    /// list; it maps a thrown failure to `command_io` and can act on that.
+    ///
+    /// Driven through `setBridgeNetworkLister`, the seam Task 3 built so a
+    /// backend can fail without standing in for the rest of
+    /// `WireGuardNetworkBackend`. What this seam cannot prove is that the
+    /// production source is wired up at all; that is the previous test's job,
+    /// and the two are guard-proved against different mutations.
+    func testANetworkBackendFailureIsTheErrorArmRatherThanAShortList() async throws {
+        let managers = try Self.managers()
+        try await Self.seedContainer(
+            into: managers.stateStore,
+            id: Self.ownedContainerID,
+            name: Self.ownedSandboxID,
+            labels: SandboxIdentity.labels(from: Self.ownerLabels)
+        )
+        try await Self.seedContainer(
+            into: managers.stateStore,
+            id: Self.unlabelledContainerID,
+            name: Self.unlabelledContainerName,
+            labels: [:]
+        )
+        try await Self.seedVolume(
+            into: managers.stateStore,
+            name: Self.ownedVolumeName,
+            labels: SandboxIdentity.labels(from: Self.ownerLabels)
+        )
+        try await Self.seedVolume(
+            into: managers.stateStore, name: Self.foreignVolumeName, labels: [:]
+        )
+        try await managers.containerManager.loadPersistedState()
+        try await managers.volumeManager.initialize()
+        await managers.networkManager.setBridgeNetworkLister(StubNetworkLister.failing)
+
+        let response = await managers.makeService().listResources(request: .init())
+
+        if case .resources(let list) = response.outcome {
+            return XCTFail(
+                "a backend that cannot list networks must not be answered with a "
+                    + "list of \(list.resources.count) resources holding no networks: "
+                    + "\(list.resources.map(\.identity.name))"
+            )
         }
         guard case .error(let error) = response.outcome else {
             return XCTFail("ListResources must answer: \(String(describing: response.outcome))")
         }
-        XCTAssertEqual(error.code, "unsupported_capability")
+        XCTAssertEqual(error.code, "command_io")
+        XCTAssertEqual(
+            error.resource, "",
+            "the failure is not about one named resource; a name here would send "
+                + "the consumer looking for a resource that is not the problem"
+        )
+        XCTAssertEqual(
+            error.message, "NetworkListerUnreachable()",
+            "the backend's own failure is carried out verbatim rather than replaced "
+                + "with prose that hides which source could not answer"
+        )
     }
+
+    /// An engine holding nothing answers an empty list, and the failing engine
+    /// beside it answers the error arm -- over state that is empty in both.
+    ///
+    /// The two arms are asserted in one test on purpose, because the property is
+    /// that they are *distinguishable* and no single-arm assertion states it. An
+    /// empty `ResourceList` is a confident report of a clean host, which is the
+    /// report that hides a leak, so an implementation that answered emptiness
+    /// where it could not answer at all would be the whole defect this method
+    /// exists to prevent -- and against two engines that hold identically
+    /// nothing, only the arm tells them apart.
+    ///
+    /// This replaces an earlier test that asserted `unsupported_capability` and
+    /// then, before that, `list.resources.isEmpty` against a service whose three
+    /// managers were empty under every input.
+    func testAnEngineHoldingNothingAnswersAnEmptyListAndAFailingOneAnswersTheErrorArm() async throws {
+        let clean = try Self.managers()
+        let cleanResponse = await clean.makeService().listResources(request: .init())
+
+        guard case .resources(let list) = cleanResponse.outcome else {
+            return XCTFail(
+                "an engine that holds nothing has observed a clean host and must say "
+                    + "so: \(String(describing: cleanResponse.outcome))"
+            )
+        }
+        XCTAssertEqual(
+            list.resources, [],
+            "a host holding nothing reports no resources, not an error"
+        )
+
+        // The same emptiness, one source unable to answer. Nothing is seeded
+        // here either, so the ONLY difference between the two responses is
+        // whether the engine could look.
+        let failing = try Self.managers()
+        await failing.networkManager.setBridgeNetworkLister(StubNetworkLister.failing)
+        let failingResponse = await failing.makeService().listResources(request: .init())
+
+        if case .resources(let reported) = failingResponse.outcome {
+            return XCTFail(
+                "an engine that could not list networks must not answer the same "
+                    + "empty list a clean engine answers: "
+                    + "\(reported.resources.count) resources"
+            )
+        }
+        guard case .error(let error) = failingResponse.outcome else {
+            return XCTFail(
+                "ListResources must answer: \(String(describing: failingResponse.outcome))"
+            )
+        }
+        XCTAssertEqual(
+            error.code, "command_io",
+            "\"I could not look\" and \"I looked and there is nothing\" are different "
+                + "answers, and a consumer's leak detection acts on the difference"
+        )
+    }
+
+    // MARK: - The mapping helpers, driven directly
 
     /// Unlabelled resources are NOT filtered out. gascan's drift detection
     /// depends on seeing them, and hiding them engine-side would break it
@@ -89,5 +350,180 @@ final class ListResourcesTests: XCTestCase {
 
     func testContainerResourceNameStripsOnlyOneLeadingSlash() {
         XCTAssertEqual(containerResourceName(names: ["//x"], id: "abc"), "/x")
+    }
+
+    // MARK: - Fixtures
+
+    /// Container ids are 64 characters and must not share their first 32:
+    /// `loadPersistedState()` derives the native id from `String(id.prefix(32))`
+    /// and keys `reverseMapping` on it, so a collision makes one seed vanish.
+    private static let ownedContainerID = String(repeating: "a", count: 64)
+    private static let internalContainerID = String(repeating: "b", count: 64)
+    private static let unlabelledContainerID = String(repeating: "c", count: 64)
+
+    private static let ownedNetworkID = String(repeating: "d", count: 64)
+    private static let foreignNetworkID = String(repeating: "e", count: 64)
+
+    /// Every name below is asserted somewhere in this file, and no one of them
+    /// is a substring of another. Finding #7 shipped a dead conjunct that way:
+    /// an assertion satisfied by a substring of a string another assertion
+    /// already pinned proves nothing on its own.
+    ///
+    /// Each container name contains a hyphen, which keeps `resolveContainerID`
+    /// from reading it as a hex short id (`ContainerManager.swift:2005-2023`).
+    private static let ownedSandboxID = "web-a1b2c3d4e5f6"
+    private static let internalContainerName = "helper-b1c2d3e4f5a6"
+    private static let unlabelledContainerName = "foreign-c1d2e3f4a5b6"
+
+    private static let ownedVolumeName = "gascan-store-d1e2f3a4b5c6"
+    private static let foreignVolumeName = "unclaimed-e1f2a3b4c5d6"
+    private static let ownedNetworkName = "gascan-bridge-f1a2b3c4d5e6"
+    private static let foreignNetworkName = "unclaimed-a2b3c4d5e6f1"
+
+    private static let workspaceImage =
+        "ghcr.io/liquescent-development/gascan/workspace@sha256:" + String(repeating: "1", count: 64)
+
+    private static let ownerLabels = Arca_Engine_V1_OwnerLabels.with {
+        $0.managedBy = "gascan"
+        $0.sandboxID = ownedSandboxID
+    }
+
+    /// The engine's own managers over a throwaway state root -- the production
+    /// factory, so what these tests list is what `arca-engine` serves.
+    ///
+    /// `wireCollaborators()` is deliberately not called. `ListResources` reads
+    /// three list calls and none of them consults either collaborator:
+    /// `listContainers` builds its summaries without `NetworkSettings` (that is
+    /// `ContainerManager.swift:826`, on the `getContainer` path `Inspect` uses),
+    /// `listVolumes` reads `VolumeManager`'s own dictionary, and `listNetworks`
+    /// reads `NetworkManager`'s own sources. Wiring them would add a dependency
+    /// these assertions cannot see, which is the kind of fixture step that
+    /// survives long after the thing it was for. What the collaborators cost
+    /// when unset is asserted in `EngineManagerWiringTests`.
+    private static func managers() throws -> EngineManagers {
+        try EngineManagers(
+            stateRoot: URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("arca-list-resources-tests-\(UUID().uuidString)"),
+            kernelPath: URL(fileURLWithPath: "/opt/arca/vmlinux"),
+            logLevel: "info",
+            logger: Logger(label: "arca-engine-tests")
+        )
+    }
+
+    /// One container row, through `StateStore` and then `loadPersistedState()`
+    /// -- the restore path the engine itself runs -- rather than through a
+    /// double. `initialize()` is the normal caller and constructs a real
+    /// `VmnetNetwork`, which no test in this target may do.
+    ///
+    /// Labels ride in the config JSON because that is the column the restore
+    /// path decodes them out of (`ContainerManager.swift:329-344`). The image is
+    /// the same digest reference for every row: `ListResources` does not read
+    /// it, and varying it would suggest it did.
+    private static func seedContainer(
+        into store: StateStore,
+        id: String,
+        name: String,
+        labels: [String: String]
+    ) async throws {
+        try await store.saveContainer(
+            id: id,
+            name: name,
+            image: workspaceImage,
+            imageID: "sha256:probe",
+            createdAt: Date(),
+            status: "exited",
+            running: false,
+            paused: false,
+            restarting: false,
+            pid: 0,
+            exitCode: 0,
+            startedAt: nil,
+            finishedAt: Date(),
+            stoppedByUser: false,
+            entrypoint: nil,
+            configJSON: String(
+                decoding: try JSONEncoder().encode(
+                    ContainerConfiguration(image: workspaceImage, labels: labels)
+                ),
+                as: UTF8.self
+            ),
+            hostConfigJSON: String(
+                decoding: try JSONEncoder().encode(HostConfig()), as: UTF8.self
+            )
+        )
+    }
+
+    /// One volume row, through the same `StateStore` write `VolumeManager` makes
+    /// itself, then read back by `VolumeManager.initialize()` -- which creates
+    /// the volumes directory and loads the table, and boots nothing.
+    private static func seedVolume(
+        into store: StateStore, name: String, labels: [String: String]
+    ) async throws {
+        try await store.saveVolume(
+            name: name,
+            driver: "local",
+            format: "ext4",
+            mountpoint: "/dev/null",
+            createdAt: Date(),
+            labelsJSON: String(decoding: try JSONEncoder().encode(labels), as: UTF8.self),
+            optionsJSON: nil
+        )
+    }
+
+    /// One network row, `driver: "null"` -- the call `createNetwork` itself
+    /// makes for that driver, and the rows `NullDriverNetworks` reads. A bridge
+    /// network would need the WireGuard backend `initialize()` builds, and
+    /// `initialize()` also creates the default `host` network over vmnet.
+    private static func seedNetwork(
+        into store: StateStore, id: String, name: String, labels: [String: String]
+    ) async throws {
+        try await store.saveNetwork(
+            id: id,
+            name: name,
+            driver: "null",
+            scope: "local",
+            createdAt: Date(),
+            subnet: "",
+            gateway: "",
+            ipRange: nil,
+            optionsJSON: nil,
+            labelsJSON: String(decoding: try JSONEncoder().encode(labels), as: UTF8.self),
+            isDefault: false
+        )
+    }
+
+    /// The resources arm, or a failure naming the arm that came back instead.
+    private static func listedResources(
+        _ managers: EngineManagers,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws -> [Arca_Engine_V1_Resource] {
+        let response = await managers.makeService().listResources(request: .init())
+        guard case .resources(let list) = response.outcome else {
+            XCTFail(
+                "expected the resources arm: \(String(describing: response.outcome))",
+                file: file, line: line
+            )
+            throw XCTSkip("no resource list to assert on")
+        }
+        return list.resources
+    }
+
+    /// Both sides of every collection assertion go through this.
+    ///
+    /// `ListResources` does not sort, and two of its three sources cannot
+    /// promise an order: `listContainers` and `listVolumes` both map a
+    /// Dictionary's `values`, whose iteration order is seeded per process.
+    /// Comparing raw would be a test that fails on a run rather than on a
+    /// regression. Sorting both sides keeps the assertion a whole-set equality
+    /// -- it still fails when an element is dropped, added, or has the wrong
+    /// owner -- while dropping only the one property the method does not have.
+    private static func sorted(
+        _ resources: [Arca_Engine_V1_Resource]
+    ) -> [Arca_Engine_V1_Resource] {
+        resources.sorted {
+            ($0.identity.kind.rawValue, $0.identity.name)
+                < ($1.identity.kind.rawValue, $1.identity.name)
+        }
     }
 }

--- a/Tests/ArcaEngineTests/OCILayoutFixture.swift
+++ b/Tests/ArcaEngineTests/OCILayoutFixture.swift
@@ -1,0 +1,79 @@
+import ContainerizationOCI
+import CryptoKit
+import Foundation
+
+/// Writes a real OCI image layout to disk: `oci-layout`, `index.json`, and the
+/// `blobs/sha256/<hex>` files the loader reads by digest.
+///
+/// A real layout rather than a stub image manager, because the whole decision
+/// under test is keyed on the digest `loadFromOCILayout` returns. A test that
+/// hands `loadVminit` a digest of its own invention proves the invention.
+///
+/// The structure is the one `~/.arca/vminit` carries -- VERIFIED against it:
+/// `head -c 400 ~/.arca/vminit/index.json` shows a single
+/// `application/vnd.oci.image.manifest.v1+json` descriptor annotated
+/// `org.opencontainers.image.ref.name: arca-vminit:latest`, and
+/// `find ~/.arca/vminit` shows `oci-layout`, `index.json` and three blobs under
+/// `blobs/sha256`. The JSON is encoded from the same `ContainerizationOCI`
+/// types Containerization decodes it with, so the bytes cannot drift from what
+/// the loader expects.
+///
+/// It is around a kilobyte rather than the real image's ~178MB because nothing
+/// in the load path unpacks a layer: `ImageStore.ImportOperation` copies layer
+/// blobs by digest and decodes only the index, the manifest and the config.
+enum OCILayoutFixture {
+    /// Builds a layout at `directory` holding one image under `reference`.
+    ///
+    /// `payload` is the layer's bytes. Two layouts differing only in it get
+    /// different layer digests, and so different manifest and image digests --
+    /// which is how a test spells "the vminit changed".
+    @discardableResult
+    static func write(at directory: URL, reference: String, payload: String) throws -> URL {
+        let blobs = directory.appendingPathComponent("blobs/sha256")
+        try FileManager.default.createDirectory(at: blobs, withIntermediateDirectories: true)
+
+        let encoder = JSONEncoder()
+        let layer = try writeBlob(
+            Data(payload.utf8), mediaType: MediaTypes.imageLayerGzip, into: blobs
+        )
+
+        // architecture and os are read back by the loader, which refuses an
+        // image that names no platform or more than one.
+        let config = ContainerizationOCI.Image(
+            architecture: "arm64",
+            os: "linux",
+            config: ImageConfig(),
+            rootfs: Rootfs(type: "layers", diffIDs: [layer.digest])
+        )
+        let configBlob = try writeBlob(
+            try encoder.encode(config), mediaType: MediaTypes.imageConfig, into: blobs
+        )
+
+        let manifest = Manifest(config: configBlob, layers: [layer])
+        var manifestBlob = try writeBlob(
+            try encoder.encode(manifest), mediaType: MediaTypes.imageManifest, into: blobs
+        )
+        // The annotation, not the blob, is what names the image: the reference
+        // is carried by the index, exactly as the exported vminit layout does.
+        manifestBlob.annotations = ["org.opencontainers.image.ref.name": reference]
+
+        try encoder.encode(Index(manifests: [manifestBlob]))
+            .write(to: directory.appendingPathComponent("index.json"))
+        try Data(#"{"imageLayoutVersion":"1.0.0"}"#.utf8)
+            .write(to: directory.appendingPathComponent("oci-layout"))
+        return directory
+    }
+
+    /// Writes one blob under its own digest and describes it.
+    ///
+    /// The loader verifies every blob it copies against the digest the
+    /// descriptor claims, so the descriptor is derived from the bytes rather
+    /// than stated beside them.
+    private static func writeBlob(
+        _ data: Data, mediaType: String, into blobs: URL
+    ) throws -> Descriptor {
+        let hex = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+        try data.write(to: blobs.appendingPathComponent(hex))
+        return Descriptor(mediaType: mediaType, digest: "sha256:\(hex)", size: Int64(data.count))
+    }
+}

--- a/Tests/ArcaEngineTests/PrepareImageTests.swift
+++ b/Tests/ArcaEngineTests/PrepareImageTests.swift
@@ -1,0 +1,369 @@
+import ContainerBridge
+import Foundation
+import Logging
+import SandboxEngineProto
+import XCTest
+@testable import ArcaEngine
+
+/// `PrepareImage`: hold-or-fail, and never a fetch.
+///
+/// Every test here seeds through the real path -- `loadWorkspaceImages`, the
+/// function `arca-engine image load` calls, over a real `OCILayoutFixture`
+/// layout -- rather than through a stub image manager. The question the method
+/// answers is entirely about what a real `ImageStore` holds, and a stub would
+/// answer it by construction.
+///
+/// **The shape these are built against.** `Ack` carries no payload
+/// (`engine.proto:74`), so a test that asserts "it returned `Ack`" passes
+/// against a method whose whole body is `PrepareImageResponse.with { $0.ok =
+/// Ack() }`. Asserting a success alone therefore proves nothing at all. Every
+/// success assertion below is paired, in the same test, with a request that
+/// must be refused -- so that a body which cannot tell the two apart fails.
+final class PrepareImageTests: XCTestCase {
+    private let logger = Logger(label: "prepare-image-tests")
+
+    /// A workspace image, not `arca-vminit:latest`: this method exists for
+    /// content a consumer pushes, and a test that prepared vminit through it
+    /// would prove the two are interchangeable.
+    private static let reference = "workspace:latest"
+    private static let repository = "workspace"
+
+    // MARK: - Content the engine holds
+
+    /// The success arm, and the discriminating refusal that makes it mean
+    /// something.
+    ///
+    /// The second half is not a bonus assertion -- it is what stops the first
+    /// half passing against a method that looks nothing up. The two requests
+    /// differ in one hex character, both name a repository the store really
+    /// holds, and a body that answers `Ack` unconditionally fails on the second.
+    func testHeldContentIsPreparedAndTheSameRepositoryUnderAnotherDigestIsNot() async throws {
+        let engine = try await preparedEngine()
+
+        let held = await engine.service.prepareImage(request: request(
+            repository: Self.repository, hex: engine.hex
+        ))
+        guard case .ok = held.outcome else {
+            return XCTFail("content the engine holds must be prepared, got \(held.outcome as Any)")
+        }
+
+        let flipped = flipFirstCharacter(of: engine.hex)
+        let absent = await engine.service.prepareImage(request: request(
+            repository: Self.repository, hex: flipped
+        ))
+        guard case .error(let error) = absent.outcome else {
+            return XCTFail("a digest the store does not hold must be refused, got \(absent.outcome as Any)")
+        }
+        XCTAssertEqual(error.code, "not_found")
+        XCTAssertEqual(error.resource, "\(Self.repository)@sha256:\(flipped)")
+        XCTAssertEqual(
+            error.message,
+            "this engine holds no image with that content digest and will not fetch one; "
+                + "load it with 'arca-engine image load --oci-layout <dir>'"
+        )
+    }
+
+    // MARK: - Content the engine does not hold
+
+    /// Absent content is `not_found`, final, and never a fetch.
+    ///
+    /// The request is deliberately shaped like one a registry could serve --
+    /// `docker.io/library/alpine` and a well-formed digest -- because that is
+    /// the frame a caller would send if it expected the engine to go and get
+    /// the content. A `PrepareImage` that fell back to `ImageManager.pullImage`
+    /// fails here: the code would be a pull failure rather than `not_found`,
+    /// or, on a host that could reach the registry, `ok`. This is the structural
+    /// guard against that fallback -- worth more than a comment saying there
+    /// is none.
+    ///
+    /// Asserted field by field on exact equality. `resource` and `message` are
+    /// not interchangeable (`EngineErrors.swift:32-35`), and a transposition
+    /// survives any assertion weaker than this.
+    func testContentTheEngineNeverHeldIsNotFoundAndIsNeverFetched() async throws {
+        let service = SandboxEngineService.forTesting(
+            stateRoot: try temporaryEngineRoot().appendingPathComponent("state"),
+            kernelPath: URL(fileURLWithPath: "/opt/arca/vmlinux")
+        )
+        let hex = String(repeating: "ab", count: 32)
+
+        let response = await service.prepareImage(request: request(
+            repository: "docker.io/library/alpine", hex: hex
+        ))
+
+        guard case .error(let error) = response.outcome else {
+            return XCTFail("absent content must be refused, got \(response.outcome as Any)")
+        }
+        XCTAssertEqual(error.code, "not_found")
+        XCTAssertEqual(error.resource, "docker.io/library/alpine@sha256:\(hex)")
+        XCTAssertEqual(
+            error.message,
+            "this engine holds no image with that content digest and will not fetch one; "
+                + "load it with 'arca-engine image load --oci-layout <dir>'"
+        )
+    }
+
+    /// The forgiving-match test on the repository axis.
+    ///
+    /// The digest is one the store really holds; only the repository differs.
+    /// Answering `Ack` here would be a success the consumer cannot check,
+    /// followed by a `Create` that fails, because `ContainerManager` resolves
+    /// the image by the reference it is given.
+    func testContentHeldUnderAnotherRepositoryIsNotFound() async throws {
+        let engine = try await preparedEngine()
+
+        let response = await engine.service.prepareImage(request: request(
+            repository: "not-the-workspace", hex: engine.hex
+        ))
+
+        guard case .error(let error) = response.outcome else {
+            return XCTFail("a foreign repository must be refused, got \(response.outcome as Any)")
+        }
+        XCTAssertEqual(error.code, "not_found")
+        XCTAssertEqual(error.resource, "not-the-workspace@sha256:\(engine.hex)")
+        XCTAssertEqual(
+            error.message,
+            "this engine holds that content digest under repository workspace, "
+                + "not not-the-workspace"
+        )
+    }
+
+    /// An image row can outlive the blobs it names, and this is the case that
+    /// separates a real check from a cheap one.
+    ///
+    /// Deleting the layer blob under the store's own root is the damage a
+    /// half-finished load or an interrupted content GC leaves behind. The
+    /// `imageExists` assertion in the middle is the premise, not decoration: it
+    /// is the cheap answer this method deliberately does not use, and it says
+    /// "held" for an image nothing can be created from, because it is built on
+    /// `inspectImage`, which reads the index, the manifest and the config and
+    /// never a layer.
+    func testAnImageMissingALayerBlobIsNotFound() async throws {
+        let engine = try await preparedEngine()
+        let layer = try XCTUnwrap(
+            engine.layers.first,
+            "the fixture image must name a layer for this test to delete one"
+        )
+        try FileManager.default.removeItem(
+            at: engine.storeRoot
+                .appendingPathComponent("content/blobs/sha256")
+                .appendingPathComponent(layer.replacingOccurrences(of: "sha256:", with: ""))
+        )
+        let cheapAnswer = await engine.service.imageManager.imageExists(nameOrId: Self.reference)
+        XCTAssertTrue(
+            cheapAnswer,
+            "the premise of this test is that the cheap check cannot see the missing layer"
+        )
+
+        let response = await engine.service.prepareImage(request: request(
+            repository: Self.repository, hex: engine.hex
+        ))
+
+        guard case .error(let error) = response.outcome else {
+            return XCTFail("an image whose layer is gone must be refused, got \(response.outcome as Any)")
+        }
+        XCTAssertEqual(error.code, "not_found")
+        XCTAssertEqual(error.resource, "\(Self.repository)@sha256:\(engine.hex)")
+        XCTAssertEqual(
+            error.message,
+            "the image stored as \(Self.reference) carries that content digest, but this engine "
+                + "does not hold 1 of the blobs it names: \(layer)"
+        )
+    }
+
+    // MARK: - Requests that are not digests
+
+    /// A malformed digest is the consumer's error, not a statement about
+    /// content.
+    ///
+    /// `not_found` would tell a consumer to go and load the content, which
+    /// cannot be the fix for a request that never named any.
+    /// `invalid_resource_identity` is the code for an identity the engine
+    /// cannot read, and it is one of the twelve gascan's table accepts.
+    ///
+    /// The unset request is in the table on purpose: `image` is a message
+    /// field, so a request that omits it arrives with both halves empty and
+    /// must not be read as a lookup for the empty digest.
+    func testARequestThatIsNotADigestIsAnInvalidIdentity() async throws {
+        let service = SandboxEngineService.forTesting()
+        let cases: [(name: String, request: Arca_Engine_V1_PrepareImageRequest, resource: String)] = [
+            ("unset", Arca_Engine_V1_PrepareImageRequest(), "@sha256:"),
+            (
+                "no repository",
+                request(repository: "", hex: String(repeating: "a", count: 64)),
+                "@sha256:" + String(repeating: "a", count: 64)
+            ),
+            ("no hex", request(repository: "workspace", hex: ""), "workspace@sha256:"),
+            (
+                "short hex",
+                request(repository: "workspace", hex: String(repeating: "a", count: 63)),
+                "workspace@sha256:" + String(repeating: "a", count: 63)
+            ),
+            (
+                "uppercase hex",
+                request(repository: "workspace", hex: String(repeating: "A", count: 64)),
+                "workspace@sha256:" + String(repeating: "A", count: 64)
+            ),
+            (
+                "prefixed hex",
+                request(repository: "workspace", hex: "sha256:" + String(repeating: "a", count: 57)),
+                "workspace@sha256:sha256:" + String(repeating: "a", count: 57)
+            ),
+        ]
+
+        for (name, request, resource) in cases {
+            let response = await service.prepareImage(request: request)
+            guard case .error(let error) = response.outcome else {
+                XCTFail("\(name) must be refused, got \(response.outcome as Any)")
+                continue
+            }
+            XCTAssertEqual(error.code, "invalid_resource_identity", "\(name) answered \(error.code)")
+            XCTAssertEqual(error.resource, resource, "\(name) named \(error.resource)")
+            XCTAssertEqual(
+                error.message,
+                "an image digest is a non-empty repository and a 64-character lowercase hex "
+                    + "sha256 carrying no prefix",
+                "\(name) said \(error.message)"
+            )
+        }
+    }
+
+    // MARK: - The error arm is never a thrown Swift error
+
+    /// A store that cannot be read is an error *outcome*, never a throw.
+    ///
+    /// An uncaught throw in a provider method becomes a gRPC status, and
+    /// `engine.proto:52-58` reserves status codes for transport faults -- an
+    /// unreachable engine, a broken stream. A status where an outcome belongs
+    /// tells the consumer the engine is gone when the truth is that one read
+    /// failed.
+    ///
+    /// The fault is injected into the store's own `state.json`, which is what
+    /// `ImageStore.list()` reads to know which images exist, so the throw comes
+    /// out of ContainerBridge exactly as a real one would. `command_io` is the
+    /// code the other two implemented methods already use for a read that
+    /// failed.
+    ///
+    /// `message` is asserted non-empty rather than by equality: it is the
+    /// underlying decode error interpolated, and pinning a Foundation error's
+    /// description would assert on a string this project does not own.
+    func testAnUnreadableStoreIsAnErrorOutcomeAndNotAThrownError() async throws {
+        let engine = try await preparedEngine()
+        try Data("not json".utf8).write(
+            to: engine.storeRoot.appendingPathComponent("state.json")
+        )
+
+        let response = await engine.service.prepareImage(request: request(
+            repository: Self.repository, hex: engine.hex
+        ))
+
+        guard case .error(let error) = response.outcome else {
+            return XCTFail("an unreadable store must answer an error, got \(response.outcome as Any)")
+        }
+        XCTAssertEqual(error.code, "command_io")
+        XCTAssertEqual(error.resource, "\(Self.repository)@sha256:\(engine.hex)")
+        XCTAssertFalse(error.message.isEmpty, "the failure must carry the cause")
+    }
+
+    // MARK: - The split both sides have to agree on
+
+    /// The repository of a stored reference, split the way the consumer splits
+    /// its own (`crates/gascan-core/src/runtime.rs:704-715`).
+    ///
+    /// The registry-port row is the one that matters: a rule that took the last
+    /// `:` unconditionally would turn `registry.example:5000/repo` into
+    /// `registry.example`, and every image from a private registry would be
+    /// refused as held under some other repository.
+    func testAStoredReferenceIsSplitTheWayTheConsumerSplitsItsOwn() {
+        XCTAssertEqual(imageRepository(ofReference: "workspace:latest"), "workspace")
+        XCTAssertEqual(imageRepository(ofReference: "workspace"), "workspace")
+        XCTAssertEqual(
+            imageRepository(ofReference: "docker.io/library/alpine:3.19"),
+            "docker.io/library/alpine"
+        )
+        XCTAssertEqual(
+            imageRepository(ofReference: "registry.example:5000/repo"),
+            "registry.example:5000/repo"
+        )
+        XCTAssertEqual(
+            imageRepository(ofReference: "registry.example:5000/repo:v1"),
+            "registry.example:5000/repo"
+        )
+        XCTAssertEqual(
+            imageRepository(ofReference: "workspace:latest@sha256:" + String(repeating: "a", count: 64)),
+            "workspace"
+        )
+    }
+
+    // MARK: - Seeding
+
+    /// A service, and a store that really holds the fixture image.
+    private struct PreparedEngine {
+        let service: SandboxEngineService
+        let storeRoot: URL
+        /// The bare hex of the digest the store recorded, read back from the
+        /// store rather than computed here. Containerization synthesizes an
+        /// index for a single-manifest layout during the import, so the digest
+        /// the store holds is not one this test could state in advance without
+        /// re-implementing that synthesis and trusting the two to stay equal.
+        let hex: String
+        /// The layer digests the stored image names, in `sha256:<hex>` form.
+        let layers: [String]
+    }
+
+    private func preparedEngine(
+        reference: String = PrepareImageTests.reference
+    ) async throws -> PreparedEngine {
+        let root = try temporaryEngineRoot()
+        let stateRoot = root.appendingPathComponent("state")
+        let report = try await loadWorkspaceImages(
+            fromOCILayout: try OCILayoutFixture.write(
+                at: root.appendingPathComponent("workspace"),
+                reference: reference,
+                payload: "pushed by the consumer, not by startup"
+            ),
+            stateRoot: stateRoot,
+            logger: logger
+        )
+        XCTAssertEqual(
+            report.references, [reference],
+            "the seed must put the reference these tests ask about into the store"
+        )
+
+        let service = SandboxEngineService.forTesting(
+            stateRoot: stateRoot, kernelPath: URL(fileURLWithPath: "/opt/arca/vmlinux")
+        )
+        let stored = try await service.imageManager.inspectImage(nameOrId: reference)
+        let details = try XCTUnwrap(
+            stored, "the store must report details for the image it just loaded"
+        )
+        let digest = try XCTUnwrap(
+            details.repoDigests.first,
+            "the store must report a digest for the image it just loaded"
+        )
+        return PreparedEngine(
+            service: service,
+            storeRoot: report.storeRoot,
+            hex: digest.replacingOccurrences(of: "sha256:", with: ""),
+            layers: details.rootFS.layers
+        )
+    }
+
+    private func request(repository: String, hex: String) -> Arca_Engine_V1_PrepareImageRequest {
+        Arca_Engine_V1_PrepareImageRequest.with {
+            $0.image = Arca_Engine_V1_ImageDigest.with {
+                $0.repository = repository
+                $0.sha256Hex = hex
+            }
+        }
+    }
+
+    /// A well-formed digest that is certainly not the one given.
+    ///
+    /// One character, so the two differ in nothing else: a test that changed
+    /// the length or the alphabet as well would be refused for being malformed
+    /// and would never reach the lookup it exists to drive.
+    private func flipFirstCharacter(of hex: String) -> String {
+        let first = hex.first == "0" ? "1" : "0"
+        return first + hex.dropFirst()
+    }
+}

--- a/Tests/ArcaEngineTests/PrepareImageTests.swift
+++ b/Tests/ArcaEngineTests/PrepareImageTests.swift
@@ -141,6 +141,16 @@ final class PrepareImageTests: XCTestCase {
     /// Both directions are asserted in one test on purpose. Asserting only the
     /// tagged name would pass against the defect whenever the store happened to
     /// list the tag first, which is exactly how it went unnoticed.
+    ///
+    /// **The third repository is the pairing this file's discipline requires,
+    /// and its absence was a real hole rather than a missing nicety.** Written
+    /// with the two `Ack`s alone, this test passed against the whole-body
+    /// `Ack` mutation -- it was one of two in the file that a method looking
+    /// nothing up survives, and it was added by the very diff that fixed the
+    /// widening. It also covers what nothing else does: a refusal while two
+    /// references are in play, which is the widening's own hazard. The message
+    /// must name **both** holders, so a fix that widened `.held` to every row
+    /// but left the diagnostic reporting one of them is caught here too.
     func testADigestHeldUnderTwoReferencesIsPreparedUnderEitherName() async throws {
         let engine = try await preparedEngine()
         try await engine.service.imageManager.tagImage(
@@ -148,7 +158,7 @@ final class PrepareImageTests: XCTestCase {
         )
 
         // The premise: two rows, one digest. Stated rather than assumed,
-        // because a tag that silently did not land would make both assertions
+        // because a tag that silently did not land would make every assertion
         // below pass for the wrong reason.
         let rows = try await engine.service.imageManager.listImages()
             .filter { $0.repoDigests.contains("sha256:\(engine.hex)") }
@@ -166,6 +176,20 @@ final class PrepareImageTests: XCTestCase {
                 continue
             }
         }
+
+        let refused = await engine.service.prepareImage(request: request(
+            repository: "not-the-workspace", hex: engine.hex
+        ))
+        guard case .error(let error) = refused.outcome else {
+            return XCTFail("a third repository must still be refused, got \(refused.outcome as Any)")
+        }
+        XCTAssertEqual(error.code, "not_found")
+        XCTAssertEqual(error.resource, "not-the-workspace@sha256:\(engine.hex)")
+        XCTAssertEqual(
+            error.message,
+            "this engine does not hold that content digest under repository not-the-workspace; "
+                + "it holds it under other/workspace, workspace"
+        )
     }
 
     /// An image row can outlive the blobs it names, and this is the case that

--- a/Tests/ArcaEngineTests/PrepareImageTests.swift
+++ b/Tests/ArcaEngineTests/PrepareImageTests.swift
@@ -122,9 +122,50 @@ final class PrepareImageTests: XCTestCase {
         XCTAssertEqual(error.resource, "not-the-workspace@sha256:\(engine.hex)")
         XCTAssertEqual(
             error.message,
-            "this engine holds that content digest under repository workspace, "
-                + "not not-the-workspace"
+            "this engine does not hold that content digest under repository not-the-workspace; "
+                + "it holds it under workspace"
         )
+    }
+
+    /// One piece of content, two references, and both must be prepared.
+    ///
+    /// A store holds a row per reference, and `tagImage` adds a row to content
+    /// that is already there -- so a digest can be held under two names at
+    /// once. The first revision of this method asked
+    /// `imageStore.list().first(where: digest matches)` and then tested *that*
+    /// row's repository, which refused one of the two names for content the
+    /// engine demonstrably held, and named the other one while doing it. Which
+    /// of the two lost was decided by store ordering, so it was not even stable
+    /// across runs.
+    ///
+    /// Both directions are asserted in one test on purpose. Asserting only the
+    /// tagged name would pass against the defect whenever the store happened to
+    /// list the tag first, which is exactly how it went unnoticed.
+    func testADigestHeldUnderTwoReferencesIsPreparedUnderEitherName() async throws {
+        let engine = try await preparedEngine()
+        try await engine.service.imageManager.tagImage(
+            source: Self.reference, target: "other/workspace:latest"
+        )
+
+        // The premise: two rows, one digest. Stated rather than assumed,
+        // because a tag that silently did not land would make both assertions
+        // below pass for the wrong reason.
+        let rows = try await engine.service.imageManager.listImages()
+            .filter { $0.repoDigests.contains("sha256:\(engine.hex)") }
+        XCTAssertEqual(
+            rows.flatMap(\.repoTags).sorted(), ["other/workspace:latest", "workspace:latest"],
+            "the tag must add a second row to the same content"
+        )
+
+        for repository in [Self.repository, "other/workspace"] {
+            let response = await engine.service.prepareImage(request: request(
+                repository: repository, hex: engine.hex
+            ))
+            guard case .ok = response.outcome else {
+                XCTFail("\(repository) names content the engine holds, got \(response.outcome as Any)")
+                continue
+            }
+        }
     }
 
     /// An image row can outlive the blobs it names, and this is the case that
@@ -165,8 +206,8 @@ final class PrepareImageTests: XCTestCase {
         XCTAssertEqual(error.resource, "\(Self.repository)@sha256:\(engine.hex)")
         XCTAssertEqual(
             error.message,
-            "the image stored as \(Self.reference) carries that content digest, but this engine "
-                + "does not hold 1 of the blobs it names: \(layer)"
+            "this engine has that content digest in its store under \(Self.reference), but does "
+                + "not hold 1 of the blobs it names: \(layer)"
         )
     }
 
@@ -183,8 +224,16 @@ final class PrepareImageTests: XCTestCase {
     /// The unset request is in the table on purpose: `image` is a message
     /// field, so a request that omits it arrives with both halves empty and
     /// must not be read as a lookup for the empty digest.
+    ///
+    /// So is the non-ASCII row, and it is not exotic padding. `uppercase hex`
+    /// covers the wrong-case class and nothing else; U+0663 covers the class
+    /// Swift's own `Character.isNumber` lets through, which is every Unicode
+    /// number. Without `isASCII` in `isSHA256Hex` this row is answered
+    /// `not_found`, and the engine says "hex" in a message about a string that
+    /// is not.
     func testARequestThatIsNotADigestIsAnInvalidIdentity() async throws {
         let service = SandboxEngineService.forTesting()
+        let arabicIndicThrees = String(repeating: "\u{0663}", count: 64)
         let cases: [(name: String, request: Arca_Engine_V1_PrepareImageRequest, resource: String)] = [
             ("unset", Arca_Engine_V1_PrepareImageRequest(), "@sha256:"),
             (
@@ -207,6 +256,11 @@ final class PrepareImageTests: XCTestCase {
                 "prefixed hex",
                 request(repository: "workspace", hex: "sha256:" + String(repeating: "a", count: 57)),
                 "workspace@sha256:sha256:" + String(repeating: "a", count: 57)
+            ),
+            (
+                "64 non-ASCII digits",
+                request(repository: "workspace", hex: arabicIndicThrees),
+                "workspace@sha256:" + arabicIndicThrees
             ),
         ]
 

--- a/Tests/ArcaEngineTests/SandboxEngineServiceTests.swift
+++ b/Tests/ArcaEngineTests/SandboxEngineServiceTests.swift
@@ -76,7 +76,7 @@ final class SandboxEngineServiceTests: XCTestCase {
 }
 
 // Reads the `EngineError` out of whichever arm a response type puts it in, so
-// the table above can be one list rather than eight near-copies. `nil` means
+// the table above can be one list rather than six near-copies. `nil` means
 // the response did not answer with an error, which for an unimplemented method
 // is itself the failure -- hence optional rather than a trap.
 

--- a/Tests/ArcaEngineTests/SandboxEngineServiceTests.swift
+++ b/Tests/ArcaEngineTests/SandboxEngineServiceTests.swift
@@ -34,20 +34,20 @@ final class SandboxEngineServiceTests: XCTestCase {
     /// what its name claimed. The code and the RPC name are what a consumer
     /// reads, so they are what this asserts.
     ///
-    /// The seven unary ones among them. `Exec` and `Logs` send their error
+    /// The six unary ones among them. `Exec` and `Logs` send their error
     /// inside a stream frame, and `GRPCAsyncResponseStreamWriter` has no
     /// initialiser a test target can reach; gascan's live tier drives both
     /// against a real engine over a real socket.
     ///
-    /// `Inspect` left this table when Task 7 implemented it. It is not an
-    /// omission: an implemented method belongs to the tests that assert what it
-    /// reports (`InspectTests`), and leaving it here would have this test fail
-    /// for the correct behaviour.
+    /// `Inspect` left this table when Task 7 implemented it, and `ListResources`
+    /// when Task 8 did. Neither is an omission: an implemented method belongs to
+    /// the tests that assert what it reports (`InspectTests`,
+    /// `ListResourcesTests`), and leaving it here would have this test fail for
+    /// the correct behaviour.
     func testEveryUnimplementedUnaryMethodAnswersUnsupportedCapability() async throws {
         let service = SandboxEngineService.forTesting()
 
         let answers: [(rpc: String, error: Arca_Engine_V1_EngineError?)] = [
-            ("ListResources", engineError(await service.listResources(request: .init()).outcome)),
             ("Create", engineError(await service.create(request: .init()).outcome)),
             ("CreateContainer", engineError(await service.createContainer(request: .init()).outcome)),
             ("PrepareImage", engineError(await service.prepareImage(request: .init()).outcome)),
@@ -57,8 +57,8 @@ final class SandboxEngineServiceTests: XCTestCase {
         ]
 
         XCTAssertEqual(
-            answers.count, 7,
-            "nine of the eleven contract methods are unimplemented, and Exec and Logs "
+            answers.count, 6,
+            "eight of the eleven contract methods are unimplemented, and Exec and Logs "
                 + "are the two that stream"
         )
         for (rpc, error) in answers {
@@ -79,13 +79,6 @@ final class SandboxEngineServiceTests: XCTestCase {
 // the table above can be one list rather than eight near-copies. `nil` means
 // the response did not answer with an error, which for an unimplemented method
 // is itself the failure -- hence optional rather than a trap.
-
-private func engineError(
-    _ outcome: Arca_Engine_V1_ListResourcesResponse.OneOf_Outcome?
-) -> Arca_Engine_V1_EngineError? {
-    if case .error(let error) = outcome { return error }
-    return nil
-}
 
 private func engineError(
     _ outcome: Arca_Engine_V1_AckResponse.OneOf_Outcome?

--- a/Tests/ArcaEngineTests/SandboxEngineServiceTests.swift
+++ b/Tests/ArcaEngineTests/SandboxEngineServiceTests.swift
@@ -34,31 +34,30 @@ final class SandboxEngineServiceTests: XCTestCase {
     /// what its name claimed. The code and the RPC name are what a consumer
     /// reads, so they are what this asserts.
     ///
-    /// The six unary ones among them. `Exec` and `Logs` send their error
+    /// The five unary ones among them. `Exec` and `Logs` send their error
     /// inside a stream frame, and `GRPCAsyncResponseStreamWriter` has no
     /// initialiser a test target can reach; gascan's live tier drives both
     /// against a real engine over a real socket.
     ///
-    /// `Inspect` left this table when Task 7 implemented it, and `ListResources`
-    /// when Task 8 did. Neither is an omission: an implemented method belongs to
-    /// the tests that assert what it reports (`InspectTests`,
-    /// `ListResourcesTests`), and leaving it here would have this test fail for
-    /// the correct behaviour.
+    /// `Inspect` left this table when Task 7 implemented it, `ListResources`
+    /// when Task 8 did, and `PrepareImage` when Task 10 did. None is an
+    /// omission: an implemented method belongs to the tests that assert what it
+    /// reports (`InspectTests`, `ListResourcesTests`, `PrepareImageTests`), and
+    /// leaving it here would have this test fail for the correct behaviour.
     func testEveryUnimplementedUnaryMethodAnswersUnsupportedCapability() async throws {
         let service = SandboxEngineService.forTesting()
 
         let answers: [(rpc: String, error: Arca_Engine_V1_EngineError?)] = [
             ("Create", engineError(await service.create(request: .init()).outcome)),
             ("CreateContainer", engineError(await service.createContainer(request: .init()).outcome)),
-            ("PrepareImage", engineError(await service.prepareImage(request: .init()).outcome)),
             ("Start", engineError(await service.start(request: .init()).outcome)),
             ("Stop", engineError(await service.stop(request: .init()).outcome)),
             ("Remove", engineError(await service.remove(request: .init()).outcome)),
         ]
 
         XCTAssertEqual(
-            answers.count, 6,
-            "eight of the eleven contract methods are unimplemented, and Exec and Logs "
+            answers.count, 5,
+            "seven of the eleven contract methods are unimplemented, and Exec and Logs "
                 + "are the two that stream"
         )
         for (rpc, error) in answers {
@@ -82,13 +81,6 @@ final class SandboxEngineServiceTests: XCTestCase {
 
 private func engineError(
     _ outcome: Arca_Engine_V1_AckResponse.OneOf_Outcome?
-) -> Arca_Engine_V1_EngineError? {
-    if case .error(let error) = outcome { return error }
-    return nil
-}
-
-private func engineError(
-    _ outcome: Arca_Engine_V1_PrepareImageResponse.OneOf_Outcome?
 ) -> Arca_Engine_V1_EngineError? {
     if case .error(let error) = outcome { return error }
     return nil

--- a/Tests/ArcaEngineTests/SandboxEngineServiceTests.swift
+++ b/Tests/ArcaEngineTests/SandboxEngineServiceTests.swift
@@ -34,15 +34,19 @@ final class SandboxEngineServiceTests: XCTestCase {
     /// what its name claimed. The code and the RPC name are what a consumer
     /// reads, so they are what this asserts.
     ///
-    /// The eight unary methods only. `Exec` and `Logs` send their error inside
-    /// a stream frame, and `GRPCAsyncResponseStreamWriter` has no initialiser a
-    /// test target can reach; gascan's live tier drives both against a real
-    /// engine over a real socket.
+    /// The seven unary ones among them. `Exec` and `Logs` send their error
+    /// inside a stream frame, and `GRPCAsyncResponseStreamWriter` has no
+    /// initialiser a test target can reach; gascan's live tier drives both
+    /// against a real engine over a real socket.
+    ///
+    /// `Inspect` left this table when Task 7 implemented it. It is not an
+    /// omission: an implemented method belongs to the tests that assert what it
+    /// reports (`InspectTests`), and leaving it here would have this test fail
+    /// for the correct behaviour.
     func testEveryUnimplementedUnaryMethodAnswersUnsupportedCapability() async throws {
         let service = SandboxEngineService.forTesting()
 
         let answers: [(rpc: String, error: Arca_Engine_V1_EngineError?)] = [
-            ("Inspect", engineError(await service.inspect(request: .init()).outcome)),
             ("ListResources", engineError(await service.listResources(request: .init()).outcome)),
             ("Create", engineError(await service.create(request: .init()).outcome)),
             ("CreateContainer", engineError(await service.createContainer(request: .init()).outcome)),
@@ -52,7 +56,11 @@ final class SandboxEngineServiceTests: XCTestCase {
             ("Remove", engineError(await service.remove(request: .init()).outcome)),
         ]
 
-        XCTAssertEqual(answers.count, 8, "the ten-method contract has eight unary methods left")
+        XCTAssertEqual(
+            answers.count, 7,
+            "nine of the eleven contract methods are unimplemented, and Exec and Logs "
+                + "are the two that stream"
+        )
         for (rpc, error) in answers {
             guard let error else {
                 XCTFail("\(rpc) must answer with an error outcome, and did not")
@@ -71,13 +79,6 @@ final class SandboxEngineServiceTests: XCTestCase {
 // the table above can be one list rather than eight near-copies. `nil` means
 // the response did not answer with an error, which for an unimplemented method
 // is itself the failure -- hence optional rather than a trap.
-
-private func engineError(
-    _ outcome: Arca_Engine_V1_InspectResponse.OneOf_Outcome?
-) -> Arca_Engine_V1_EngineError? {
-    if case .error(let error) = outcome { return error }
-    return nil
-}
 
 private func engineError(
     _ outcome: Arca_Engine_V1_ListResourcesResponse.OneOf_Outcome?

--- a/Tests/ArcaEngineTests/SandboxEngineServiceTests.swift
+++ b/Tests/ArcaEngineTests/SandboxEngineServiceTests.swift
@@ -4,99 +4,53 @@ import XCTest
 @testable import ArcaEngine
 
 final class SandboxEngineServiceTests: XCTestCase {
-    /// An unimplemented method must still ANSWER. Returning a gRPC status
-    /// instead would be a transport fault by the contract's reading, and the
-    /// consumer would report an unreachable engine rather than an unsupported
-    /// operation.
+    /// The one unary method this build does not implement must still ANSWER.
     ///
-    /// Calls the context-free `start(request:)` overload rather than the
-    /// protocol-conforming `start(request:context:)`: grpc-swift's
-    /// `GRPCAsyncServerCallContext` has no public initialiser, so a test
-    /// target cannot construct one. See SandboxEngineService.swift.
-    func testUnimplementedMethodsAnswerWithUnsupportedCapabilityNamingTheRpc() async throws {
-        let service = SandboxEngineService.forTesting()
-        let response = await service.start(
-            request: Arca_Engine_V1_StartRequest.with { $0.sandboxID = "web-a1b2c3d4e5f6" }
-        )
-        guard case .error(let error) = response.outcome else {
-            return XCTFail("an unimplemented method must answer with an error outcome")
-        }
-        XCTAssertEqual(error.code, "unsupported_capability")
-        XCTAssertTrue(error.message.contains("Start"), "must name the RPC: \(error.message)")
-    }
-
-    /// Every unimplemented response carries an `unsupported_capability` error
-    /// naming its RPC.
+    /// Returning a gRPC status instead would be a transport fault by the
+    /// contract's reading (engine.proto:52-58), and the consumer would report an
+    /// unreachable engine rather than an unsupported operation. The code and the
+    /// RPC name are what a consumer reads, so they are what this asserts; an
+    /// earlier version asserted only `XCTAssertNotNil(outcome)`, which is true
+    /// whenever *any* arm is set and so would have passed had the method answered
+    /// `ok`.
     ///
-    /// This replaces a version that asserted only `XCTAssertNotNil(outcome)`.
-    /// An outcome is non-nil whenever *any* arm is set, so that test passed if
-    /// every one of these methods had answered `ok` -- the precise inversion of
-    /// what its name claimed. The code and the RPC name are what a consumer
-    /// reads, so they are what this asserts.
+    /// Calls the context-free `createContainer(request:)` overload rather than
+    /// the protocol-conforming one: grpc-swift's `GRPCAsyncServerCallContext` has
+    /// no public initialiser, so a test target cannot construct one. See
+    /// SandboxEngineService.swift.
     ///
-    /// The four unary ones among them. `Exec` and `Logs` send their error
-    /// inside a stream frame, and `GRPCAsyncResponseStreamWriter` has no
-    /// initialiser a test target can reach; gascan's live tier drives both
-    /// against a real engine over a real socket.
-    ///
-    /// `Inspect` left this table when Task 7 implemented it, `ListResources`
-    /// when Task 8 did, `PrepareImage` when Task 10 did, and `Create` when Task
-    /// 11 did. None is an omission: an implemented method belongs to the tests
-    /// that assert what it reports (`InspectTests`, `ListResourcesTests`,
-    /// `PrepareImageTests`, `CreateTests`), and leaving it here would have this
-    /// test fail for the correct behaviour.
-    ///
-    /// `CreateContainer` stays, and it is the one worth watching. It shares
-    /// `CreateRequest` with `Create` and is a create in every respect except
-    /// that its resources already exist, so it is the method most likely to be
-    /// quietly satisfied by a change aimed at its neighbour. It is not
+    /// **`CreateContainer` is the last unary method on this list, and it is the
+    /// one worth watching.** `Inspect` left it when Task 7 implemented it,
+    /// `ListResources` when Task 8 did, `PrepareImage` when Task 10 did, `Create`
+    /// when Task 11 did, and `Start`, `Stop` and `Remove` when Task 12 did. None
+    /// is an omission: an implemented method belongs to the tests that assert
+    /// what it reports (`InspectTests`, `ListResourcesTests`,
+    /// `PrepareImageTests`, `CreateTests`, `LifecycleTests`), and leaving it here
+    /// would have this test fail for the correct behaviour. `CreateContainer`
+    /// shares `CreateRequest` with `Create` and is a create in every respect
+    /// except that its resources already exist, so it is the method most likely
+    /// to be quietly satisfied by a change aimed at its neighbour. It is not
     /// implemented, and this is what says so.
-    func testEveryUnimplementedUnaryMethodAnswersUnsupportedCapability() async throws {
+    ///
+    /// `Exec` and `Logs` are the other two unimplemented methods and are not
+    /// here: both send their error inside a stream frame, and
+    /// `GRPCAsyncResponseStreamWriter` has no initialiser a test target can
+    /// reach. gascan's live tier drives both against a real engine over a real
+    /// socket.
+    func testCreateContainerAnswersUnsupportedCapabilityNamingTheRpc() async throws {
         let service = SandboxEngineService.forTesting()
+        let outcome = await service.createContainer(
+            request: Arca_Engine_V1_CreateContainerRequest()
+        ).outcome
 
-        let answers: [(rpc: String, error: Arca_Engine_V1_EngineError?)] = [
-            ("CreateContainer", engineError(await service.createContainer(request: .init()).outcome)),
-            ("Start", engineError(await service.start(request: .init()).outcome)),
-            ("Stop", engineError(await service.stop(request: .init()).outcome)),
-            ("Remove", engineError(await service.remove(request: .init()).outcome)),
-        ]
-
-        XCTAssertEqual(
-            answers.count, 4,
-            "six of the eleven contract methods are unimplemented, and Exec and Logs "
-                + "are the two that stream"
-        )
-        for (rpc, error) in answers {
-            guard let error else {
-                XCTFail("\(rpc) must answer with an error outcome, and did not")
-                continue
-            }
-            XCTAssertEqual(error.code, "unsupported_capability", "\(rpc) answered \(error.code)")
-            XCTAssertTrue(
-                error.message.contains(rpc),
-                "\(rpc)'s message must name the RPC: \(error.message)"
-            )
+        guard case .failed(let failed) = outcome else {
+            return XCTFail("an unimplemented method must answer with an error outcome, got "
+                + String(describing: outcome))
         }
+        XCTAssertEqual(failed.error.code, "unsupported_capability")
+        XCTAssertTrue(
+            failed.error.message.contains("CreateContainer"),
+            "must name the RPC: \(failed.error.message)"
+        )
     }
-}
-
-// Reads the `EngineError` out of whichever arm a response type puts it in, so
-// the table above can be one list rather than six near-copies. `nil` means
-// the response did not answer with an error, which for an unimplemented method
-// is itself the failure -- hence optional rather than a trap.
-
-private func engineError(
-    _ outcome: Arca_Engine_V1_AckResponse.OneOf_Outcome?
-) -> Arca_Engine_V1_EngineError? {
-    if case .error(let error) = outcome { return error }
-    return nil
-}
-
-/// Create is the one shape that nests: its failure arm is a `CreateFailed`,
-/// which carries the error alongside the resources a partial create made.
-private func engineError(
-    _ outcome: Arca_Engine_V1_CreateResponse.OneOf_Outcome?
-) -> Arca_Engine_V1_EngineError? {
-    if case .failed(let failed) = outcome { return failed.error }
-    return nil
 }

--- a/Tests/ArcaEngineTests/SandboxEngineServiceTests.swift
+++ b/Tests/ArcaEngineTests/SandboxEngineServiceTests.swift
@@ -34,21 +34,27 @@ final class SandboxEngineServiceTests: XCTestCase {
     /// what its name claimed. The code and the RPC name are what a consumer
     /// reads, so they are what this asserts.
     ///
-    /// The five unary ones among them. `Exec` and `Logs` send their error
+    /// The four unary ones among them. `Exec` and `Logs` send their error
     /// inside a stream frame, and `GRPCAsyncResponseStreamWriter` has no
     /// initialiser a test target can reach; gascan's live tier drives both
     /// against a real engine over a real socket.
     ///
     /// `Inspect` left this table when Task 7 implemented it, `ListResources`
-    /// when Task 8 did, and `PrepareImage` when Task 10 did. None is an
-    /// omission: an implemented method belongs to the tests that assert what it
-    /// reports (`InspectTests`, `ListResourcesTests`, `PrepareImageTests`), and
-    /// leaving it here would have this test fail for the correct behaviour.
+    /// when Task 8 did, `PrepareImage` when Task 10 did, and `Create` when Task
+    /// 11 did. None is an omission: an implemented method belongs to the tests
+    /// that assert what it reports (`InspectTests`, `ListResourcesTests`,
+    /// `PrepareImageTests`, `CreateTests`), and leaving it here would have this
+    /// test fail for the correct behaviour.
+    ///
+    /// `CreateContainer` stays, and it is the one worth watching. It shares
+    /// `CreateRequest` with `Create` and is a create in every respect except
+    /// that its resources already exist, so it is the method most likely to be
+    /// quietly satisfied by a change aimed at its neighbour. It is not
+    /// implemented, and this is what says so.
     func testEveryUnimplementedUnaryMethodAnswersUnsupportedCapability() async throws {
         let service = SandboxEngineService.forTesting()
 
         let answers: [(rpc: String, error: Arca_Engine_V1_EngineError?)] = [
-            ("Create", engineError(await service.create(request: .init()).outcome)),
             ("CreateContainer", engineError(await service.createContainer(request: .init()).outcome)),
             ("Start", engineError(await service.start(request: .init()).outcome)),
             ("Stop", engineError(await service.stop(request: .init()).outcome)),
@@ -56,8 +62,8 @@ final class SandboxEngineServiceTests: XCTestCase {
         ]
 
         XCTAssertEqual(
-            answers.count, 5,
-            "seven of the eleven contract methods are unimplemented, and Exec and Logs "
+            answers.count, 4,
+            "six of the eleven contract methods are unimplemented, and Exec and Logs "
                 + "are the two that stream"
         )
         for (rpc, error) in answers {

--- a/Tests/ArcaEngineTests/ShutdownObserverTests.swift
+++ b/Tests/ArcaEngineTests/ShutdownObserverTests.swift
@@ -1,0 +1,191 @@
+import Darwin
+import Foundation
+import GRPC
+import NIOConcurrencyHelpers
+import NIOCore
+import NIOPosix
+import XCTest
+
+@testable import ArcaEngine
+
+/// That the guard which stops `serve()` hanging cannot also kill a healthy shutdown.
+///
+/// **The engine waits on its accepted connections draining, and only the first signal completes
+/// that wait.** So a listening socket closing for any other reason would leave the process
+/// waiting forever while holding the flock that makes `EngineServer.start` refuse the path to a
+/// successor -- an engine that can neither serve nor be replaced. The guard against that reads
+/// "the listener closed and nothing asked for it", and it is one `guard` away from being a
+/// disaster: keyed wrongly, it fires on EVERY graceful shutdown, mid-drain, and turns a clean
+/// stop into `EXIT_FAILURE`.
+///
+/// **What makes the guard safe is an ordering, and these tests are what measure it.** The signal
+/// handler records the request as the CONDITION of the branch that then initiates the shutdown,
+/// so by the time the resulting close reaches the observer the request is always recorded. That
+/// is structural in the handler; it is not structural in the rule, and a refactor could invert
+/// it without looking wrong.
+///
+/// **WHAT THESE TESTS DO NOT PIN, said plainly because the alternative is a reader assuming
+/// otherwise.** They exercise `ShutdownRequests` and the NIO/grpc-swift semantics the rule rests
+/// on, wired here the way `ServeCommand.serve` wires them -- not `serve()` itself, which is
+/// private to the executable and reaches `VmnetNetwork` through `run()`, so it needs an
+/// entitlement and a host vmnet. Changing `serve()`'s own wiring would not fail these. What
+/// would fail them is the thing most likely to happen: a dependency bump that changed when
+/// `onClose` completes relative to quiescence.
+final class ShutdownObserverTests: XCTestCase {
+    private var group: MultiThreadedEventLoopGroup!
+    private var createdPaths: [String] = []
+
+    override func setUp() {
+        super.setUp()
+        group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    }
+
+    override func tearDown() {
+        XCTAssertNoThrow(try group.syncShutdownGracefully())
+        for path in createdPaths {
+            unlink(path)
+            unlink(path + ".lock")
+        }
+        createdPaths = []
+        super.tearDown()
+    }
+
+    /// `/tmp` for the `sun_path` reason `EngineServerTests` records.
+    private func testSocketPath() -> String {
+        let path = "/tmp/arca-shutdown-observer-\(UUID().uuidString.prefix(8)).sock"
+        createdPaths.append(path)
+        return path
+    }
+
+    /// A raw peer, connected and silent.
+    ///
+    /// Silent on purpose: grpc-swift closes a connection whose protocol it has finished
+    /// negotiating when quiescing sends its GOAWAY, and closing is exactly what must NOT happen
+    /// while these tests look. One that has sent nothing is in no protocol at all, so it holds
+    /// the drain open and the listener closes long before quiescence completes -- which is the
+    /// window the guard has to survive.
+    private func connectRawSocket(to path: String) throws -> Int32 {
+        let descriptor = socket(AF_UNIX, SOCK_STREAM, 0)
+        XCTAssertGreaterThanOrEqual(descriptor, 0, "socket() failed: \(errno)")
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        _ = withUnsafeMutablePointer(to: &address.sun_path) { raw in
+            path.withCString { source in
+                strncpy(UnsafeMutableRawPointer(raw).assumingMemoryBound(to: CChar.self), source, 103)
+            }
+        }
+        let size = socklen_t(MemoryLayout<sockaddr_un>.size)
+        let result = withUnsafePointer(to: &address) { raw in
+            raw.withMemoryRebound(to: sockaddr.self, capacity: 1) { connect(descriptor, $0, size) }
+        }
+        XCTAssertEqual(result, 0, "connect() failed: \(errno)")
+        return descriptor
+    }
+
+    /// The observer, wired as `serve()` wires it, reporting whether it would have exited.
+    ///
+    /// `exit()` cannot run inside a test process, so what is measured is the branch taken.
+    private func installObserver(
+        _ engine: EngineServer,
+        _ asked: ShutdownRequests,
+        wouldExit: NIOLockedValueBox<Bool>,
+        ran: NIOLockedValueBox<Bool>
+    ) {
+        engine.onClose.whenComplete { _ in
+            ran.withLockedValue { $0 = true }
+            guard !asked.anyRecorded else { return }
+            wouldExit.withLockedValue { $0 = true }
+        }
+    }
+
+    /// The load-bearing case: a graceful shutdown with a peer holding the drain open.
+    ///
+    /// `onClose` completes here long before `quiesced` does -- that is the whole reason the
+    /// engine stopped waiting on it -- so this is precisely when a mis-keyed guard would fire.
+    func testTheObserverDoesNotFireOnAGracefulShutdownWithAHeldPeer() async throws {
+        let path = testSocketPath()
+        let engine = try await EngineServer.start(
+            socketPath: path, service: .forTesting(), group: group)
+        let peer = try connectRawSocket(to: path)
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        let asked = ShutdownRequests()
+        let wouldExit = NIOLockedValueBox(false)
+        let ran = NIOLockedValueBox(false)
+        installObserver(engine, asked, wouldExit: wouldExit, ran: ran)
+
+        // Recorded first, then initiated -- the order the handler makes structural.
+        let quiesced = group.next().makePromise(of: Void.self)
+        XCTAssertTrue(asked.recordAndReportFirst())
+        engine.server.initiateGracefulShutdown(promise: quiesced)
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        XCTAssertTrue(
+            ran.withLockedValue { $0 },
+            "the listener must have closed, or this test asserts nothing at all"
+        )
+        XCTAssertFalse(
+            wouldExit.withLockedValue { $0 },
+            "the guard fired on a healthy graceful shutdown, which would exit non-zero mid-drain"
+        )
+
+        close(peer)
+        try await engine.shutDown()
+    }
+
+    /// The control, and without it the assertion above passes against a dead observer.
+    func testTheObserverFiresWhenNoShutdownWasRecorded() async throws {
+        let path = testSocketPath()
+        let engine = try await EngineServer.start(
+            socketPath: path, service: .forTesting(), group: group)
+
+        let asked = ShutdownRequests()
+        let wouldExit = NIOLockedValueBox(false)
+        let ran = NIOLockedValueBox(false)
+        installObserver(engine, asked, wouldExit: wouldExit, ran: ran)
+
+        engine.server.close(promise: nil)
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        XCTAssertTrue(
+            wouldExit.withLockedValue { $0 },
+            "a listener that closed with nothing asking for it must end the process"
+        )
+        try engine.releaseSocketPath()
+    }
+
+    /// That the ordering is load-bearing rather than incidental.
+    ///
+    /// Inverting it -- initiate, then record -- makes the observer reach the exit branch on a
+    /// perfectly healthy shutdown. Asserted rather than printed: without this, a refactor that
+    /// moved the record after the initiate would leave the two tests above green, and the first
+    /// would silently become a test of nothing.
+    func testInvertingTheOrderWouldKillAHealthyShutdown() async throws {
+        let path = testSocketPath()
+        let engine = try await EngineServer.start(
+            socketPath: path, service: .forTesting(), group: group)
+        let peer = try connectRawSocket(to: path)
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        let asked = ShutdownRequests()
+        let wouldExit = NIOLockedValueBox(false)
+        let ran = NIOLockedValueBox(false)
+        installObserver(engine, asked, wouldExit: wouldExit, ran: ran)
+
+        let quiesced = group.next().makePromise(of: Void.self)
+        engine.server.initiateGracefulShutdown(promise: quiesced)
+        try await Task.sleep(nanoseconds: 200_000_000)
+        _ = asked.recordAndReportFirst()
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        XCTAssertTrue(
+            wouldExit.withLockedValue { $0 },
+            "recording after the close must lose the race; if it does not, the ordering the "
+                + "handler relies on is not what makes the guard safe and this suite is "
+                + "measuring the wrong invariant"
+        )
+
+        close(peer)
+        try await engine.shutDown()
+    }
+}

--- a/Tests/ArcaEngineTests/TestSupport.swift
+++ b/Tests/ArcaEngineTests/TestSupport.swift
@@ -15,23 +15,32 @@ extension SandboxEngineService {
     static func forTesting() -> SandboxEngineService {
         forTesting(
             stateRoot: URL(fileURLWithPath: NSTemporaryDirectory())
-                .appendingPathComponent("arca-engine-tests-\(UUID().uuidString)")
+                .appendingPathComponent("arca-engine-tests-\(UUID().uuidString)"),
+            // Outside the state root on purpose. Nothing here boots a sandbox,
+            // so it is never read, and putting it under the root would quietly
+            // restate the derivation `--kernel-path` replaced.
+            kernelPath: URL(fileURLWithPath: "/opt/arca/vmlinux")
         )
     }
 
-    /// The same service against a state root the caller names, so a test can
-    /// assert on where the managers were actually rooted.
+    /// The same service against a state root and kernel the caller names, so a
+    /// test can assert on where the managers were actually rooted.
     ///
-    /// Paths come from `EnginePaths` -- the derivation `arca-engine` itself
-    /// calls -- and not from a copy of its `appendingPathComponent` lines. The
-    /// copy is what made this helper a replica of the wiring rather than the
-    /// wiring: while it stood, changing the engine's real image-store root left
-    /// the whole suite green.
+    /// State-root paths come from `EnginePaths` -- the derivation `arca-engine`
+    /// itself calls -- and not from a copy of its `appendingPathComponent`
+    /// lines. The copy is what made this helper a replica of the wiring rather
+    /// than the wiring: while it stood, changing the engine's real image-store
+    /// root left the whole suite green.
     ///
-    /// No default for `stateRoot`, in keeping with the rule the path parameters
-    /// on `ContainerManager` follow: the no-argument overload above states the
-    /// throwaway root it wants.
-    static func forTesting(stateRoot: URL) -> SandboxEngineService {
+    /// The kernel is a parameter rather than an `EnginePaths` member for the
+    /// same reason it is a separate CLI option: it is a read-only input the
+    /// engine is handed, not state the engine owns. Deriving it here while
+    /// `arca-engine` took it from `--kernel-path` would put the drift back.
+    ///
+    /// No defaults on either, in keeping with the rule the path parameters on
+    /// `ContainerManager` follow: the no-argument overload above states the
+    /// throwaway values it wants.
+    static func forTesting(stateRoot: URL, kernelPath: URL) -> SandboxEngineService {
         let logger = Logger(label: "arca-engine-tests")
         let paths = EnginePaths(stateRoot: stateRoot)
 
@@ -45,14 +54,14 @@ extension SandboxEngineService {
         )
         let containerManager = ContainerManager(
             imageManager: imageManager,
-            kernelPath: paths.kernel.path,
+            kernelPath: kernelPath.path,
             imageStoreRoot: paths.imageStoreRoot,
             layerCachePath: paths.layerCache,
             stateStore: stateStore,
             logger: logger
         )
         let config = ArcaConfig(
-            kernelPath: paths.kernel.path,
+            kernelPath: kernelPath.path,
             socketPath: paths.socket.path,
             logLevel: "info"
         )

--- a/Tests/ArcaEngineTests/TestSupport.swift
+++ b/Tests/ArcaEngineTests/TestSupport.swift
@@ -30,7 +30,7 @@ extension SandboxEngineService {
     /// itself calls -- and not from a copy of its constructor calls. The copy is
     /// what made this helper a replica of the wiring rather than the wiring:
     /// while it stood, Task 1's review measured that swapping
-    /// `imageStoreRoot: paths.layerCache` in `ArcaEngineCommand` left the whole
+    /// `imageStoreRoot: paths.layerCache` in `ServeCommand` left the whole
     /// suite green. See the measurement recorded on `EngineManagers` for what
     /// the same swap costs now.
     ///

--- a/Tests/ArcaEngineTests/TestSupport.swift
+++ b/Tests/ArcaEngineTests/TestSupport.swift
@@ -13,36 +13,54 @@ extension SandboxEngineService {
     /// be created, which should fail the test run loudly rather than surface
     /// as an ordinary assertion failure.
     static func forTesting() -> SandboxEngineService {
+        forTesting(
+            stateRoot: URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("arca-engine-tests-\(UUID().uuidString)")
+        )
+    }
+
+    /// The same service against a state root the caller names, so a test can
+    /// assert on where the managers were actually rooted.
+    ///
+    /// Paths come from `EnginePaths` -- the derivation `arca-engine` itself
+    /// calls -- and not from a copy of its `appendingPathComponent` lines. The
+    /// copy is what made this helper a replica of the wiring rather than the
+    /// wiring: while it stood, changing the engine's real image-store root left
+    /// the whole suite green.
+    ///
+    /// No default for `stateRoot`, in keeping with the rule the path parameters
+    /// on `ContainerManager` follow: the no-argument overload above states the
+    /// throwaway root it wants.
+    static func forTesting(stateRoot: URL) -> SandboxEngineService {
         let logger = Logger(label: "arca-engine-tests")
-        let root = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("arca-engine-tests-\(UUID().uuidString)")
+        let paths = EnginePaths(stateRoot: stateRoot)
 
         let stateStore = try! StateStore(
-            path: root.appendingPathComponent("state.db").path,
+            path: paths.stateDatabase.path,
             logger: logger
         )
         let imageManager = try! ImageManager(
             logger: logger,
-            imageStorePath: root.appendingPathComponent("images")
+            imageStorePath: paths.imageStoreRoot
         )
         let containerManager = ContainerManager(
             imageManager: imageManager,
-            kernelPath: root.appendingPathComponent("vmlinux").path,
-            imageStoreRoot: root.appendingPathComponent("images"),
-            layerCachePath: root.appendingPathComponent("layers"),
+            kernelPath: paths.kernel.path,
+            imageStoreRoot: paths.imageStoreRoot,
+            layerCachePath: paths.layerCache,
             stateStore: stateStore,
             logger: logger
         )
         let config = ArcaConfig(
-            kernelPath: root.appendingPathComponent("vmlinux").path,
-            socketPath: root.appendingPathComponent("arca.sock").path,
+            kernelPath: paths.kernel.path,
+            socketPath: paths.socket.path,
             logLevel: "info"
         )
 
         return SandboxEngineService(
             containerManager: containerManager,
             volumeManager: VolumeManager(
-                volumesBasePath: root.appendingPathComponent("volumes").path,
+                volumesBasePath: paths.volumesRoot.path,
                 stateStore: stateStore,
                 logger: logger
             ),

--- a/Tests/ArcaEngineTests/TestSupport.swift
+++ b/Tests/ArcaEngineTests/TestSupport.swift
@@ -26,11 +26,13 @@ extension SandboxEngineService {
     /// The same service against a state root and kernel the caller names, so a
     /// test can assert on where the managers were actually rooted.
     ///
-    /// State-root paths come from `EnginePaths` -- the derivation `arca-engine`
-    /// itself calls -- and not from a copy of its `appendingPathComponent`
-    /// lines. The copy is what made this helper a replica of the wiring rather
-    /// than the wiring: while it stood, changing the engine's real image-store
-    /// root left the whole suite green.
+    /// The managers come from `EngineManagers` -- the one factory `arca-engine`
+    /// itself calls -- and not from a copy of its constructor calls. The copy is
+    /// what made this helper a replica of the wiring rather than the wiring:
+    /// while it stood, Task 1's review measured that swapping
+    /// `imageStoreRoot: paths.layerCache` in `ArcaEngineCommand` left the whole
+    /// suite green. See the measurement recorded on `EngineManagers` for what
+    /// the same swap costs now.
     ///
     /// The kernel is a parameter rather than an `EnginePaths` member for the
     /// same reason it is a separate CLI option: it is a read-only input the
@@ -40,48 +42,16 @@ extension SandboxEngineService {
     /// No defaults on either, in keeping with the rule the path parameters on
     /// `ContainerManager` follow: the no-argument overload above states the
     /// throwaway values it wants.
+    ///
+    /// Nothing here calls `EngineManagers`' managers' `initialize()`. That needs
+    /// a live `Containerization.VmnetNetwork`, which is a host resource and not
+    /// state-root-scoped; `arca-engine` is the only caller that asks for one.
     static func forTesting(stateRoot: URL, kernelPath: URL) -> SandboxEngineService {
-        let logger = Logger(label: "arca-engine-tests")
-        let paths = EnginePaths(stateRoot: stateRoot)
-
-        let stateStore = try! StateStore(
-            path: paths.stateDatabase.path,
-            logger: logger
-        )
-        let imageManager = try! ImageManager(
-            logger: logger,
-            imageStorePath: paths.imageStoreRoot
-        )
-        let containerManager = ContainerManager(
-            imageManager: imageManager,
-            kernelPath: kernelPath.path,
-            imageStoreRoot: paths.imageStoreRoot,
-            layerCachePath: paths.layerCache,
-            stateStore: stateStore,
-            logger: logger
-        )
-        let config = ArcaConfig(
-            kernelPath: kernelPath.path,
-            socketPath: paths.socket.path,
-            logLevel: "info"
-        )
-
-        return SandboxEngineService(
-            containerManager: containerManager,
-            volumeManager: VolumeManager(
-                volumesBasePath: paths.volumesRoot.path,
-                stateStore: stateStore,
-                logger: logger
-            ),
-            networkManager: NetworkManager(
-                config: config,
-                stateStore: stateStore,
-                containerManager: containerManager,
-                logger: logger
-            ),
-            imageManager: imageManager,
-            execManager: ExecManager(containerManager: containerManager, logger: logger),
-            logger: logger
-        )
+        try! EngineManagers(
+            stateRoot: stateRoot,
+            kernelPath: kernelPath,
+            logLevel: "info",
+            logger: Logger(label: "arca-engine-tests")
+        ).makeService()
     }
 }

--- a/Tests/ArcaEngineTests/TestSupport.swift
+++ b/Tests/ArcaEngineTests/TestSupport.swift
@@ -28,6 +28,8 @@ extension SandboxEngineService {
         let containerManager = ContainerManager(
             imageManager: imageManager,
             kernelPath: root.appendingPathComponent("vmlinux").path,
+            imageStoreRoot: root.appendingPathComponent("images"),
+            layerCachePath: root.appendingPathComponent("layers"),
             stateStore: stateStore,
             logger: logger
         )

--- a/Tests/ArcaTests/NetworkPruneGateTests.swift
+++ b/Tests/ArcaTests/NetworkPruneGateTests.swift
@@ -2,7 +2,7 @@ import ContainerBridge
 import DockerAPI
 import Foundation
 import Logging
-import Testing
+import XCTest
 
 /// `docker network prune` reads `getNetworkAttachments` as its "skip networks
 /// with active containers" gate, and then deletes on the answer.
@@ -15,30 +15,41 @@ import Testing
 /// assertion lives here -- in the target that already has both `DockerAPI` and
 /// `ContainerBridge` -- rather than being quietly downgraded to the weaker one.
 ///
-/// Not `@Suite(.serialized)` and no daemon: every test below runs against a
+/// No shared state and no daemon: every test below builds its own fixture over a
 /// fresh state root under `NSTemporaryDirectory()` and starts no VM.
-@Suite("Network prune attachment gate")
-struct NetworkPruneGateTests {
+///
+/// XCTest and not swift-testing, unlike the rest of `ArcaTests`. Gas Can's
+/// release gate -- `scripts/build-arca-engine.sh` -- is the only thing that runs
+/// these tests, and it invokes SwiftPM with `--disable-swift-testing`, so a
+/// `@Test` here is a test nothing executes. That flag is not incidental to the
+/// gate: in release configuration SwiftPM launches the swift-testing runner
+/// through an executable target, and Arca's `Arca` executable is an
+/// ArgumentParser command that rejects the runner's options.
+///
+/// The `MEASURED` blocks on the tests below were recorded before that
+/// conversion, so the failure output they quote is swift-testing's (`Test run
+/// with N tests in 1 suite failed ...`). The mutations and the tests that
+/// caught them are unchanged; only the runner printing the result is.
+final class NetworkPruneGateTests: XCTestCase {
     /// The control. Without it the survival test below proves nothing: a prune
     /// that never deletes anything -- because the network was default, or
     /// filtered out, or `deleteNetwork` refused it -- would pass the survival
     /// assertion just as well as a working gate.
-    @Test("An unused network is pruned, so the survival assertion has teeth")
-    func unusedNetworkIsPruned() async throws {
+    func testAnUnusedNetworkIsPrunedSoTheSurvivalAssertionHasTeeth() async throws {
         let fixture = try await PruneFixture()
         let networkID = try await fixture.createPrunableNetwork()
 
         let result = await fixture.handlers.handlePruneNetworks()
 
         guard case .success(let response) = result else {
-            Issue.record("prune failed on a network with no attachments: \(result)")
+            XCTFail("prune failed on a network with no attachments: \(result)")
             return
         }
-        #expect(response.networksDeleted == ["probe-prune"])
+        XCTAssertEqual(response.networksDeleted, ["probe-prune"])
 
         let remaining = try await fixture.networkManager.listNetworks()
-        #expect(
-            !remaining.contains { $0.id == networkID },
+        XCTAssertFalse(
+            remaining.contains(where: { $0.id == networkID }),
             "the pruned network must be gone from the store"
         )
     }
@@ -65,8 +76,7 @@ struct NetworkPruneGateTests {
     /// the thing under test is `handlePruneNetworks`' use of the answer, so the
     /// answer is an input; there the thing under test was the derivation that
     /// produces it, which a stub would have replaced.
-    @Test("A network with an attached container is not pruned")
-    func attachedNetworkIsNotPruned() async throws {
+    func testANetworkWithAnAttachedContainerIsNotPruned() async throws {
         let fixture = try await PruneFixture()
         let networkID = try await fixture.createPrunableNetwork()
         await fixture.networkManager.setNetworkAttachmentSource(
@@ -76,17 +86,17 @@ struct NetworkPruneGateTests {
         let result = await fixture.handlers.handlePruneNetworks()
 
         guard case .success(let response) = result else {
-            Issue.record("prune failed on a healthy attachment read: \(result)")
+            XCTFail("prune failed on a healthy attachment read: \(result)")
             return
         }
-        #expect(
+        XCTAssertTrue(
             response.networksDeleted.isEmpty,
             "prune deleted probe-prune despite a container being attached to it: \(result)"
         )
 
         let remaining = try await fixture.networkManager.listNetworks()
-        #expect(
-            remaining.contains { $0.id == networkID },
+        XCTAssertTrue(
+            remaining.contains(where: { $0.id == networkID }),
             "the in-use network must still exist after the prune"
         )
     }
@@ -127,8 +137,7 @@ struct NetworkPruneGateTests {
     /// 0.013 seconds with 1 issue`, this test alone. Nothing in
     /// `ArcaEngineTests` can see that mutation; this suite is the only thing
     /// standing between it and a released deletion.
-    @Test("An in-use network survives a partial store failure during prune")
-    func inUseNetworkSurvivesAttachmentReadFailure() async throws {
+    func testAnInUseNetworkSurvivesAPartialStoreFailureDuringPrune() async throws {
         let fixture = try await PruneFixture()
         let networkID = try await fixture.createPrunableNetwork()
         await fixture.networkManager.setNetworkAttachmentSource(FailingAttachmentSource())
@@ -136,7 +145,7 @@ struct NetworkPruneGateTests {
         let result = await fixture.handlers.handlePruneNetworks()
 
         guard case .failure = result else {
-            Issue.record(
+            XCTFail(
                 "prune deleted probe-prune despite being unable to read its attachments: \(result)"
             )
             return
@@ -149,8 +158,8 @@ struct NetworkPruneGateTests {
         // StateStore and never consults the attachment source, so the source
         // the test broke cannot answer this.
         let remaining = try await fixture.networkManager.listNetworks()
-        #expect(
-            remaining.contains { $0.id == networkID },
+        XCTAssertTrue(
+            remaining.contains(where: { $0.id == networkID }),
             "the in-use network must still exist after a failed attachment read"
         )
     }

--- a/Tests/ArcaTests/NetworkPruneGateTests.swift
+++ b/Tests/ArcaTests/NetworkPruneGateTests.swift
@@ -1,0 +1,179 @@
+import ContainerBridge
+import DockerAPI
+import Foundation
+import Logging
+import Testing
+
+/// `docker network prune` reads `getNetworkAttachments` as its "skip networks
+/// with active containers" gate, and then deletes on the answer.
+///
+/// The rest of this task's tests live in `ArcaEngineTests` and assert that the
+/// read reports a store failure rather than returning `[:]`. They cannot assert
+/// the property that actually matters: proving `getNetworkAttachments` throws
+/// does not prove prune declines to delete. `NetworkHandlers` is in `DockerAPI`,
+/// which `ArcaEngineTests` deliberately does not depend on, so the deletion
+/// assertion lives here -- in the target that already has both `DockerAPI` and
+/// `ContainerBridge` -- rather than being quietly downgraded to the weaker one.
+///
+/// Not `@Suite(.serialized)` and no daemon: every test below runs against a
+/// fresh state root under `NSTemporaryDirectory()` and starts no VM.
+@Suite("Network prune attachment gate")
+struct NetworkPruneGateTests {
+    /// The control. Without it the survival test below proves nothing: a prune
+    /// that never deletes anything -- because the network was default, or
+    /// filtered out, or `deleteNetwork` refused it -- would pass the survival
+    /// assertion just as well as a working gate.
+    @Test("An unused network is pruned, so the survival assertion has teeth")
+    func unusedNetworkIsPruned() async throws {
+        let fixture = try await PruneFixture()
+        let networkID = try await fixture.createPrunableNetwork()
+
+        let result = await fixture.handlers.handlePruneNetworks()
+
+        guard case .success(let response) = result else {
+            Issue.record("prune failed on a network with no attachments: \(result)")
+            return
+        }
+        #expect(response.networksDeleted == ["probe-prune"])
+
+        let remaining = try await fixture.networkManager.listNetworks()
+        #expect(
+            !remaining.contains { $0.id == networkID },
+            "the pruned network must be gone from the store"
+        )
+    }
+
+    /// The property this task exists for: an in-use network survives a partial
+    /// store failure.
+    ///
+    /// "Partial" is the case Task 3 left open. `listNetworks()` succeeds -- the
+    /// network is read straight out of the store -- while the attachment read
+    /// for that same network fails. Swallowed by `try?`, that combination made
+    /// the network look unused and prune deleted it and reported success.
+    ///
+    /// The assertion is on the network still being there afterwards, not on the
+    /// returned error. MEASURED, restoring the swallow in
+    /// `NetworkManager.getNetworkAttachments` --
+    ///
+    ///     if let attachments = try? await attachmentSource
+    ///         .getNetworkAttachments(networkID: networkID) { return attachments }
+    ///     return [:]
+    ///
+    /// -- and leaving the `catch` in `handlePruneNetworks` in place:
+    /// `swift test --filter NetworkPruneGateTests` -> `Test run with 2 tests in
+    /// 1 suite failed after 0.014 seconds with 1 issue`, this test on `prune
+    /// deleted probe-prune despite being unable to read its attachments:
+    /// success(DockerAPI.NetworkPruneResponse(networksDeleted:
+    /// ["probe-prune"]))`. The control above stayed green. The deletion is
+    /// named in that output, which is the point: the assertion is on the
+    /// deletion, not on the thrown error.
+    @Test("An in-use network survives a partial store failure during prune")
+    func inUseNetworkSurvivesAttachmentReadFailure() async throws {
+        let fixture = try await PruneFixture()
+        let networkID = try await fixture.createPrunableNetwork()
+        await fixture.networkManager.setNetworkAttachmentSource(FailingAttachmentSource())
+
+        let result = await fixture.handlers.handlePruneNetworks()
+
+        guard case .failure = result else {
+            Issue.record(
+                "prune deleted probe-prune despite being unable to read its attachments: \(result)"
+            )
+            return
+        }
+
+        // Read back through the real store, not through the returned response:
+        // a handler that reported nothing deleted while deleting the row is
+        // exactly the shape of failure this test is here to catch.
+        // `listNetworks()` reads `--driver null` networks straight out of the
+        // StateStore and never consults the attachment source, so the source
+        // the test broke cannot answer this.
+        let remaining = try await fixture.networkManager.listNetworks()
+        #expect(
+            remaining.contains { $0.id == networkID },
+            "the in-use network must still exist after a failed attachment read"
+        )
+    }
+}
+
+/// A `NetworkManager` and the `NetworkHandlers` over it, against a throwaway
+/// state root. Real managers over a real SQLite file; nothing is stubbed except
+/// where a test installs a failing attachment source.
+private struct PruneFixture {
+    let networkManager: NetworkManager
+    let handlers: NetworkHandlers
+
+    init() async throws {
+        let logger = Logger(label: "arca-prune-gate-tests")
+        let stateRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("arca-prune-gate-tests-\(UUID().uuidString)")
+
+        let stateStore = try StateStore(
+            path: stateRoot.appendingPathComponent("state.db").path,
+            logger: logger
+        )
+        let imageManager = try ImageManager(
+            logger: logger,
+            imageStorePath: stateRoot.appendingPathComponent("images")
+        )
+        let containerManager = ContainerManager(
+            imageManager: imageManager,
+            kernelPath: stateRoot.appendingPathComponent("vmlinux").path,
+            imageStoreRoot: stateRoot.appendingPathComponent("images"),
+            layerCachePath: stateRoot.appendingPathComponent("layers"),
+            stateStore: stateStore,
+            logger: logger
+        )
+        let networkManager = NetworkManager(
+            config: ArcaConfig(
+                kernelPath: stateRoot.appendingPathComponent("vmlinux").path,
+                socketPath: stateRoot.appendingPathComponent("arca.sock").path,
+                logLevel: "info"
+            ),
+            stateStore: stateStore,
+            containerManager: containerManager,
+            logger: logger
+        )
+
+        self.networkManager = networkManager
+        self.handlers = NetworkHandlers(
+            networkManager: networkManager,
+            containerManager: containerManager,
+            logger: logger
+        )
+    }
+
+    /// One network prune is willing to consider: not default, no `until` or
+    /// `label` filter standing between it and deletion.
+    ///
+    /// `driver: "null"` because that is the one driver whose whole lifecycle --
+    /// create, list, delete -- is the StateStore, with no backend that
+    /// `NetworkManager.initialize()` alone can install and no VM. The gate under
+    /// test is driver-independent: `handlePruneNetworks` calls
+    /// `getNetworkAttachments` for every network it walks.
+    func createPrunableNetwork() async throws -> String {
+        try await networkManager.createNetwork(
+            name: "probe-prune",
+            driver: "null",
+            subnet: nil,
+            gateway: nil,
+            ipRange: nil,
+            options: [:],
+            labels: [:],
+            isDefault: false
+        )
+    }
+}
+
+/// The store failure a test cannot induce by breaking SQLite on demand.
+private struct AttachmentsUnreachable: Error {}
+
+private struct FailingAttachmentSource: NetworkAttachmentSource {
+    func getNetworkAttachments(networkID: String) async throws -> [String: NetworkAttachment] {
+        throw AttachmentsUnreachable()
+    }
+
+    func getContainerNetworks(containerID: String) async throws -> [NetworkMetadata] {
+        throw AttachmentsUnreachable()
+    }
+}

--- a/Tests/ArcaTests/NetworkPruneGateTests.swift
+++ b/Tests/ArcaTests/NetworkPruneGateTests.swift
@@ -190,6 +190,7 @@ private struct PruneFixture {
             kernelPath: stateRoot.appendingPathComponent("vmlinux").path,
             imageStoreRoot: stateRoot.appendingPathComponent("images"),
             layerCachePath: stateRoot.appendingPathComponent("layers"),
+            logRoot: stateRoot.appendingPathComponent("logs"),
             stateStore: stateStore,
             logger: logger
         )

--- a/Tests/ArcaTests/NetworkPruneGateTests.swift
+++ b/Tests/ArcaTests/NetworkPruneGateTests.swift
@@ -43,6 +43,54 @@ struct NetworkPruneGateTests {
         )
     }
 
+    /// The gate's normal path: the read succeeds, says a container is attached,
+    /// and the network is kept.
+    ///
+    /// Added after review. The two tests either side of this one both pin "the
+    /// read *failed* -> do not delete"; neither pins "the read *succeeded and
+    /// was non-empty* -> do not delete", which is the whole reason the gate is
+    /// there. MEASURED, with `if !attachments.isEmpty { continue }` deleted
+    /// outright from `handlePruneNetworks` and nothing else changed:
+    /// `swift test --filter ArcaEngineTests` -> `Executed 43 tests, with 0
+    /// failures`, and `swift test --filter NetworkPruneGateTests` -> `Test run
+    /// with 3 tests in 1 suite failed after 0.013 seconds with 2 issues`, this
+    /// test alone, on `prune deleted probe-prune despite a container being
+    /// attached to it: success(DockerAPI.NetworkPruneResponse(networksDeleted:
+    /// ["probe-prune"]))` and on `remaining.contains { $0.id == networkID }`.
+    /// The other two tests in this suite stayed green. Before this test
+    /// existed that same deletion left the entire diff green.
+    ///
+    /// A stub answers here, unlike the store-backed tests in `ArcaEngineTests`.
+    /// That is the right call at this level and the wrong one at that one: here
+    /// the thing under test is `handlePruneNetworks`' use of the answer, so the
+    /// answer is an input; there the thing under test was the derivation that
+    /// produces it, which a stub would have replaced.
+    @Test("A network with an attached container is not pruned")
+    func attachedNetworkIsNotPruned() async throws {
+        let fixture = try await PruneFixture()
+        let networkID = try await fixture.createPrunableNetwork()
+        await fixture.networkManager.setNetworkAttachmentSource(
+            AttachedSource(networkID: networkID)
+        )
+
+        let result = await fixture.handlers.handlePruneNetworks()
+
+        guard case .success(let response) = result else {
+            Issue.record("prune failed on a healthy attachment read: \(result)")
+            return
+        }
+        #expect(
+            response.networksDeleted.isEmpty,
+            "prune deleted probe-prune despite a container being attached to it: \(result)"
+        )
+
+        let remaining = try await fixture.networkManager.listNetworks()
+        #expect(
+            remaining.contains { $0.id == networkID },
+            "the in-use network must still exist after the prune"
+        )
+    }
+
     /// The property this task exists for: an in-use network survives a partial
     /// store failure.
     ///
@@ -61,12 +109,24 @@ struct NetworkPruneGateTests {
     ///
     /// -- and leaving the `catch` in `handlePruneNetworks` in place:
     /// `swift test --filter NetworkPruneGateTests` -> `Test run with 2 tests in
-    /// 1 suite failed after 0.014 seconds with 1 issue`, this test on `prune
-    /// deleted probe-prune despite being unable to read its attachments:
+    /// 1 suite failed after 0.014 seconds with 1 issue` (measured when this
+    /// suite stood at 2 tests), this test on `prune deleted probe-prune despite
+    /// being unable to read its attachments:
     /// success(DockerAPI.NetworkPruneResponse(networksDeleted:
-    /// ["probe-prune"]))`. The control above stayed green. The deletion is
-    /// named in that output, which is the point: the assertion is on the
-    /// deletion, not on the thrown error.
+    /// ["probe-prune"]))`. The control stayed green. The deletion is named in
+    /// that output, which is the point: the assertion is on the deletion, not
+    /// on the thrown error.
+    ///
+    /// The same bug reachable from the handler side rather than the manager
+    /// side, found in review: the `catch` above **cannot** be removed -- this
+    /// method is non-throwing, so that is a compile error -- but its body can
+    /// be replaced with `attachments = [:]`, which compiles and restores the
+    /// original bug verbatim. MEASURED: `swift test --filter ArcaEngineTests`
+    /// -> `Executed 43 tests, with 0 failures`, while `swift test --filter
+    /// NetworkPruneGateTests` -> `Test run with 3 tests in 1 suite failed after
+    /// 0.013 seconds with 1 issue`, this test alone. Nothing in
+    /// `ArcaEngineTests` can see that mutation; this suite is the only thing
+    /// standing between it and a released deletion.
     @Test("An in-use network survives a partial store failure during prune")
     func inUseNetworkSurvivesAttachmentReadFailure() async throws {
         let fixture = try await PruneFixture()
@@ -162,6 +222,31 @@ private struct PruneFixture {
             labels: [:],
             isDefault: false
         )
+    }
+}
+
+/// One container attached to the network under test, reported without error.
+/// The healthy answer the gate is supposed to act on.
+private struct AttachedSource: NetworkAttachmentSource {
+    let networkID: String
+
+    func getNetworkAttachments(networkID: String) async throws -> [String: NetworkAttachment] {
+        guard networkID == self.networkID else {
+            return [:]
+        }
+        let containerID = String(repeating: "a", count: 64)
+        return [
+            containerID: NetworkAttachment(
+                networkID: networkID,
+                ip: "172.18.0.2",
+                mac: "02:42:ac:12:00:02",
+                aliases: ["attached-probe"]
+            )
+        ]
+    }
+
+    func getContainerNetworks(containerID: String) async throws -> [NetworkMetadata] {
+        []
     }
 }
 


### PR DESCRIPTION
Milestone 2 of P5.1. The engine takes ownership of its own state root and implements the sandbox lifecycle: `Inspect`, `ListResources`, `PrepareImage`, `Create`, `Start`, `Stop`, `Remove`, plus an `arca-engine image load` subcommand. Eight of the eleven contract methods are now real; `CreateContainer`, `Exec` and `Logs` still answer `unsupported_capability`.

**The thesis.** Milestone 1 refused to call `initialize()` because `ContainerManager`'s restore loop writes — it marks every persisted `running` container exited/137 and writes that back, which over a state root shared with a live `ArcaDaemon` would declare the daemon's containers dead. That hazard belongs to *sharing a root*, not to writing. The engine now owns `~/Library/Application Support/dev.gascan/engine/`, and against its own root the same write is correct crash recovery.

**Nineteen tasks, twelve planned.** Seven were added on maintainer rulings after a review, a spike or a measurement found something real, and two are review rounds over work that had shipped unreviewed.

## What the reviews found, because it is the load-bearing part

Tasks 13–17 shipped without independent review. Two rounds of adversarial review over them found **1 Critical, 7 Important and 17 Minor**. Every one is fixed.

- **Critical — a stale layer cache silently dropped image layers.** The guest classifies block devices by an ext4 volume label; the unpacker writes that label only when it *formats* a layer, and it formats only on a cache miss. Pre-label entries came back from the cache-hit branch unexamined and the guest skipped them: a rootfs built from a subset of its own image, or from none of it, with `Start` still succeeding. The documented mitigation named the wrong directory (`~/.arca/layers` is ArcaDaemon's; the engine's is `<state-root>/layers`), and the live tier structurally could not see it — every live engine gets a fresh temp state root, so the cache is always empty.
- **The graceful-shutdown crash.** `serve()` waited on the *listening* channel's close, which `ServerQuiescingHelper` performs synchronously, so the event-loop group was shut down under still-registered channels. Measured with Gas Can's `shutdown.rs`, interleaved rather than A-then-B: **12/32 (38%) → 0/32** on the container case, **6/192 → 0/192** across two cheaper workloads. It never needed a container — an engine that created none still crashed 1 in 96.
- **Two defects the fix exposed**: the escalation path had never been load-bearing (one signal always ended the process, so nothing ever waited for an in-flight RPC), and quiescing cannot close a connection whose protocol grpc-swift has not finished negotiating, so the drain is now bounded at 10s. A timed-out drain exits non-zero; an operator's second signal exits zero.

## Verification

Both trees clean, run after the final fix:

| | |
|---|---|
| `swift test --filter ArcaEngineTests` | `Executed 160 tests, with 0 failures` |
| `swift test --filter ArcaTests.NetworkPruneGateTests` | `Executed 3 tests, with 0 failures` |
| Gas Can's live tier, `--test-threads=1` | 14 passed / 0 failed, 216s, 568 engines stopped clean |

**This repository has no CI.** Gas Can's `engine` job — which builds Arca from a signed tag in a clean checkout — is the only automated thing that exercises it, and it is red against the current pin *by design*: the gate now requires a suite the pinned revision does not carry. The pin bump belongs to milestone 4 and needs a signed tag.

Submodule `containerization` moves to `3f68806` (`Vas-Solutus/arca-containerization`, branch `merge/upstream-main`), pushed first so the pointer is fetchable.

**Merge with a merge commit, not a squash** — 46 commits, and the handoff cites per-task history by SHA.
